### PR TITLE
Skip XML comments and PIs in the compilers

### DIFF
--- a/opensiddur/exporter/compiler.py
+++ b/opensiddur/exporter/compiler.py
@@ -25,7 +25,7 @@ from typing import Any, Literal, Optional, TypedDict
 from lxml.etree import ElementBase
 from lxml import etree
 
-from opensiddur.exporter.constants import JLPTEI_NAMESPACE, PROCESSING_NAMESPACE
+from opensiddur.exporter.constants import JLPTEI_NAMESPACE, PROCESSING_NAMESPACE, is_element_node
 from opensiddur.exporter.derived_settings import SettingChangeTrigger, recalculate_derived_settings
 from opensiddur.exporter.linear import (
     ConditionalScope,
@@ -806,6 +806,11 @@ class CompilerProcessor:
         return False, None
 
     def _process_element(self, element: ElementBase, root: Optional[ElementBase] = None) -> ElementBase:
+        # Comments and processing instructions carry no JLPTEI meaning and cannot be rebuilt from
+        # their tag. Drop them before the processing context sees them; the caller carries the tail.
+        if not is_element_node(element):
+            return None  # type: ignore[return-value]
+
         self._update_processing_context_before(element)
 
         if (

--- a/opensiddur/exporter/condition_eval.py
+++ b/opensiddur/exporter/condition_eval.py
@@ -24,6 +24,7 @@ from opensiddur.exporter.conditional_settings import (
     TEI_VALT,
     TEI_VNOT,
 )
+from opensiddur.exporter.constants import is_element_node
 from opensiddur.exporter.linear import NumericValue, Undefined, parse_numeric_literal
 
 
@@ -167,8 +168,11 @@ def _parse_condition_node(element: ElementBase) -> ConditionNode:
 
 
 def _condition_children(conditional_el: ElementBase) -> list[ElementBase]:
-    """Return condition AST source children (exclude tei:note)."""
-    return [child for child in conditional_el if child.tag != TEI_NOTE]
+    """Return condition AST source children (exclude tei:note, comments and PIs)."""
+    return [
+        child for child in conditional_el
+        if is_element_node(child) and child.tag != TEI_NOTE
+    ]
 
 
 def parse_condition_element(conditional_el: ElementBase) -> ConditionNode:

--- a/opensiddur/exporter/constants.py
+++ b/opensiddur/exporter/constants.py
@@ -1,5 +1,7 @@
 """Shared exporter constants (kept dependency-light to avoid circular imports)."""
 
+from lxml.etree import ElementBase
+
 JLPTEI_NAMESPACE = "http://jewishliturgy.org/ns/jlptei/2"
 PROCESSING_NAMESPACE = "http://jewishliturgy.org/ns/processing"
 
@@ -15,4 +17,13 @@ STRUCTURAL_BLOCKS = frozenset(
         f"{{{TEI_NS}}}l",
     }
 )
+
+
+def is_element_node(node: ElementBase) -> bool:
+    """True for element nodes.
+
+    lxml sets the tag of a comment to the etree.Comment factory function and of a processing
+    instruction to etree.PI, so anything that rebuilds a node from its tag must filter them out.
+    """
+    return isinstance(node.tag, str)
 

--- a/opensiddur/exporter/external_compiler.py
+++ b/opensiddur/exporter/external_compiler.py
@@ -18,6 +18,7 @@ from opensiddur.exporter.constants import (
     STRUCTURAL_BLOCKS,
     TEI_NS,
     XML_NS,
+    is_element_node,
 )
 from opensiddur.exporter.linear import LinearData
 from opensiddur.exporter.refdb import ReferenceDatabase
@@ -169,9 +170,14 @@ class ExternalCompilerProcessor(CompilerProcessor):
             else:
                 child_result = self._process_element(child, root)
                 result.extend(child_result)
-                if child.tail and child_result:
-                    last = child_result[-1]
-                    last.tail = (last.tail or '') + child.tail
+                if child.tail:
+                    if child_result:
+                        last = child_result[-1]
+                        last.tail = (last.tail or '') + child.tail
+                    else:
+                        # A child that compiles to nothing (a comment, a stripped j:conditional)
+                        # still leaves its tail behind as document text.
+                        self._carry_dropped_tail(result, child)
 
         self.marker_stack.pop()
 
@@ -723,6 +729,11 @@ class ExternalCompilerProcessor(CompilerProcessor):
         """
         Process the given element and return the list of processed elements.
         """
+        # Comments and processing instructions are dropped before the processing context sees
+        # them: a visit would reset include_tail_after_end and lose the end element's tail.
+        if not is_element_node(element):
+            return []
+
         context = self._update_processing_context_before(element)
 
         processed = []

--- a/opensiddur/exporter/inline_compiler.py
+++ b/opensiddur/exporter/inline_compiler.py
@@ -10,7 +10,7 @@ from opensiddur.exporter.compiler import (
     _AnnotationCommand,
 )
 from opensiddur.exporter.conditional_settings import CONDITIONAL_CONTROL_TAGS
-from opensiddur.exporter.constants import PROCESSING_NAMESPACE
+from opensiddur.exporter.constants import PROCESSING_NAMESPACE, is_element_node
 from opensiddur.exporter.external_compiler import ExternalCompilerProcessor
 from opensiddur.exporter.linear import LinearData
 from opensiddur.exporter.refdb import ReferenceDatabase
@@ -99,6 +99,13 @@ class InlineCompilerProcessor(CompilerProcessor):
         """
         Process the given element and return the text content.
         """
+        if not is_element_node(element):
+            # A comment or processing instruction contributes no text. Return the empty wrapper
+            # without touching the processing context; the caller carries the tail.
+            empty = etree.Element(f"{{{PROCESSING_NAMESPACE}}}transcludeInline", nsmap=self.ns_map)
+            empty.text = ""
+            return empty
+
         context = self._update_processing_context_before(element)
 
         text_element = etree.Element(f"{{{PROCESSING_NAMESPACE}}}transcludeInline", nsmap=self.ns_map)

--- a/opensiddur/tests/exporter/test_compiler.py
+++ b/opensiddur/tests/exporter/test_compiler.py
@@ -1184,6 +1184,119 @@ class TestCompilerProcessorWithFiles(unittest.TestCase):
         self.assertEqual(root_lang, 'en', "Root element should have xml:lang='en'")
 
 
+class TestCompilerProcessorCommentsAndPIs(unittest.TestCase):
+    """Comments and processing instructions must be dropped, not crash the compiler (#41)."""
+
+    def setUp(self):
+        reset_linear_data()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.test_project_dir = Path(self.temp_dir.name) / "test_project"
+        self.test_project_dir.mkdir(parents=True)
+        get_linear_data().xml_cache.base_path = Path(self.temp_dir.name)
+
+    def _compile(self, file_name: str, content: bytes):
+        file_path = self.test_project_dir / file_name
+        with open(file_path, 'wb') as f:
+            f.write(content)
+        return CompilerProcessor("test_project", file_name).process()
+
+    def test_comment_between_siblings_is_dropped(self):
+        """A comment between elements compiles and does not reach the output."""
+        xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text>
+        <tei:p>First</tei:p>
+        <!-- an editorial remark -->
+        <tei:p>Second</tei:p>
+    </tei:text>
+</root>'''
+
+        result = self._compile("comment_siblings.xml", xml_content)
+        result_str = etree.tostring(result, encoding='unicode')
+
+        self.assertNotIn('<!--', result_str)
+        self.assertNotIn('an editorial remark', result_str)
+        self.assertIn('First', result_str)
+        self.assertIn('Second', result_str)
+
+    def test_comment_tail_text_is_preserved(self):
+        """The text following a dropped comment is document text and must survive."""
+        xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text><tei:p>a<!-- why -->b</tei:p></tei:text>
+</root>'''
+
+        result = self._compile("comment_tail.xml", xml_content)
+        paragraphs = result.findall(f'.//{{{"http://www.tei-c.org/ns/1.0"}}}p')
+
+        self.assertEqual(len(paragraphs), 1)
+        self.assertEqual(''.join(paragraphs[0].itertext()), 'ab')
+
+    def test_comment_tail_after_element_child_is_preserved(self):
+        """A comment following a child element hands its tail to that child."""
+        xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text><tei:p><tei:hi>emphasis</tei:hi><!-- why --> trailing</tei:p></tei:text>
+</root>'''
+
+        result = self._compile("comment_tail_after_child.xml", xml_content)
+        paragraphs = result.findall(f'.//{{{"http://www.tei-c.org/ns/1.0"}}}p')
+
+        self.assertEqual(len(paragraphs), 1)
+        self.assertEqual(''.join(paragraphs[0].itertext()), 'emphasis trailing')
+
+    def test_comment_as_only_child(self):
+        """An element whose only child is a comment survives as an empty element."""
+        xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text><tei:p><!-- nothing but a comment --></tei:p></tei:text>
+</root>'''
+
+        result = self._compile("comment_only_child.xml", xml_content)
+        paragraphs = result.findall(f'.//{{{"http://www.tei-c.org/ns/1.0"}}}p')
+
+        self.assertEqual(len(paragraphs), 1)
+        self.assertEqual(len(paragraphs[0]), 0)
+        self.assertNotIn('nothing but a comment', etree.tostring(result, encoding='unicode'))
+
+    def test_processing_instruction_is_dropped(self):
+        """A PI takes the same code path as a comment: etree.PI as its tag."""
+        xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text>
+        <tei:p>First</tei:p>
+        <?some-target some data?>
+        <tei:p>Second</tei:p>
+    </tei:text>
+</root>'''
+
+        result = self._compile("pi.xml", xml_content)
+        result_str = etree.tostring(result, encoding='unicode')
+
+        self.assertNotIn('some-target', result_str)
+        self.assertIn('First', result_str)
+        self.assertIn('Second', result_str)
+
+    def test_comment_inside_conditional_definition(self):
+        """A comment among the condition children is not parsed as a condition."""
+        xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:j="http://jewishliturgy.org/ns/jlptei/2">
+    <tei:text>
+        <j:declare xml:id="d">
+            <tei:fs type="t:fs"><tei:f name="x"><tei:binary value="true"/></tei:f></tei:fs>
+        </j:declare>
+        <j:conditional xml:id="c">
+            <!-- included only when x is true -->
+            <tei:fs type="t:fs"><tei:f name="x"><tei:binary value="true"/></tei:f></tei:fs>
+        </j:conditional>
+        <tei:p>included</tei:p>
+        <j:endConditional target="#c"/>
+        <j:endDeclare target="#d"/>
+    </tei:text>
+</root>'''
+
+        result = self._compile("comment_in_conditional.xml", xml_content)
+        result_str = etree.tostring(result, encoding='unicode')
+
+        self.assertIn('included', result_str)
+        self.assertNotIn('<!--', result_str)
+
+
 class TestCompilerProcessorIdRewriting(unittest.TestCase):
     """Test ID rewriting functionality in CompilerProcessor."""
 

--- a/opensiddur/tests/exporter/test_external_compiler.py
+++ b/opensiddur/tests/exporter/test_external_compiler.py
@@ -1265,6 +1265,56 @@ class TestExternalCompilerProcessor(unittest.TestCase):
         # Should not include the chapter 2 text
         self.assertNotIn("Chapter 2 text", result_str, "Should not include the chapter 2 text")
 
+    def test_comment_between_range_siblings_is_dropped(self):
+        """A comment inside a compiled range is dropped and its tail kept (#41)."""
+        xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:div>
+        <tei:p corresp="urn:start">First paragraph</tei:p> Tail after start
+        <!-- an editorial remark --> Tail after comment
+        <tei:p corresp="urn:end">Last paragraph</tei:p>
+    </tei:div>
+</root>'''
+
+        project, file_name = self._create_test_file("comment_range.xml", xml_content)
+
+        start_path = self._get_element_path(xml_content, "urn:start")
+        end_path = self._get_element_path(xml_content, "urn:end")
+        result = ExternalCompilerProcessor(project, file_name, start_path, end_path).process()
+
+        self.assertEqual(len(result), 2)
+        result_str = ''.join(etree.tostring(elem, encoding='unicode') for elem in result)
+        self.assertNotIn('<!--', result_str)
+        self.assertNotIn('an editorial remark', result_str)
+
+        # Both the tail of the start element and the tail of the dropped comment are document text
+        self.assertIn("Tail after start", result[0].tail)
+        self.assertIn("Tail after comment", result[0].tail)
+
+    def test_comment_after_end_element_does_not_disturb_tail_handling(self):
+        """Visiting a comment must not reset the state machine's include_tail_after_end."""
+        xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:div>
+        <tei:p corresp="urn:start">First paragraph</tei:p> Tail after start
+        <tei:p corresp="urn:end">Last paragraph</tei:p> Tail after end
+        <!-- an editorial remark -->
+        <tei:p>After end (excluded)</tei:p>
+    </tei:div>
+</root>'''
+
+        project, file_name = self._create_test_file("comment_after_end.xml", xml_content)
+
+        start_path = self._get_element_path(xml_content, "urn:start")
+        end_path = self._get_element_path(xml_content, "urn:end")
+        processor = ExternalCompilerProcessor(
+            project, file_name, start_path, end_path, include_tail_after_end=True)
+        result = processor.process()
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("Tail after end", result[1].tail)
+        result_str = ''.join(etree.tostring(elem, encoding='unicode') for elem in result)
+        self.assertNotIn('an editorial remark', result_str)
+        self.assertNotIn("After end (excluded)", result_str)
+
 
 def _linear_data_with_root_parallel(root: etree._Element):
     class _XmlCache:

--- a/opensiddur/tests/exporter/test_inline_compiler.py
+++ b/opensiddur/tests/exporter/test_inline_compiler.py
@@ -1055,6 +1055,29 @@ class TestInlineCompilerProcessor(unittest.TestCase):
         # Should not include the chapter 2 text
         self.assertNotIn("Chapter 2 text", result_str, "Should not include the chapter 2 text")
 
+    def test_comment_contributes_no_text_and_keeps_its_tail(self):
+        """A comment is dropped; the text following it stays in the inline text (#41)."""
+        xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:div>
+        <tei:p corresp="urn:start">First<!-- an editorial remark --> paragraph</tei:p>
+        <tei:p corresp="urn:end">Last paragraph</tei:p>
+    </tei:div>
+</root>'''
+
+        project, file_name = self._create_test_file("comment_inline.xml", xml_content)
+
+        start_path = self._get_element_path(xml_content, "urn:start")
+        end_path = self._get_element_path(xml_content, "urn:end")
+        processor = InlineCompilerProcessor(
+            project, file_name, start_path, end_path, linear_data=self.linear_data)
+        result = processor.process()
+
+        result_str = etree.tostring(result, encoding='unicode')
+        self.assertNotIn('an editorial remark', result_str)
+        self.assertIn('First', result.text)
+        self.assertIn('paragraph', result.text)
+        self.assertIn('Last paragraph', result.text)
+
 
 class TestInlineCompilerProcessorAnnotations(unittest.TestCase):
     """Test annotation inclusion functionality in InlineCompilerProcessor."""

--- a/opensiddur/tests/exporter/test_parallel_compiler.py
+++ b/opensiddur/tests/exporter/test_parallel_compiler.py
@@ -535,6 +535,23 @@ class TestProcessElementAsMarker(_ProcessorBase):
         self.assertEqual(len(div_starts), 1)
         self.assertEqual(len(div_ends), 1)
 
+    def test_comment_child_is_dropped_and_its_tail_kept(self):
+        """A comment in marker mode is dropped; the text after it is document text (#41)."""
+        proc = self._make_processor()
+        proc.marker_stack = []
+        self._push_context(proc)
+        try:
+            tei_p = etree.fromstring(
+                b'<tei:p xmlns:tei="http://www.tei-c.org/ns/1.0">'
+                b'text<!-- an editorial remark --> after comment</tei:p>')
+            result = proc._process_element_as_marker(tei_p)
+        finally:
+            self._pop_context(proc)
+
+        serialized = ''.join(etree.tostring(el, encoding='unicode') for el in result)
+        self.assertNotIn('an editorial remark', serialized)
+        self.assertIn(' after comment', ''.join(el.tail or '' for el in result))
+
 
 # ── parallel-compilation suppression ────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #41.

An XML comment anywhere inside `tei:TEI` made every compiler die with
`TypeError: Argument must be bytes or unicode, got 'cython_function_or_method'`. The compilers are
identity transforms that rebuild each node with `etree.Element(element.tag)`, and lxml sets the tag
of a comment to the `etree.Comment` factory function and of a PI to `etree.PI`. Nothing filtered
non-element nodes, and nothing validated them out — a comment is valid JLPTEI to both RelaxNG and
Schematron, so a file could pass validation and then crash the exporter.

## Changes

- `constants.py` — new `is_element_node()` predicate. It lives there rather than in `compiler.py`
  because `condition_eval` needs it too and `compiler` already imports `condition_eval`.
- `compiler.py`, `external_compiler.py`, `inline_compiler.py` — drop comments and PIs at the top of
  `_process_element`, *before* the processing context sees them: a visit would reset
  `include_tail_after_end` and lose the end element's tail. The text following a dropped node is
  document text and is carried by the existing `_carry_dropped_tail`.

Two adjacent failures come along:

- `condition_eval._condition_children` — a comment among the children of a `j:conditional` was
  parsed as a condition and raised `Unexpected condition element`. Now filtered.
- `external_compiler._process_element_as_marker` — marker mode dropped a child's tail whenever the
  child compiled to nothing. That lost text for stripped `j:conditional` blocks too, not only
  comments.

Comments are skipped rather than copied through, per the issue: copying them would require every
downstream stage to tolerate them, and no project file carries a comment today.

## Tests

10 new tests across `test_compiler.py`, `test_external_compiler.py`, `test_inline_compiler.py` and
`test_parallel_compiler.py`: comment between siblings, tail text (`<tei:p>a<!--c-->b</tei:p>` → `ab`),
comment as only child, processing instruction, comment inside a conditional definition, comment
inside a compiled range, comment after the end element, marker mode, inline mode.

## Verification

- `uv run pytest opensiddur/tests/exporter` → 529 passed.
- Reverting only the source changes makes 9 of the 10 new tests fail (the 10th is an ordering guard
  that already passed).
- End-to-end: inserted `<!-- an editorial remark -->` into `original-example/index.xml` and compiled.
  Exit 0, no comment in the output, and the output is identical to the pre-comment baseline apart
  from one blank line — the comment's whitespace tail, correctly carried.

The 45 failing importer tests on this branch fail identically on `main` (they need the gitignored
compiled schema artifacts) and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)