### PR TITLE
Restore the Decalogue text dropped by the MAM importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Miqra al pi ha-Masorah importer: the `{{מ:כפול}}` template, which carries a verse in both
+  cantillations (ta'am elyon and ta'am tachton), was discarded by the stylesheet, emitting the
+  Ten Commandments as empty verses in Exodus 20 and Deuteronomy 5. The two readings now become a
+  `tei:choice` of `j:option`, each carrying a `corresp` URN by which a setting selects one, and
+  the manuscript apparatus attached to the merged doubly-accented text is preserved.
+- Miqra al pi ha-Masorah importer: a row whose text contained a parashah break lost both its
+  text and its verse milestone, dropping 54 verses across the project — among them Exodus 20:13,
+  Deuteronomy 5:17, and most of the Shirat haYam and Ha'azinu shirah.
+
 ## [0.1.0] - 2026-05-26
 
 Initial public release.

--- a/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
@@ -26,6 +26,19 @@
     </xsl:choose>
   </xsl:function>
 
+  <!-- True when a מ:כפול carries nothing but a parashah break in each of its strands, i.e. the
+       two readings agree on where the break falls and differ only in whether it lands mid-verse. -->
+  <xsl:function name="miqra:parashah-only" as="xs:boolean">
+    <xsl:param name="dual" as="element(miqra:dual-accent)"/>
+    <xsl:sequence select="
+      exists($dual/miqra:strand/miqra:parashah)
+      and (every $n in $dual/miqra:strand/node() satisfies (
+        $n instance of element(miqra:parashah)
+        or ($n instance of text() and normalize-space($n) = '')
+      ))
+    "/>
+  </xsl:function>
+
   <xsl:function name="miqra:has-verse-ref" as="xs:boolean">
     <xsl:param name="chapter" as="xs:string"/>
     <xsl:param name="verse" as="xs:string"/>
@@ -79,23 +92,47 @@
   <xsl:template match="miqra:row" mode="flatten">
     <!-- Column C: only parashah markers structure paragraphs; // line breaks are cosmetic. -->
     <xsl:apply-templates select="miqra:nav/miqra:parashah" mode="flatten"/>
+    <!-- The row's own identity, bound before any grouping: inside xsl:for-each-group the
+         context item is a member of the group, not the row. -->
+    <xsl:variable name="chapter" select="string(@chapter)"/>
+    <xsl:variable name="verse" select="string(@verse)"/>
+    <xsl:variable name="fileName" select="string(ancestor::miqra:book/@fileName)"/>
+    <xsl:variable name="text-nodes" as="node()*">
+      <xsl:apply-templates select="miqra:text/node()" mode="hoist"/>
+    </xsl:variable>
     <xsl:choose>
-      <xsl:when test="miqra:text/miqra:parashah">
-        <xsl:for-each-group select="miqra:text/node()" group-starting-with="miqra:parashah">
+      <xsl:when test="$text-nodes[self::miqra:parashah]">
+        <xsl:for-each-group select="$text-nodes" group-starting-with="miqra:parashah">
           <xsl:apply-templates select="current-group()[self::miqra:parashah]" mode="flatten"/>
-          <xsl:if test="current-group()[not(self::miqra:parashah)]">
-            <miqra:verse chapter="{@chapter}" verse="{@verse}" fileName="{ancestor::miqra:book/@fileName}">
-              <xsl:copy-of select="current-group()[not(self::miqra:parashah)]/node()[not(self::miqra:note)]"/>
+          <xsl:variable name="content"
+                        select="current-group()[not(self::miqra:parashah)][not(self::miqra:note)]"/>
+          <xsl:if test="exists($content)">
+            <miqra:verse chapter="{$chapter}" verse="{$verse}" fileName="{$fileName}">
+              <xsl:copy-of select="$content"/>
             </miqra:verse>
           </xsl:if>
         </xsl:for-each-group>
       </xsl:when>
       <xsl:otherwise>
-        <miqra:verse chapter="{@chapter}" verse="{@verse}" fileName="{ancestor::miqra:book/@fileName}">
-          <xsl:copy-of select="miqra:text/node()[not(self::miqra:note)]"/>
+        <miqra:verse chapter="{$chapter}" verse="{$verse}" fileName="{$fileName}">
+          <xsl:copy-of select="$text-nodes[not(self::miqra:note)]"/>
         </miqra:verse>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <!-- Lift parashah breaks out of מ:כפול so the paragraph grouping above can see them. -->
+  <xsl:mode name="hoist" on-no-match="shallow-copy"/>
+
+  <xsl:template match="miqra:dual-accent[miqra:parashah-only(.)]" mode="hoist">
+    <!-- Keep the apparatus anchors from the merged text, which is not itself rendered. -->
+    <xsl:for-each select="miqra:merged//miqra:variant[@noteId]">
+      <miqra:anchor xml:id="{@noteId}-ref"/>
+    </xsl:for-each>
+    <xsl:copy-of select="miqra:merged//miqra:anchor"/>
+    <!-- Both readings break in the same place; keep the ta'am tachton marker, which is the
+         reading MAM's own verse division follows. -->
+    <xsl:copy-of select="miqra:strand[@role = 'א']/miqra:parashah"/>
   </xsl:template>
 
   <xsl:template match="miqra:parashah" mode="flatten">
@@ -268,7 +305,42 @@
     </tei:seg>
   </xsl:template>
 
-  <xsl:template match="miqra:line-anchor | miqra:segment | miqra:good-ending | miqra:dual-trope-link | miqra:dual-accent | miqra:strand" mode="inline"/>
+  <!-- Dual cantillation (מ:כפול): the two readings are alternate wordings of the same text,
+       exactly one of which is read, which is what j:option is for. templates.tsv documents the
+       strand labels: א is ta'am tachton (פשוטה at Gen 35:22), ב is ta'am elyon (מדרשית).
+       The corresp URNs are fixed rather than per-passage, so one setting picks the reading
+       everywhere it occurs. Parashah-only spans never reach here; see mode="hoist". -->
+  <xsl:template match="miqra:dual-accent" mode="inline">
+    <xsl:apply-templates select="miqra:merged" mode="inline"/>
+    <tei:choice>
+      <j:option corresp="urn:x-opensiddur:condition:bible:taam-tachton">
+        <xsl:apply-templates select="miqra:strand[@role = 'א']/node()" mode="inline"/>
+      </j:option>
+      <j:option corresp="urn:x-opensiddur:condition:bible:taam-elyon">
+        <xsl:apply-templates select="miqra:strand[@role = 'ב']/node()" mode="inline"/>
+      </j:option>
+    </tei:choice>
+  </xsl:template>
+
+  <!-- The merged doubly-accented text is not rendered — the strands carry it — but the
+       manuscript apparatus hangs off it, so its anchors must still exist in the body. -->
+  <xsl:template match="miqra:merged" mode="inline">
+    <xsl:apply-templates select=".//miqra:variant[@noteId] | .//miqra:anchor" mode="anchor-only"/>
+  </xsl:template>
+
+  <xsl:template match="miqra:variant[@noteId]" mode="anchor-only">
+    <tei:seg xml:id="{@noteId}-ref"/>
+  </xsl:template>
+
+  <xsl:template match="miqra:anchor" mode="anchor-only">
+    <tei:seg>
+      <xsl:copy-of select="@xml:id"/>
+    </tei:seg>
+  </xsl:template>
+
+  <!-- A strand is only ever reached through miqra:dual-accent, which selects its children
+       directly; the empty rule keeps a stray one from leaking text through the built-in rule. -->
+  <xsl:template match="miqra:line-anchor | miqra:segment | miqra:good-ending | miqra:dual-trope-link | miqra:strand" mode="inline"/>
 
   <xsl:template match="miqra:parashah" mode="block"/>
   <xsl:template match="miqra:parashah" mode="inline"/>

--- a/opensiddur/importer/miqra_al_pi_hamasorah/miqra_wikitext.py
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/miqra_wikitext.py
@@ -630,14 +630,23 @@ class MiqraWikiTextProcessor(MediaWikiProcessor):
         return f"<miqra:dual-trope-link>{target}</miqra:dual-trope-link>"
 
     def _handle_dual_accent(self, template) -> str:
-        dual = self._p(self._named_param(template, "כפול"))
+        """A span carried with both cantillations, and its two singly-accented strands.
+
+        ``כפול`` is the merged, doubly-accented text as the codices write it; it carries the
+        manuscript apparatus, so it must be an element rather than an attribute value, where
+        the nested ``{{נוסח}}`` notes would be escaped away. The strands keep the source's own
+        ``א``/``ב`` labels; ``templates.tsv`` documents which cantillation each names, and the
+        stylesheet applies that mapping.
+        """
+        merged = self._p(self._named_param(template, "כפול"))
         a = self._p(self._named_param(template, "א"))
         b = self._p(self._named_param(template, "ב"))
         return (
-            f'<miqra:dual-accent dual="{_xml_escape(dual)}">'
-            f"<miqra:strand role=\"א\">{a}</miqra:strand>"
-            f"<miqra:strand role=\"ב\">{b}</miqra:strand>"
-            f"</miqra:dual-accent>"
+            "<miqra:dual-accent>"
+            f"<miqra:merged>{merged}</miqra:merged>"
+            f'<miqra:strand role="א">{a}</miqra:strand>'
+            f'<miqra:strand role="ב">{b}</miqra:strand>'
+            "</miqra:dual-accent>"
         )
 
     def _handle_note_link(self, template) -> str:

--- a/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
+++ b/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
@@ -1,0 +1,168 @@
+"""Tests for the Miqra intermediate → JLPTEI stylesheet
+(``opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt``).
+
+These run the transformation directly over hand-written intermediate XML, so
+they exercise the stylesheet without depending on the shape of the real TSV
+sources.
+"""
+
+import re
+import unittest
+
+from lxml import etree
+
+from opensiddur.importer.miqra_al_pi_hamasorah.convert_tsv import intermediate_to_tei
+
+TEI_NS = "http://www.tei-c.org/ns/1.0"
+J_NS = "http://jewishliturgy.org/ns/jlptei/2"
+NS = {"tei": TEI_NS, "j": J_NS}
+
+TAAM_TACHTON = "urn:x-opensiddur:condition:bible:taam-tachton"
+TAAM_ELYON = "urn:x-opensiddur:condition:bible:taam-elyon"
+
+
+def _book(*rows: str) -> str:
+    return (
+        '<miqra:book xmlns:miqra="urn:x-opensiddur:miqra:intermediate"'
+        ' xmlns:mw="urn:x-opensiddur:mw:intermediate"'
+        ' fileName="exodus" bookNameEn="Exodus">'
+        + "".join(rows)
+        + "</miqra:book>"
+    )
+
+
+def _row(verse: str, text: str, chapter: str = "20") -> str:
+    return (
+        f'<miqra:row source="s" pageKey="p" rowId="{verse}"'
+        f' chapter="{chapter}" verse="{verse}">'
+        "<miqra:nav/><miqra:scaffold/>"
+        f"<miqra:text>{text}</miqra:text>"
+        "</miqra:row>"
+    )
+
+
+def _transform(*rows: str) -> tuple[etree._Element, etree._Element | None]:
+    """Return the parsed body and standOff (``None`` when there are no notes)."""
+    outputs = intermediate_to_tei(_book(*rows))
+    body = etree.fromstring(outputs["body"].encode("utf-8"))
+    stand_off = outputs.get("stand_off") or ""
+    return body, etree.fromstring(stand_off.encode("utf-8")) if stand_off else None
+
+
+def _verse_text(body: etree._Element, chapter: str, verse: str) -> str:
+    """All text scoped to one verse: from its milestone up to the next verse milestone.
+
+    A verse split by a parashah break repeats its milestone in each paragraph, so the
+    text is gathered across paragraphs rather than read out of a single one.
+    """
+    urn = f"urn:x-opensiddur:text:bible:exodus/{chapter}/{verse}"
+    collected: list[str] = []
+    collecting = False
+    for node in body.iter():
+        if node.tag == f"{{{TEI_NS}}}milestone" and node.get("unit") == "verse":
+            collecting = node.get("corresp") == urn
+        if collecting and node.text and node.tag != f"{{{TEI_NS}}}milestone":
+            collected.append(node.text)
+        if collecting and node.tail:
+            collected.append(node.tail)
+    return re.sub(r"\s+", " ", "".join(collected)).strip()
+
+
+class TestDualAccent(unittest.TestCase):
+    """``{{מ:כפול}}`` carries a verse in both cantillations. The two readings are
+    alternate wordings — exactly one is read — which is what ``j:option`` expresses."""
+
+    DUAL = (
+        "<miqra:dual-accent>"
+        "<miqra:merged>גג֑֔ג</miqra:merged>"
+        '<miqra:strand role="א">תחתון</miqra:strand>'
+        '<miqra:strand role="ב">עליון</miqra:strand>'
+        "</miqra:dual-accent>"
+    )
+
+    def test_emits_a_choice_of_two_options(self):
+        body, _ = _transform(_row("2", self.DUAL))
+        options = body.findall(f".//{{{J_NS}}}option")
+        self.assertEqual(2, len(options))
+        self.assertEqual(
+            [TAAM_TACHTON, TAAM_ELYON], [o.get("corresp") for o in options]
+        )
+        # templates.tsv documents א as ta'am tachton and ב as ta'am elyon.
+        self.assertEqual("תחתון", options[0].text)
+        self.assertEqual("עליון", options[1].text)
+
+    def test_options_are_not_mixed_with_kri_ktiv(self):
+        """Schematron forbids j:option beside j:read/j:written; keep them apart."""
+        body, _ = _transform(_row("2", self.DUAL))
+        choice = body.find(f".//{{{TEI_NS}}}choice")
+        self.assertIsNone(choice.find(f"{{{J_NS}}}read"))
+        self.assertIsNone(choice.find(f"{{{J_NS}}}written"))
+
+    def test_merged_text_is_not_rendered_but_its_notes_stay_anchored(self):
+        dual = (
+            "<miqra:dual-accent>"
+            "<miqra:merged>"
+            '<miqra:variant noteId="n1"><miqra:display>גג֑֔ג</miqra:display></miqra:variant>'
+            '<miqra:note xml:id="n1">הערה</miqra:note>'
+            "</miqra:merged>"
+            '<miqra:strand role="א">תחתון</miqra:strand>'
+            '<miqra:strand role="ב">עליון</miqra:strand>'
+            "</miqra:dual-accent>"
+        )
+        body, stand_off = _transform(_row("2", dual))
+        self.assertNotIn("גג֑֔ג", _verse_text(body, "20", "2"))
+
+        note = stand_off.find(f".//{{{TEI_NS}}}note")
+        self.assertEqual("#n1-ref", note.get("target"))
+        anchors = [
+            seg.get(f"{{http://www.w3.org/XML/1998/namespace}}id")
+            for seg in body.findall(f".//{{{TEI_NS}}}seg")
+        ]
+        self.assertIn("n1-ref", anchors)
+
+    def test_parashah_only_strands_become_one_break(self):
+        """When both strands hold only a parashah break they agree on where it falls and
+        differ only in whether it lands mid-verse. A break is block structure and cannot
+        live inside tei:choice, so the ta'am tachton marker is kept and no choice is made."""
+        dual = (
+            "<miqra:dual-accent>"
+            "<miqra:merged/>"
+            '<miqra:strand role="א"><miqra:parashah type="close" midVerse="true"/></miqra:strand>'
+            '<miqra:strand role="ב"><miqra:parashah type="close"/></miqra:strand>'
+            "</miqra:dual-accent>"
+        )
+        body, _ = _transform(_row("12", f"לפני{dual}אחרי"))
+        self.assertEqual([], body.findall(f".//{{{J_NS}}}option"))
+        paragraphs = body.findall(f"{{{TEI_NS}}}div/{{{TEI_NS}}}p")
+        self.assertEqual(2, len(paragraphs))
+        self.assertEqual("closed-1", paragraphs[1].get("type"))
+        self.assertEqual("לפני", _verse_text(body, "20", "12")[:4])
+        self.assertIn("אחרי", _verse_text(body, "20", "12"))
+
+
+class TestMidVerseParashah(unittest.TestCase):
+    """A parashah break inside a verse splits its paragraph. The verse must keep both
+    its text and its milestone on each side of the break."""
+
+    def test_verse_survives_a_mid_text_break(self):
+        body, _ = _transform(
+            _row("13", 'AAA<miqra:parashah type="close-inline" midVerse="true"/>BBB'),
+            _row("14", "CCC"),
+        )
+        self.assertEqual("AAA BBB", _verse_text(body, "20", "13"))
+        milestones = [
+            m.get("corresp")
+            for m in body.findall(f".//{{{TEI_NS}}}milestone")
+            if m.get("unit") == "verse"
+        ]
+        # The milestone repeats so the verse's corresp scope resumes after the break.
+        self.assertEqual(2, milestones.count("urn:x-opensiddur:text:bible:exodus/20/13"))
+        self.assertIn("urn:x-opensiddur:text:bible:exodus/20/14", milestones)
+
+    def test_plain_verse_is_unaffected(self):
+        body, _ = _transform(_row("14", "CCC"))
+        self.assertEqual("CCC", _verse_text(body, "20", "14"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_wikitext.py
+++ b/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_wikitext.py
@@ -316,9 +316,20 @@ class TestMiqraWikitext(unittest.TestCase):
             "{{מ:כפול|כפול=ד|א=א|ב=ב}}"
         )
         self.assertIn("<miqra:dual-trope-link>target</miqra:dual-trope-link>", frag)
-        self.assertIn('<miqra:dual-accent dual="ד">', frag)
-        self.assertIn('role="א"', frag)
-        self.assertIn('role="ב"', frag)
+        self.assertIn("<miqra:dual-accent>", frag)
+        self.assertIn("<miqra:merged>ד</miqra:merged>", frag)
+        self.assertIn('<miqra:strand role="א">א</miqra:strand>', frag)
+        self.assertIn('<miqra:strand role="ב">ב</miqra:strand>', frag)
+
+    def test_dual_accent_keeps_apparatus_of_merged_text(self):
+        """The manuscript apparatus hangs off the merged doubly-accented reading, so
+        ``כפול`` must be an element: in an attribute the note markup would be escaped away."""
+        frag = wikitext_to_intermediate_xml(
+            "{{מ:כפול|כפול={{נוסח|דד|2=הערת כתבי־היד}}|א=א|ב=ב}}"
+        )
+        self.assertIn("<miqra:note", frag)
+        self.assertIn("הערת כתבי־היד", frag)
+        self.assertNotIn("&lt;miqra:note", frag)
 
     def test_emphasis_and_footnote_mark(self):
         frag = wikitext_to_intermediate_xml("{{מודגש|חשוב}}{{ש}}")

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -374,6 +374,19 @@ that is either said or omitted, whereas alternates are always said — the quest
 wording. Text that some communities add and others omit is a condition, not an alternate; see
 [Conditional text](#conditional-text).
 
+A passage that the masorah carries with both cantillations — the Decalogue in Exodus 20 and
+Deuteronomy 5, and Genesis 35:22 — is an alternate of this kind: the words are the same and only
+the accentuation differs, so the two readings are `j:option`s selected by a fixed pair of URNs
+rather than by a per-passage one, since one setting chooses the reading wherever it occurs:
+```xml
+<tei:choice>
+   <j:option corresp="urn:x-opensiddur:condition:bible:taam-tachton">לֹ֥א תִרְצָ֖ח</j:option>
+   <j:option corresp="urn:x-opensiddur:condition:bible:taam-elyon">לֹ֖א תִּרְצָֽח׃</j:option>
+</tei:choice>
+```
+Where the two readings differ over whether a parashah break falls mid-verse, only the ta'am
+tachton placement is encoded: a break is block structure and cannot live inside a `tei:choice`.
+
 Haftarot are a special case of Biblical material. They are from the works of the prophets (or writings) but are 
 discontinuous. Each parshah's hatarah may additionally have multiple options, depending on custom, and internal 
 discontinuities, sometimes even bridging multiple books. The recommended way to encode haftarot is as a separate


### PR DESCRIPTION
Fixes #45.

Two independent bugs left the Ten Commandments empty in Exodus 20 and Deuteronomy 5.

## `{{מ:כפול}}` was discarded

The template marks a verse the masorah carries with both cantillations. `_handle_dual_accent` parsed it correctly, but `miqra_to_tei.xslt` matched `miqra:dual-accent`/`miqra:strand` with an empty template and deleted everything inside. 34 occurrences: Gen 35:22, Exodus 20, Deuteronomy 5.

The two readings are alternate wordings of the same words — exactly one is read — so they now become a `tei:choice` of `j:option`, which is what `JLPTEI-3.md` and the ODD document `j:option` for:

```xml
<tei:choice>
   <j:option corresp="urn:x-opensiddur:condition:bible:taam-tachton">לֹ֥א תִרְצָ֖ח</j:option>
   <j:option corresp="urn:x-opensiddur:condition:bible:taam-elyon">לֹ֖א תִּרְצָֽח׃</j:option>
</tei:choice>
```

The `corresp` URNs are a fixed pair rather than per-passage, so one setting picks the reading everywhere it occurs. `templates.tsv` documents the strand labels — א is ta'am tachton (פשוטה at Gen 35:22), ב is ta'am elyon (מדרשית) — and I checked that against MAM's own verse boundaries at all 34 sites before relying on it.

7 of the 34 have strands holding nothing but a parashah break, differing only over whether it falls mid-verse. A break is block structure and cannot live inside a `tei:choice`, so those are hoisted out in the `flatten` pass and keep the ta'am tachton placement.

The merged doubly-accented text (`כפול=`) was interpolated into an attribute value, which XML-escaped away the `{{נוסח}}` apparatus nested inside it. It is now a `miqra:merged` element. The merged text itself is not rendered — the strands carry it — but its 23 notes now reach the standOff with anchors in the body.

## Rows with a parashah break lost their verse

In `miqra:row` mode `flatten`, the `miqra:text/miqra:parashah` branch had two faults:

- it copied `current-group()[not(self::miqra:parashah)]/node()`, and `current-group()` already holds the children of `miqra:text`, so the trailing `/node()` selected nothing;
- it read `@chapter`/`@verse` inside `xsl:for-each-group`, where the context item is a member of the group, not the row — so `miqra:has-verse-ref` saw empty strings and emitted no milestone either.

That dropped **54 verses** across the project: Exodus 20:13, Deuteronomy 5:17 and 2:8, most of the Shirat haYam (Ex 15) and Ha'azinu (Deut 32) shirah, and a few in Ezekiel and Joshua.

## Verification

- 1059 tests pass. New `test_miqra_to_tei_xslt.py` drives the stylesheet over hand-written intermediate XML (synthetic only, no dependence on the source TSVs); `test_miqra_wikitext.py` gains a case for the merged-text apparatus.
- Regenerating all 44 books — RelaxNG + Schematron run before every write, all clean — leaves **0 verse gaps** in any chapter, down from 54.
- Exodus note count 220 → 243, dangling anchors 22 → 19.
- The one apparent text reduction, `numbers.xml` −1192 chars, is Numbers 10:35–36: both verses were previously empty and their text plus escaped note content had leaked into 10:34's scope. Now split correctly.

The remaining 183 dangling standOff targets project-wide are a separate, pre-existing bug, filed as #46.

Regenerated project files: opensiddur/opensiddur-projects#2 — merge this PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
