### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/opensiddur/opensiddur-ai/security/code-scanning/1](https://github.com/opensiddur/opensiddur-ai/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/tests.yml` so the workflow does not rely on ambient defaults.  
Best fix without changing functionality: define workflow-level minimal permissions as:

- `contents: read`

This is sufficient for `actions/checkout` and typical test execution, and does not grant write scopes. Place it at the top level (after `on:` block, before `jobs:`), so it applies to all jobs unless overridden later.

No imports, methods, or dependencies are needed—just YAML key insertion in the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
