### PR TITLE
Read opensiddur:time as local time at opensiddur:location

### DIFF
--- a/opensiddur/exporter/calendar/compute.py
+++ b/opensiddur/exporter/calendar/compute.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import hdate
+import tzfpy
 from pyluach import dates as pyluach_dates
 from pyluach import parshios
 
@@ -102,6 +104,22 @@ SERVICE_TIME_FEATURES = (
 )
 
 
+def _timezone_name_at(latitude: float, longitude: float) -> str | None:
+    """The IANA zone name covering a coordinate, or None if there is none."""
+    # tzfpy takes longitude first, the reverse of the order used everywhere else here.
+    return tzfpy.get_tz(longitude, latitude)
+
+
+def _zone_from_name(name: str | None) -> tzinfo | None:
+    """Resolve an IANA zone name, or None if it is absent or unknown to the system."""
+    if not name:
+        return None
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+
+
 @dataclass(frozen=True)
 class SettingSnapshot:
     """Read-only view of active setting values."""
@@ -122,6 +140,18 @@ class SettingSnapshot:
         if isinstance(value, float):
             return int(value)
         return int(value)
+
+    def get_float(self, fs_type: str, feature_name: str) -> float | None:
+        """Coordinates, which reach the stack as a NumericValue when declared in JLPTEI."""
+        value = self.get(fs_type, feature_name)
+        if value is None:
+            return None
+        if isinstance(value, NumericValue):
+            return float(value.value)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
     def get_bool(self, fs_type: str, feature_name: str) -> bool | None:
         value = self.get(fs_type, feature_name)
@@ -153,12 +183,35 @@ class SettingSnapshot:
         except ValueError:
             return None
 
+    def timezone(self) -> tzinfo:
+        """The zone in which ``opensiddur:time`` is to be read.
+
+        An explicitly declared ``timezone`` wins; otherwise the zone is looked up from the
+        coordinates, so a document that gives only latitude and longitude still gets local wall
+        clock time. UTC is the last resort, for a document with no location at all.
+
+        The lookup lives here rather than only in the derivation graph because the compute
+        functions are also called directly, without a settings stack behind them.
+        """
+        name = self.get(FS_LOCATION, "timezone")
+        if isinstance(name, str) and name:
+            zone = _zone_from_name(name)
+            if zone is not None:
+                return zone
+        lat = self.get_float(FS_LOCATION, "latitude")
+        lon = self.get_float(FS_LOCATION, "longitude")
+        if lat is not None and lon is not None:
+            zone = _zone_from_name(_timezone_name_at(lat, lon))
+            if zone is not None:
+                return zone
+        return timezone.utc
+
     def location(self) -> hdate.Location | None:
-        lat = self.get(FS_LOCATION, "latitude")
-        lon = self.get(FS_LOCATION, "longitude")
+        lat = self.get_float(FS_LOCATION, "latitude")
+        lon = self.get_float(FS_LOCATION, "longitude")
         if lat is None or lon is None:
             return None
-        return hdate.Location("", float(lat), float(lon), "UTC", 0)
+        return hdate.Location("", lat, lon, self.timezone(), 0)
 
     def is_diaspora(self) -> bool:
         is_israel = self.get_bool(FS_ISRAEL, "is-israel")
@@ -207,8 +260,7 @@ def _effective_gregorian_date(snapshot: SettingSnapshot) -> date | None:
     if loc is None or tod is None:
         return gdate
     nightfall = hdate.Zmanim(gdate, location=loc).tset_hakohavim.local
-    aware = datetime.combine(gdate, tod).replace(tzinfo=nightfall.tzinfo)
-    return gdate + timedelta(days=1) if aware >= nightfall else gdate
+    return gdate + timedelta(days=1) if _datetime_from_snapshot(snapshot) >= nightfall else gdate
 
 
 def _hebrew_from_snapshot(snapshot: SettingSnapshot) -> pyluach_dates.HebrewDate | None:
@@ -227,13 +279,20 @@ def _hebrew_from_snapshot(snapshot: SettingSnapshot) -> pyluach_dates.HebrewDate
 
 
 def _datetime_from_snapshot(snapshot: SettingSnapshot) -> datetime | None:
+    """The author-supplied moment, as an instant.
+
+    ``opensiddur:time`` is a wall clock reading at ``opensiddur:location``, so it is the zone of
+    that location that turns it into an instant comparable with the zmanim. This is the only
+    place that conversion happens; combining with a ``ZoneInfo`` resolves the offset for the
+    date in question, so a date on either side of a daylight saving transition is handled.
+    """
     gdate = snapshot.gregorian_date()
     if gdate is None:
         return None
     tod = snapshot.time_of_day()
     if tod is None:
-        return datetime.combine(gdate, time(12, 0))
-    return datetime.combine(gdate, tod)
+        tod = time(12, 0)
+    return datetime.combine(gdate, tod, tzinfo=snapshot.timezone())
 
 
 def compute_hebrew_date(snapshot: SettingSnapshot) -> dict[str, Any] | None:
@@ -247,13 +306,12 @@ def compute_hebrew_date(snapshot: SettingSnapshot) -> dict[str, Any] | None:
 def compute_hebrew_time(snapshot: SettingSnapshot) -> dict[str, Any] | None:
     gdate = snapshot.gregorian_date()
     loc = snapshot.location()
-    dt = _datetime_from_snapshot(snapshot)
-    if gdate is None or loc is None or dt is None:
+    aware_dt = _datetime_from_snapshot(snapshot)
+    if gdate is None or loc is None or aware_dt is None:
         return None
     z = hdate.Zmanim(gdate, location=loc)
     sunrise = z.netz_hachama.local
     sunset = z.shkia.local
-    aware_dt = dt.replace(tzinfo=sunrise.tzinfo)
     if aware_dt < sunrise:
         variable_hour = 0
         elapsed = (aware_dt - (sunrise - timedelta(days=1))).total_seconds()
@@ -273,15 +331,33 @@ def compute_hebrew_time(snapshot: SettingSnapshot) -> dict[str, Any] | None:
 
 
 def compute_israel(snapshot: SettingSnapshot) -> dict[str, Any] | None:
-    lat = snapshot.get(FS_LOCATION, "latitude")
-    lon = snapshot.get(FS_LOCATION, "longitude")
+    lat = snapshot.get_float(FS_LOCATION, "latitude")
+    lon = snapshot.get_float(FS_LOCATION, "longitude")
     if lat is None or lon is None:
         return None
     is_israel = (
-        _ISRAEL_LAT[0] <= float(lat) <= _ISRAEL_LAT[1]
-        and _ISRAEL_LON[0] <= float(lon) <= _ISRAEL_LON[1]
+        _ISRAEL_LAT[0] <= lat <= _ISRAEL_LAT[1]
+        and _ISRAEL_LON[0] <= lon <= _ISRAEL_LON[1]
     )
     return {"is-israel": is_israel}
+
+
+def compute_location(snapshot: SettingSnapshot) -> dict[str, Any] | None:
+    """Derive the time zone from the coordinates.
+
+    Only the zone is derived; latitude and longitude are the author's to state. Deriving it
+    means a document that gives coordinates alone still reads ``opensiddur:time`` as local wall
+    clock time, and an author who declares ``timezone`` explicitly overrides this by the usual
+    explicit-beats-derived rule.
+    """
+    lat = snapshot.get_float(FS_LOCATION, "latitude")
+    lon = snapshot.get_float(FS_LOCATION, "longitude")
+    if lat is None or lon is None:
+        return None
+    name = _timezone_name_at(lat, lon)
+    if name is None:
+        return None
+    return {"timezone": name}
 
 
 def compute_day_of_week(snapshot: SettingSnapshot) -> dict[str, Any] | None:
@@ -302,8 +378,7 @@ def compute_day_of_week(snapshot: SettingSnapshot) -> dict[str, Any] | None:
         bayn = False
         if loc is not None and dt is not None and snapshot.time_of_day() is not None:
             z = hdate.Zmanim(gdate, location=loc)
-            aware_dt = dt.replace(tzinfo=z.shkia.local.tzinfo)
-            bayn = z.shkia.local < aware_dt < z.tset_hakohavim.local
+            bayn = z.shkia.local < dt < z.tset_hakohavim.local
         result["hebrew-day"] = hebrew_day
         result["bayn-hashmashot"] = bayn
     return result
@@ -506,11 +581,10 @@ def compute_torah_reading(snapshot: SettingSnapshot) -> dict[str, Any] | None:
 def compute_service_time(snapshot: SettingSnapshot) -> dict[str, Any] | None:
     gdate = snapshot.gregorian_date()
     loc = snapshot.location()
-    dt = _datetime_from_snapshot(snapshot)
-    if gdate is None or loc is None or dt is None or snapshot.time_of_day() is None:
+    aware_dt = _datetime_from_snapshot(snapshot)
+    if gdate is None or loc is None or aware_dt is None or snapshot.time_of_day() is None:
         return None
     z = hdate.Zmanim(gdate, location=loc)
-    aware_dt = dt.replace(tzinfo=z.alot_hashachar.local.tzinfo)
     holidays = compute_holiday(snapshot) or {}
     dow = compute_day_of_week(snapshot) or {}
     is_shabbat = dow.get("hebrew-day") == 7

--- a/opensiddur/exporter/derivation_graph.py
+++ b/opensiddur/exporter/derivation_graph.py
@@ -26,6 +26,7 @@ from opensiddur.exporter.calendar.compute import (
     compute_holiday,
     compute_holiday_aggregate,
     compute_israel,
+    compute_location,
     compute_quorum,
     compute_service_time,
     compute_torah_reading,
@@ -66,6 +67,12 @@ def _time_inputs() -> frozenset[FeatureRef]:
 
 
 DERIVATION_SPECS: tuple[DerivationSpec, ...] = (
+    # First, so that the derived time zone is on the stack before anything reads a location.
+    DerivationSpec(
+        fs_type=FS_LOCATION,
+        required_inputs=_location_inputs(),
+        compute=compute_location,
+    ),
     DerivationSpec(
         fs_type=FS_ISRAEL,
         required_inputs=_location_inputs(),

--- a/opensiddur/tests/exporter/test_calendar_compute.py
+++ b/opensiddur/tests/exporter/test_calendar_compute.py
@@ -1,6 +1,7 @@
 """Unit tests for calendar compute adapters."""
 
 import unittest
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from pyluach import dates as pyluach_dates
@@ -13,6 +14,7 @@ from opensiddur.exporter.calendar.compute import (
     FS_QUORUM,
     FS_TIME,
     SettingSnapshot,
+    _datetime_from_snapshot,
     _map_hdate_holidays,
     compute_day_of_week,
     compute_hebrew_date,
@@ -20,6 +22,7 @@ from opensiddur.exporter.calendar.compute import (
     compute_holiday,
     compute_holiday_aggregate,
     compute_israel,
+    compute_location,
     compute_quorum,
     compute_service_time,
     compute_torah_reading,
@@ -187,10 +190,10 @@ class TestComputeFunctions(unittest.TestCase):
             (FS_GREGORIAN, "day"): 12,
             (FS_LOCATION, "latitude"): 31.78,
             (FS_LOCATION, "longitude"): 35.22,
-            # Neila runs from plag hamincha (13:59) until nightfall, at which point Yom
-            # Kippur is over and the date has rolled to the next day. Zmanim are computed
-            # against a UTC-offset location, so the time is in that same frame.
-            (FS_TIME, "hour"): 14,
+            # Neila runs from plag hamincha (16:59 in Jerusalem this day) until nightfall
+            # (18:28), at which point Yom Kippur is over and the date has rolled to the next
+            # day. Times are local to opensiddur:location.
+            (FS_TIME, "hour"): 17,
             (FS_TIME, "minute"): 30,
             (FS_TIME, "second"): 0,
         })
@@ -198,14 +201,14 @@ class TestComputeFunctions(unittest.TestCase):
         self.assertTrue(result["neila"])
 
     def test_service_time_after_nightfall_is_the_next_day(self):
-        """Yom Kippur has ended by 16:00 in this frame, so there is no neila."""
+        """Nightfall in Jerusalem is 18:28, so by 19:00 Yom Kippur is over and there is no neila."""
         snap = _snapshot({
             (FS_GREGORIAN, "year"): 2024,
             (FS_GREGORIAN, "month"): 10,
             (FS_GREGORIAN, "day"): 12,
             (FS_LOCATION, "latitude"): 31.78,
             (FS_LOCATION, "longitude"): 35.22,
-            (FS_TIME, "hour"): 16,
+            (FS_TIME, "hour"): 19,
             (FS_TIME, "minute"): 0,
             (FS_TIME, "second"): 0,
         })
@@ -375,9 +378,8 @@ if __name__ == "__main__":
 class TestNightfallRollover(unittest.TestCase):
     """The Hebrew day begins in the evening.
 
-    Zmanim are computed against a location with a zero UTC offset, so times are supplied in
-    that same frame throughout these tests: a New York seder at 8pm EDT is 00:00Z the
-    following day.
+    Times throughout these tests are local wall clock readings at the location given, which is
+    New York unless stated otherwise: a New York seder at 8:30pm is simply hour 20, minute 30.
     """
 
     @staticmethod
@@ -400,13 +402,15 @@ class TestNightfallRollover(unittest.TestCase):
         self.assertEqual(compute_hebrew_date(snap), compute_hebrew_date(self._snap(2025, 4, 12, 10)))
 
     def test_seder_nights_are_pesah_one_and_two(self):
-        self.assertEqual(compute_holiday(self._snap(2025, 4, 13, 0))["pesah"], 1)
-        self.assertEqual(compute_holiday(self._snap(2025, 4, 14, 0))["pesah"], 2)
+        """The seders begin after nightfall on the evenings of 12 and 13 April 2025."""
+        self.assertEqual(compute_holiday(self._snap(2025, 4, 12, 21))["pesah"], 1)
+        self.assertEqual(compute_holiday(self._snap(2025, 4, 13, 21))["pesah"], 2)
 
     def test_friday_evening_is_shabbat_and_saturday_evening_is_not(self):
+        # Nightfall in Jerusalem on these dates is 19:21 and 19:23 local.
         jerusalem = {"lat": 31.78, "lon": 35.22}
-        friday_night = compute_holiday_aggregate(self._snap(2025, 4, 11, 17, **jerusalem))
-        saturday_night = compute_holiday_aggregate(self._snap(2025, 4, 12, 17, **jerusalem))
+        friday_night = compute_holiday_aggregate(self._snap(2025, 4, 11, 20, **jerusalem))
+        saturday_night = compute_holiday_aggregate(self._snap(2025, 4, 12, 20, **jerusalem))
         self.assertTrue(friday_night["shabbat"])
         self.assertFalse(friday_night["motzaei-shabbat"])
         self.assertFalse(saturday_night["shabbat"])
@@ -415,6 +419,74 @@ class TestNightfallRollover(unittest.TestCase):
     def test_hebrew_day_uses_pyluach_weekday_numbering(self):
         """Saturday is 7. pyluach already numbers Sunday=1..Saturday=7."""
         self.assertEqual(compute_day_of_week(self._snap(2024, 4, 20))["hebrew-day"], 7)
+
+
+class TestLocalTime(unittest.TestCase):
+    """opensiddur:time is a wall clock reading at opensiddur:location, not UTC."""
+
+    @staticmethod
+    def _snap(overrides=None):
+        """A New York seder, 8:30pm on 1 April 2026 — the case reported in the issue."""
+        data = {
+            (FS_GREGORIAN, "year"): 2026,
+            (FS_GREGORIAN, "month"): 4,
+            (FS_GREGORIAN, "day"): 1,
+            (FS_TIME, "hour"): 20,
+            (FS_TIME, "minute"): 30,
+            (FS_LOCATION, "latitude"): 40.71,
+            (FS_LOCATION, "longitude"): -74.01,
+        }
+        data.update(overrides or {})
+        return _snapshot(data)
+
+    _JERUSALEM = {(FS_LOCATION, "latitude"): 31.78, (FS_LOCATION, "longitude"): 35.22}
+
+    def test_new_york_seder_at_half_past_eight_is_pesah(self):
+        """The reported case: nightfall in New York is 19:36, so 20:30 is already 15 Nisan.
+
+        Read as UTC this is 20:30Z against a 23:36Z nightfall, and the day does not roll.
+        """
+        snap = self._snap()
+        self.assertEqual(compute_hebrew_date(snap), {"year": 5786, "month": 1, "day": 15})
+        self.assertEqual(compute_holiday(snap)["pesah"], 1)
+
+    def test_explicit_timezone_overrides_the_coordinates(self):
+        snap = self._snap({(FS_LOCATION, "timezone"): "UTC"})
+        self.assertEqual(compute_hebrew_date(snap), {"year": 5786, "month": 1, "day": 14})
+        self.assertEqual(compute_holiday(snap)["pesah"], 0)
+
+    def test_unknown_timezone_name_falls_back_to_the_coordinates(self):
+        snap = self._snap({(FS_LOCATION, "timezone"): "Mars/Olympus_Mons"})
+        self.assertEqual(str(snap.timezone()), "America/New_York")
+
+    def test_coordinates_declared_in_jlptei_arrive_as_numeric_values(self):
+        """A j:declare puts NumericValue on the stack where YAML puts a plain number."""
+        snap = self._snap({
+            (FS_LOCATION, "latitude"): NumericValue(value=41),
+            (FS_LOCATION, "longitude"): NumericValue(value=-74),
+        })
+        self.assertEqual(str(snap.timezone()), "America/New_York")
+        self.assertEqual(snap.location().latitude, 41.0)
+        self.assertEqual(compute_israel(snap), {"is-israel": False})
+
+    def test_timezone_is_utc_without_a_location(self):
+        snap = _snapshot({(FS_GREGORIAN, "year"): 2026})
+        self.assertEqual(snap.timezone().utcoffset(None), timedelta(0))
+
+    def test_compute_location_derives_the_zone_from_the_coordinates(self):
+        # Longitude is negative here, so a swapped argument order would not land in New York.
+        self.assertEqual(compute_location(self._snap()), {"timezone": "America/New_York"})
+        self.assertEqual(compute_location(self._snap(self._JERUSALEM)), {"timezone": "Asia/Jerusalem"})
+        tel_aviv = self._snap({(FS_LOCATION, "latitude"): 32.08, (FS_LOCATION, "longitude"): 34.78})
+        self.assertEqual(compute_location(tel_aviv), {"timezone": "Asia/Jerusalem"})
+        self.assertIsNone(compute_location(_snapshot({})))
+
+    def test_daylight_saving_is_honoured(self):
+        """The same wall clock reading is a different instant either side of a transition."""
+        summer = self._snap(self._JERUSALEM | {(FS_GREGORIAN, "month"): 7})
+        winter = self._snap(self._JERUSALEM | {(FS_GREGORIAN, "month"): 1})
+        self.assertEqual(_datetime_from_snapshot(summer).utcoffset(), timedelta(hours=3))
+        self.assertEqual(_datetime_from_snapshot(winter).utcoffset(), timedelta(hours=2))
 
 
 class TestEruvTavshilin(unittest.TestCase):

--- a/opensiddur/tests/exporter/test_derived_settings.py
+++ b/opensiddur/tests/exporter/test_derived_settings.py
@@ -255,6 +255,40 @@ class TestGoldenCalendarDates(unittest.TestCase):
         entry = get_active_setting_entry(self.linear_data, "opensiddur:holiday-aggregate", "shabbat")
         self.assertTrue(entry.value)
 
+    def test_timezone_is_derived_from_the_coordinates(self):
+        self._load({
+            "opensiddur:location": {"latitude": 40.71, "longitude": -74.01},
+        })
+        entry = get_active_setting_entry(self.linear_data, "opensiddur:location", "timezone")
+        self.assertEqual(entry.value, "America/New_York")
+        self.assertEqual(entry.source, "derived")
+
+    def test_declared_timezone_beats_the_derived_one(self):
+        self._load({
+            "opensiddur:location": {
+                "latitude": 40.71,
+                "longitude": -74.01,
+                "timezone": "UTC",
+            },
+        })
+        entry = get_active_setting_entry(self.linear_data, "opensiddur:location", "timezone")
+        self.assertEqual(entry.value, "UTC")
+        self.assertNotEqual(entry.source, "derived")
+
+    def test_local_evening_rolls_the_hebrew_date_over(self):
+        """The reported case: a New York seder at 8:30pm on 1 April 2026 is 15 Nisan."""
+        self._load({
+            "opensiddur:gregorian-date": {"year": 2026, "month": 4, "day": 1},
+            "opensiddur:time": {"hour": 20, "minute": 30},
+            "opensiddur:location": {"latitude": 40.71, "longitude": -74.01},
+        })
+        self.assertEqual(
+            get_active_setting_entry(self.linear_data, "opensiddur:hebrew-date", "day").value, 15
+        )
+        self.assertEqual(
+            get_active_setting_entry(self.linear_data, "opensiddur:holiday", "pesah").value, 1
+        )
+
     def test_torah_reading_parsha(self):
         self._load({
             "opensiddur:gregorian-date": {"year": 2024, "month": 10, "day": 3},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "openpyxl>=3.1.5",
     "pyluach>=2.3.0",
     "hdate>=1.2.1",
+    "tzfpy>=1.3.2",
 ]
 
 [project.urls]

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -530,6 +530,10 @@ The time of day is represented by:
 * `minute` may take values between 0 and 59.
 * `second` may take values between 0 and 59.
 
+The time is a local wall clock reading at the place given by `opensiddur:location`, not UTC. A
+seder beginning at 8:30 PM in New York is written `hour` 20, `minute` 30, together with the
+New York coordinates. The `opensiddur:location` structure below determines the time zone.
+
 Given the secular date/time, the processing model calculates the Hebrew date and halachic time:
 ```xml
 <tei:fs type="opensiddur:hebrew-date">
@@ -582,10 +586,19 @@ In order to calculate the Hebrew date/time from the secular date/time, the locat
    <tei:f name="longitude">
       <tei:numeric value="{longitude}"/>
    </tei:f>
+   <tei:f name="timezone">
+      <tei:symbol value="{IANA time zone name}"/>
+   </tei:f>
 </tei:fs>
 ```
 
 The `latitude` has values between `-90` (90 degrees south) and `90` (90 degrees north) and `longitude` between `-180` (180 degrees west) and `180` (180 degrees east).
+
+The `timezone` is an IANA time zone name, such as `America/New_York` or `Asia/Jerusalem`. It is
+the zone in which `opensiddur:time` is read. It need not be given: when it is absent it is
+derived from the latitude and longitude, and a declared value overrides the derived one. That
+override is what an author near a time zone border, or one who wants a time stated in UTC,
+should reach for.
 
 Given location, the Israel/diaspora binary can be derived:
 ```xml

--- a/specs/COMPILER_SPECIFICATION.md
+++ b/specs/COMPILER_SPECIFICATION.md
@@ -171,6 +171,8 @@ Evaluation uses tristate logic with truth tables from JLPTEI-3 (`condition_eval.
 
 Many JLPTEI feature structures are **derived** from other settings (e.g. `opensiddur:hebrew-date` from `opensiddur:gregorian-date` and `opensiddur:location`; `opensiddur:holiday` from dates, times, and location). See `schema/JLPTEI-3.md` for the full derivation graph.
 
+A feature structure may also derive one of its own features: `opensiddur:location/timezone` is derived from the latitude and longitude of the same structure. `opensiddur:time` is read as a wall clock reading in that zone.
+
 Derived entries use `source="derived"` on the settings stack, with a `contributors` set recording the `declare_id` of each input feature’s winning entry. Derived entry IDs are deterministic: `__derived__:{fs_type}:{feature_name}`.
 
 **Explicit beats derived:** if the winning stack entry for a feature is `init` or `declared`, derivation for that feature is skipped (last explicit setting prevails).

--- a/uv.lock
+++ b/uv.lock
@@ -1914,6 +1914,7 @@ dependencies = [
     { name = "pyppeteer" },
     { name = "requests" },
     { name = "saxonche" },
+    { name = "tzfpy" },
     { name = "unstructured" },
 ]
 
@@ -1946,6 +1947,7 @@ requires-dist = [
     { name = "pyppeteer", specifier = ">=2.0.0" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "saxonche", specifier = ">=12.7.0" },
+    { name = "tzfpy", specifier = ">=1.3.2" },
     { name = "unstructured", specifier = ">=0.18.14" },
 ]
 
@@ -3317,6 +3319,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzfpy"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/16/7311f6449ba0b391e146a52684f3b32a18dd4775f6890ca08ef3f3f103aa/tzfpy-1.3.2.tar.gz", hash = "sha256:5f4dbe9be6957ba6eb16fb4deb67f0c14e8da2e46674ead2bd38dffa9c58da08", size = 424831, upload-time = "2026-07-12T01:35:11.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/9f/2363f8c714ea66c8d6e1368a20db39cdcc13cda8ed19ec614cea9eb05bdb/tzfpy-1.3.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5e240beda40a3de8e16ede62c61bf568ba59bf63e375940a9c7e770f001aff41", size = 4452036, upload-time = "2026-07-12T01:34:42.594Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/cf/38d031b1e796439bf713323fa917859c2fbb45e6e73bec514f8646202baa/tzfpy-1.3.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3f8ff5e13bd88259064678b1aeed3de0892e0f22c462173c49adc938ceb6496e", size = 4519176, upload-time = "2026-07-12T01:34:45.143Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/29/68cea2d25ecfbf3a0c13f17c820d90e12729568c395128d1d4bea0a835ee/tzfpy-1.3.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b604acdf93d0fe6959d2242bc94857889e17c180a5b73e19f2052adb1d6a98b2", size = 4487592, upload-time = "2026-07-12T01:34:47.22Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e1/670b2cadb15b75c53d42ba828533eee07bf0297113373825475291851d36/tzfpy-1.3.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c16fe691c99390b6f1ca5245a11c846eaa336eb21276ce6ea3cc8d2d639a89a", size = 4497177, upload-time = "2026-07-12T01:34:49.253Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/bf/47efc11c2bb816f7e65d173b93286279ffdfff0ac6dfefef54f95be50e0e/tzfpy-1.3.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f1d21ad1be0c98ee54bc98e7a34d14ab26dcad8870d347db51e5285033fca6dc", size = 4663052, upload-time = "2026-07-12T01:34:51.58Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e5/36960c3c78bab5c1864ebd1d7331d63fab3d10092fc2ec4bd5b6ab106cbe/tzfpy-1.3.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0b3ec412c2e4b4e9799091d09210c858ee6dfa3b1edda747c2b3d82a9ca8ff80", size = 4697037, upload-time = "2026-07-12T01:34:53.567Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/eb/e5f6dcda9d44f228ae5e1a27ed9e5c28fd70b0442ac98516e44e0c554842/tzfpy-1.3.2-cp310-abi3-win_amd64.whl", hash = "sha256:47f5853af4d7759a0ca10a4f036b0f4f20873089c124d38d79a4018c380182fc", size = 4341633, upload-time = "2026-07-12T01:34:55.573Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #34.

## The problem

`SettingSnapshot.location()` built its `hdate.Location` with a hardcoded `"UTC"` timezone, so every zmanim value came back in a UTC frame. The consumers then stamped that frame's `tzinfo` onto the *author-supplied* wall clock time with `.replace(tzinfo=...)` rather than converting it. `opensiddur:time` therefore meant UTC.

The reported case — a New York seder at 8:30 PM on 1 April 2026:

```
UTC              nightfall = 23:36:36+00:00   20:30Z   < nightfall → no rollover, not Pesah
America/New_York nightfall = 19:36:36-04:00   20:30-04 ≥ nightfall → 15 Nisan, Pesah day 1
```

To get the intended behaviour an author had to write `hour=0 minute=30` on the following civil day, which was neither documented nor discoverable.

## The fix

- **A `timezone` feature on `opensiddur:location`**, an IANA name encoded as `tei:symbol`. It is **derived from the latitude and longitude** when not stated, so existing documents that give only coordinates now read their times locally with no edit; a declared value overrides the derived one by the usual explicit-beats-derived rule. That override is the escape hatch for an author near a zone border, or one who genuinely wants a time stated in UTC.
- **One localization point.** `_datetime_from_snapshot()` now returns an aware datetime, and the four `.replace(tzinfo=...)` call sites (`_effective_gregorian_date`, `compute_hebrew_time`, `compute_day_of_week`, `compute_service_time`) go away. Combining with a `ZoneInfo` resolves the offset for the date in question, so daylight saving is handled — `.replace()` with a fixed offset was not.
- `tzfpy` for the coordinate lookup: a 4.5 MB wheel with no required dependencies, against `timezonefinder`'s 55 MB plus numpy/h3/cffi/flatbuffers. Both are backed by the same boundary dataset (timezone-boundary-builder) and differ only within a few km of a border, which the explicit `timezone` feature covers.

## Notes for review

**No ODD change**, contrary to the issue's suggestion: `symbol` is already in the `iso-fs` moduleRef and there are no per-feature declarations to extend. `America/New_York` is a valid `teidata.word`.

**Three existing tests encoded the UTC frame** in their expectations and comments (`neila` at 14:30, Friday evening at 17:00). Each was re-derived from Jerusalem local zmanim rather than nudged until it passed — neila now runs 16:59–18:28 local, and Friday evening rolls at 19:21.

**A `get_float` coercion was needed.** Coordinates reach the settings stack as a `NumericValue` when declared in JLPTEI but as a plain number when loaded from YAML; the existing `float(lat)` calls in `location()` and `compute_israel()` handled only the latter and would have raised on a declared location.

**A separate pre-existing bug, left alone.** `tei:numeric/@value` is parsed with `int()`, so the fractional coordinates in issue #34's own reproduction XML (`value="40.71"`) raise `ValueError` when declared inline. Only the YAML settings path accepts floats. That is outside this issue's scope and probably wants its own.

## Verification

- Full CI suite passes: 1002 tests, `OK (skipped=23)`.
- `bash scripts/build-schema.sh` succeeds after the JLPTEI-3.md edit.
- End to end through `CompilerProcessor`: a Pesah-conditioned block is emitted for the New York seder declaration with the derived zone, and suppressed when `timezone` is forced to `UTC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)