### PR TITLE
Fix parsha milestones in the JPS 1917 importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Shared table of the 54 weekly parshiyot (`opensiddur/importer/util/parshiyot.py`), mapping any
+  source's spelling of a parshah name to a canonical Hebrew name and a URN slug.
+
 ### Fixed
 - Miqra al pi ha-Masorah importer: the `{{מ:כפול}}` template, which carries a verse in both
   cantillations (ta'am elyon and ta'am tachton), was discarded by the stylesheet, emitting the
@@ -16,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Miqra al pi ha-Masorah importer: a row whose text contained a parashah break lost both its
   text and its verse milestone, dropping 54 verses across the project — among them Exodus 20:13,
   Deuteronomy 5:17, and most of the Shirat haYam and Ha'azinu shirah.
+- JPS 1917 importer: the 22 acrostic stanza headings of Psalm 119 are no longer emitted as
+  `tei:milestone[@unit='parsha']`; they become `@unit='acrostic'` and carry no URN.
+- JPS 1917 importer: parsha URNs are transliterated path segments
+  (`…/ki_teitzei`) instead of raw Hebrew with literal spaces, and `@n` carries the canonical
+  name (`לך־לך`, not `לךלך`).
+- JPS 1917 importer: the opening parshah of each book of the Torah, which has no running head in
+  the source, is now emitted. All 54 parshiyot are present.
+- JPS 1917 importer: each generated file declares its own document URN instead of all 44 sharing
+  `urn:x-opensiddur:text:bible:tanakh@jps1917`.
 
 ## [0.1.0] - 2026-05-26
 

--- a/opensiddur/importer/jps1917/convert_wikisource.py
+++ b/opensiddur/importer/jps1917/convert_wikisource.py
@@ -13,6 +13,7 @@ from opensiddur.importer.util.pages import (
     get_page,
 )
 from opensiddur.importer.jps1917.mediawiki_processor import create_processor
+from opensiddur.importer.util.parshiyot import skeleton_map_json
 from opensiddur.importer.util.prettify import prettify_xml
 from opensiddur.importer.util.validation import validate
 from opensiddur.common.xslt import xslt_transform_string
@@ -48,6 +49,10 @@ class Book(BaseModel):
     start_page: int
     end_page: int
     is_section: Optional[bool] = False
+    # The parshah a book of the Torah opens with. The source marks parshiyot with a centered
+    # running head, but the first one of each book has none — the book's title heading is
+    # printed in its place — so it has to be declared here.
+    first_parsha: Optional[str] = None
 
 class Index(BaseModel):
     index_title_en: str
@@ -81,6 +86,7 @@ JPS_1917 = [
                         book_name_en = "Genesis", 
                         book_name_he = "בראשית", 
                         file_name = "genesis", 
+                        first_parsha = "בראשית", 
                         start_page = 3+PAGE_OFFSET, 
                         end_page = 64+PAGE_OFFSET
                     ),
@@ -88,6 +94,7 @@ JPS_1917 = [
                         book_name_en = "Exodus", 
                         book_name_he = "שמות", 
                         file_name = "exodus", 
+                        first_parsha = "שמות", 
                         start_page = 65+PAGE_OFFSET, 
                         end_page = 117+PAGE_OFFSET
                     ),
@@ -95,6 +102,7 @@ JPS_1917 = [
                         book_name_en = "Leviticus", 
                         book_name_he = "ויקרא", 
                         file_name = "leviticus", 
+                        first_parsha = "ויקרא", 
                         start_page = 118+PAGE_OFFSET, 
                         end_page = 156+PAGE_OFFSET
                     ),
@@ -102,6 +110,7 @@ JPS_1917 = [
                         book_name_en = "Numbers", 
                         book_name_he = "במדבר", 
                         file_name = "numbers", 
+                        first_parsha = "במדבר", 
                         start_page = 157+PAGE_OFFSET, 
                         end_page = 211+PAGE_OFFSET
                     ),
@@ -109,6 +118,7 @@ JPS_1917 = [
                         book_name_en = "Deuteronomy", 
                         book_name_he = "דברים", 
                         file_name = "deuteronomy", 
+                        first_parsha = "דברים", 
                         start_page = 212+PAGE_OFFSET, 
                         end_page = 258+PAGE_OFFSET
                     ),
@@ -606,6 +616,7 @@ def book_file(
     header_content = header(
         book_name_he = book.book_name_he,
         book_name_en = book.book_name_en,
+        entrypoint = book.file_name,
         transcription_credits = transcription_credits,
     )
     xml_dict = process_mediawiki(
@@ -616,14 +627,14 @@ def book_file(
         wrapper_div_type="book",
         book_name=book.file_name,
         is_section=book.is_section,
+        parsha_names=skeleton_map_json(),
+        first_parsha=book.first_parsha or "",
     )
-    
+
     tei_content = tei_file(
         header = header_content,
         **xml_dict,
     )
-    with open("temp.tei.xml", "w") as f:
-        f.write(tei_content)
     validate_and_write_tei_file(tei_content, book.file_name, project_dir)
 
     return tei_content
@@ -640,11 +651,16 @@ def index_file(
         )
     else:
         transcription_credits = None
+    # The top-level index stands for the whole Tanakh, so it keeps the tanakh URN; the
+    # sub-indices name themselves. Either way the document URN matches the body div below,
+    # so no two files in the project claim the same one.
+    entrypoint = "tanakh" if idx.file_name == "index" else idx.file_name
     header_content = header(
         book_name_he = idx.index_title_he,
         book_name_en = idx.index_title_en,
         book_sub_he = idx.index_sub_he,
         book_sub_en = idx.index_sub_en,
+        entrypoint = entrypoint,
         transcription_credits = transcription_credits,
     )
     if idx.start_page is not None and idx.end_page is not None:
@@ -655,6 +671,7 @@ def index_file(
             sourcetexts_root=sourcetexts_root,
             wrapper_div_type="",
             book_name="",
+            parsha_names=skeleton_map_json(),
         )
     else:
         xml_dict = {}
@@ -670,7 +687,7 @@ def index_file(
         for book in idx.transclusions
     ])
     index_body = f"""<tei:body>
-    <tei:div corresp="urn:x-opensiddur:text:bible:{idx.file_name}">
+    <tei:div corresp="urn:x-opensiddur:text:bible:{entrypoint}">
         <tei:head>{idx.index_title_en}</tei:head>
         {transclusion_str}
     </tei:div>
@@ -682,8 +699,6 @@ def index_file(
         header = header_content,
         **xml_dict,
     )
-    with open("temp.tei.xml", "w") as f:
-        f.write(tei_content)
     validate_and_write_tei_file(tei_content, idx.file_name, project_dir)
 
     for transclusion in idx.transclusions:

--- a/opensiddur/importer/jps1917/mediawiki_to_tei.xslt
+++ b/opensiddur/importer/jps1917/mediawiki_to_tei.xslt
@@ -3,6 +3,7 @@
     xmlns:tei="http://www.tei-c.org/ns/1.0"
     xmlns:j="http://jewishliturgy.org/ns/jlptei/2"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:f="urn:opensiddur:jps1917"
     exclude-result-prefixes="#all">
 
     <xsl:output method="xml" omit-xml-declaration="yes"/>
@@ -16,7 +17,57 @@
 
     <!-- is the book section-delimited? -->
     <xsl:param name="is_section" as="xs:boolean?"/>
-    
+
+    <!-- The parshah name table, as JSON, keyed by consonant skeleton. Produced by
+    opensiddur.importer.util.parshiyot.skeleton_map_json(); each entry is
+    {"n": canonical Hebrew name, "slug": URN path segment}. Passed as a string because
+    xslt_transform_string can only marshal atomic values. -->
+    <xsl:param name="parsha_names" as="xs:string?"/>
+
+    <!-- The Hebrew name of the parshah a book opens with, for the five books of the Torah.
+    Their opening parshiyot have no running head in the source — the book title heading
+    occupies that slot — so they have to be supplied rather than read off the page. -->
+    <xsl:param name="first_parsha" as="xs:string?"/>
+
+    <xsl:variable name="parshiyot" as="map(*)"
+        select="if ($parsha_names) then parse-json($parsha_names) else map{}"/>
+
+    <!-- Reduce a parshah name to its bare consonant skeleton, so that the way a source
+    happens to spell it — pointed or not, maqaf written as a maqaf, a space, or nothing —
+    does not affect the lookup. Mirrors
+    opensiddur.importer.util.hebrew.normalize_hebrew: everything outside the Hebrew letter
+    range goes, which covers combining marks as well as separators. -->
+    <xsl:function name="f:parsha-skeleton" as="xs:string">
+        <xsl:param name="name" as="xs:string"/>
+        <xsl:sequence select="replace($name, '[^&#x05D0;-&#x05EA;]', '')"/>
+    </xsl:function>
+
+    <!-- The table entry for a parshah named in Hebrew. Terminates rather than guessing:
+    a name the table does not know is either a typo or, as with the Psalm 119 acrostic,
+    markup that is not a parshah at all. -->
+    <xsl:function name="f:parsha" as="map(*)">
+        <xsl:param name="name" as="xs:string"/>
+        <xsl:variable name="entry" select="$parshiyot(f:parsha-skeleton($name))"/>
+        <xsl:if test="empty($entry)">
+            <xsl:message terminate="yes">
+                <xsl:text>Unknown parshah name: </xsl:text>
+                <xsl:value-of select="$name"/>
+                <xsl:text> (skeleton: </xsl:text>
+                <xsl:value-of select="f:parsha-skeleton($name)"/>
+                <xsl:text>) in book </xsl:text>
+                <xsl:value-of select="$book_name"/>
+            </xsl:message>
+        </xsl:if>
+        <xsl:sequence select="$entry"/>
+    </xsl:function>
+
+    <xsl:function name="f:parsha-milestone" as="element(tei:milestone)">
+        <xsl:param name="name" as="xs:string"/>
+        <xsl:variable name="entry" select="f:parsha($name)"/>
+        <tei:milestone unit="parsha" n="{$entry?n}"
+            corresp="urn:x-opensiddur:text:bible:{$book_name}/{$entry?slug}"/>
+    </xsl:function>
+
     <!-- Identity template: copy everything by default -->
     <xsl:template match="text()">
         <xsl:copy/>
@@ -120,7 +171,26 @@
                                 <xsl:attribute name="n" select="$book_name"/>
                                 <xsl:attribute name="corresp" select="concat('urn:x-opensiddur:text:bible:', $book_name)"/>
                             </xsl:if>
-                            <xsl:copy-of select="$wrapped-content"/>
+                            <xsl:choose>
+                                <xsl:when test="$first_parsha">
+                                    <!-- The book's opening parshah, which the source does not
+                                    mark, goes after the title heading and before the text, in
+                                    a tei:p of its own like every parshah milestone the running
+                                    heads produce. -->
+                                    <xsl:variable name="head"
+                                        select="$wrapped-content/self::tei:head[1]"/>
+                                    <xsl:copy-of select="
+                                        $wrapped-content[exists($head) and (. &lt;&lt; $head or . is $head)]"/>
+                                    <tei:p>
+                                        <xsl:sequence select="f:parsha-milestone($first_parsha)"/>
+                                    </tei:p>
+                                    <xsl:copy-of select="
+                                        $wrapped-content[empty($head) or . &gt;&gt; $head]"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:copy-of select="$wrapped-content"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
                         </tei:div>
                     </xsl:otherwise>
                 </xsl:choose>
@@ -187,10 +257,20 @@
         </xsl:message>
     </xsl:template>
 
-    <xsl:template match="c[lang]">
-        <xsl:variable name="parsha" select="normalize-space(lang)"/>
-        <tei:milestone unit="parsha" n="{$parsha}" 
-            corresp="urn:x-opensiddur:text:bible:{$book_name}/{$parsha}"/>
+    <!-- A centered Hebrew word on its own is a parshah running head:
+    {{c|{{lang|he|ויצא}}}} -->
+    <xsl:template match="c[lang][not(text()[normalize-space()])]">
+        <xsl:sequence select="f:parsha-milestone(normalize-space(lang))"/>
+    </xsl:template>
+
+    <!-- A centered Hebrew letter followed by its printed Latin name is an acrostic stanza
+    heading in Psalm 119: {{c|{{lang|he|א}} ALEPH.}}. These are not parshiyot — they were
+    emitted as unit="parsha" until they collided with the real ones — and they are not
+    addressable text divisions, so they take no corresp. They must not become tei:head
+    either: the multiple-head grouping in the mediawikis template would split Psalms into
+    a sub-book div per stanza. -->
+    <xsl:template match="c[lang][text()[normalize-space()]]">
+        <tei:milestone unit="acrostic" n="{normalize-space(lang)}"/>
     </xsl:template>
 
     <!-- double height row = double-line break - it's a paragraph... -->

--- a/opensiddur/importer/util/parshiyot.py
+++ b/opensiddur/importer/util/parshiyot.py
@@ -1,0 +1,157 @@
+"""The names of the weekly parshiyot, in the three forms the importers need.
+
+``JLPTEI-3.md`` asks for transliterated Hebrew in URN path segments, "unless the text has a
+common name (with a common spelling)". Every parshah does, so the table below is explicit
+rather than produced by running the transliteration rules over the Hebrew: mechanical
+transliteration would give forms nobody writes (``vzat_hbrkh``), and it would silently drop
+the maqaf in לך־לך.
+
+The table is also the join between sources that name the parshiyot differently — MAM in
+pointed Hebrew, hebcal in English, the JPS 1917 scans in unpointed Hebrew with the maqaf
+sometimes written as a space and sometimes not at all — so lookups by Hebrew name go through
+:func:`opensiddur.importer.util.hebrew.normalize_hebrew`, which reduces a name to its bare
+consonant skeleton. That is why ``לךלך`` (jps1917), ``לך־לך`` (MAM) and ``לֶךְ־לְךָ`` all resolve
+to the same entry. The skeletons of all 54 names are distinct, so nothing is conflated:
+``כי תשא``/``כי־תצא``/``כי־תבוא`` fold to ``כיתשא``/``כיתצא``/``כיתבוא``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from opensiddur.importer.util.hebrew import normalize_hebrew
+
+# (Hebrew name, hebcal name, opensiddur slug)
+PARSHA_NAMES: tuple[tuple[str, str, str], ...] = (
+    ("בראשית", "Bereshit", "bereshit"),
+    ("נֹח", "Noach", "noach"),
+    ("לך־לך", "Lech-Lecha", "lech_lecha"),
+    ("וירא", "Vayera", "vayera"),
+    ("חיי שרה", "Chayei Sara", "chayei_sara"),
+    ("תולדֹת", "Toldot", "toldot"),
+    ("ויצא", "Vayetzei", "vayetzei"),
+    ("וישלח", "Vayishlach", "vayishlach"),
+    ("וישב", "Vayeshev", "vayeshev"),
+    ("מקץ", "Miketz", "miketz"),
+    ("ויגש", "Vayigash", "vayigash"),
+    ("ויחי", "Vayechi", "vayechi"),
+    ("שמות", "Shemot", "shemot"),
+    ("וארא", "Vaera", "vaera"),
+    ("בֹא", "Bo", "bo"),
+    ("בשלח", "Beshalach", "beshalach"),
+    ("יתרו", "Yitro", "yitro"),
+    ("משפטים", "Mishpatim", "mishpatim"),
+    ("תרומה", "Terumah", "terumah"),
+    ("תצוה", "Tetzaveh", "tetzaveh"),
+    ("כי תשא", "Ki Tisa", "ki_tisa"),
+    ("ויקהל", "Vayakhel", "vayakhel"),
+    ("פקודי", "Pekudei", "pekudei"),
+    ("ויקרא", "Vayikra", "vayikra"),
+    ("צו", "Tzav", "tzav"),
+    ("שמיני", "Shmini", "shmini"),
+    ("תזריע", "Tazria", "tazria"),
+    ("מצֹרע", "Metzora", "metzora"),
+    ("אחרי מות", "Achrei Mot", "achrei_mot"),
+    ("קדֹשים", "Kedoshim", "kedoshim"),
+    ("אמֹר", "Emor", "emor"),
+    ("בהר", "Behar", "behar"),
+    ("בחֻקֹתי", "Bechukotai", "bechukotai"),
+    ("במדבר", "Bamidbar", "bamidbar"),
+    ("נשֹא", "Nasso", "nasso"),
+    ("בהעלֹתך", "Beha'alotcha", "behaalotcha"),
+    ("שלח", "Sh'lach", "shlach"),
+    ("קֹרח", "Korach", "korach"),
+    ("חֻקת", "Chukat", "chukat"),
+    ("בלק", "Balak", "balak"),
+    ("פינחס", "Pinchas", "pinchas"),
+    ("מטות", "Matot", "matot"),
+    ("מסעי", "Masei", "masei"),
+    ("דברים", "Devarim", "devarim"),
+    ("ואתחנן", "Vaetchanan", "vaetchanan"),
+    ("עקב", "Eikev", "eikev"),
+    ("ראה", "Re'eh", "reeh"),
+    ("שֹפטים", "Shoftim", "shoftim"),
+    ("כי־תצא", "Ki Teitzei", "ki_teitzei"),
+    ("כי־תבוא", "Ki Tavo", "ki_tavo"),
+    ("נִצבים", "Nitzavim", "nitzavim"),
+    ("וילך", "Vayeilech", "vayeilech"),
+    ("האזינו", "Ha'azinu", "haazinu"),
+    ("וזאת הברכה", "Vezot Haberakhah", "vezot_haberakhah"),
+)
+
+# Weeks on which two parshiyot are read together. hebcal names these by joining the two.
+COMBINED_PARSHIYOT: tuple[tuple[str, str], ...] = (
+    ("Vayakhel-Pekudei", "vayakhel_pekudei"),
+    ("Tazria-Metzora", "tazria_metzora"),
+    ("Achrei Mot-Kedoshim", "achrei_mot_kedoshim"),
+    ("Behar-Bechukotai", "behar_bechukotai"),
+    ("Chukat-Balak", "chukat_balak"),
+    ("Matot-Masei", "matot_masei"),
+    ("Nitzavim-Vayeilech", "nitzavim_vayeilech"),
+)
+
+# Spellings that differ from the table by more than pointing, so the consonant skeleton alone
+# does not reach them: a source writing a name plene where the table has it defective. Listed
+# explicitly rather than folded away, because dropping every mater lectionis would conflate
+# real names — וישלח and שלח both reduce to שלח once ו and י go.
+SPELLING_ALIASES: tuple[tuple[str, str], ...] = (
+    ("תולדות", "תולדֹת"),  # jps1917
+    ("אמור", "אמֹר"),  # jps1917
+)
+
+_BY_SKELETON = {
+    normalize_hebrew(hebrew): (hebrew, hebcal, slug)
+    for hebrew, hebcal, slug in PARSHA_NAMES
+}
+_BY_SKELETON.update({
+    normalize_hebrew(variant): _BY_SKELETON[normalize_hebrew(canonical)]
+    for variant, canonical in SPELLING_ALIASES
+})
+
+HEBCAL_TO_SLUG = {hebcal: slug for _, hebcal, slug in PARSHA_NAMES}
+HEBCAL_TO_SLUG.update(dict(COMBINED_PARSHIYOT))
+SLUG_TO_HEBREW = {slug: hebrew for hebrew, _, slug in PARSHA_NAMES}
+
+
+def _entry(hebrew: str) -> tuple[str, str, str]:
+    entry = _BY_SKELETON.get(normalize_hebrew(hebrew))
+    if entry is None:
+        raise KeyError(f"Unknown parshah name: {hebrew!r}")
+    return entry
+
+
+def canonical_hebrew(hebrew: str) -> str:
+    """The table's spelling of a parshah named in Hebrew, however it was written."""
+    return _entry(hebrew)[0]
+
+
+def slug_for_hebrew(hebrew: str) -> str:
+    """The slug for a parshah named in Hebrew, with or without pointing."""
+    return _entry(hebrew)[2]
+
+
+def hebcal_for_hebrew(hebrew: str) -> str:
+    return _entry(hebrew)[1]
+
+
+def slugify_reading_name(name: str) -> str:
+    """Slug for a reading hebcal names but the parshah table does not, e.g. a festival."""
+    folded = name.replace("'", "").replace("’", "")
+    return re.sub(r"[\s\-/]+", "_", folded.lower()).strip("_")
+
+
+def skeleton_map_json() -> str:
+    """The table as JSON, keyed by consonant skeleton, for handing to an XSLT stylesheet.
+
+    ``xslt_transform_string`` can only marshal atomic values, so stylesheets that need the
+    table take it as a string parameter and rebuild it with ``parse-json()``. Keying by
+    skeleton lets the stylesheet do the same widening with one ``replace()``.
+    """
+    return json.dumps(
+        {
+            skeleton: {"n": hebrew, "slug": slug}
+            for skeleton, (hebrew, _, slug) in _BY_SKELETON.items()
+        },
+        ensure_ascii=False,
+    )

--- a/opensiddur/tests/importer/jps1917/test_convert_wikisource.py
+++ b/opensiddur/tests/importer/jps1917/test_convert_wikisource.py
@@ -1,5 +1,6 @@
+import re
 import unittest
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import ANY, patch, MagicMock, mock_open
 import tempfile
 import os
 from pathlib import Path
@@ -9,6 +10,7 @@ from opensiddur.importer.jps1917.convert_wikisource import (
     book_file, index_file, Book, Index, mediawiki_xml_to_tei, main, make_project_directory,
     TITLE_PAGE, prepend_to_front,
 )
+from opensiddur.importer.util.parshiyot import skeleton_map_json
 from opensiddur.importer.util.validation import validate_with_start, validate
 
 
@@ -1140,6 +1142,7 @@ class TestBookFile(unittest.TestCase):
         mock_header.assert_called_once_with(
             book_name_he="בראשית",
             book_name_en="Genesis",
+            entrypoint="genesis",
             transcription_credits=["Credit1", "Credit2"]
         )
         
@@ -1150,6 +1153,8 @@ class TestBookFile(unittest.TestCase):
             wrapper_div_type="book",
             book_name="genesis",
             is_section=False,
+            parsha_names=ANY,
+            first_parsha="",
         )
         
         # Verify tei_file was called with correct parameters
@@ -1160,9 +1165,6 @@ class TestBookFile(unittest.TestCase):
             standOff=""
         )
         
-        # Verify temp file was written
-        mock_file.assert_called_once_with("temp.tei.xml", "w")
-        mock_file().write.assert_called_once_with("<tei:TEI>Complete TEI content</tei:TEI>")
         
         # Verify validate_and_write_tei_file was called
         mock_validate_write.assert_called_once_with("<tei:TEI>Complete TEI content</tei:TEI>", "genesis", None)
@@ -1209,6 +1211,8 @@ class TestBookFile(unittest.TestCase):
             wrapper_div_type="book",
             book_name="genesis_ch1",
             is_section=True,
+            parsha_names=ANY,
+            first_parsha="",
         )
         
         # Verify return value
@@ -1316,6 +1320,7 @@ class TestIndexFile(unittest.TestCase):
             book_name_en="The Torah",
             book_sub_he="חמישה חומשי תורה",
             book_sub_en="Five Books of Moses",
+            entrypoint="torah",
             transcription_credits=["Index transcriber"]
         )
         
@@ -1325,6 +1330,7 @@ class TestIndexFile(unittest.TestCase):
             sourcetexts_root=None,
             wrapper_div_type="",
             book_name="",
+            parsha_names=ANY,
         )
         
         # Verify tei_file was called with correct body containing transclusions
@@ -1342,9 +1348,6 @@ class TestIndexFile(unittest.TestCase):
         self.assertIn('<tei:head>The Torah</tei:head>', body_content)
         self.assertIn('<j:transclude target="urn:x-opensiddur:text:bible:genesis"/>', body_content)
         self.assertIn('<j:transclude target="urn:x-opensiddur:text:bible:exodus"/>', body_content)
-        
-        # Verify temp file was written (multiple times due to recursion)
-        self.assertGreater(mock_file.call_count, 0)
         
         # Verify validate_and_write_tei_file was called for the index
         mock_validate_write.assert_any_call("<tei:TEI>Complete index TEI</tei:TEI>", "torah", None)
@@ -1384,6 +1387,7 @@ class TestIndexFile(unittest.TestCase):
             book_name_en="Bible Index",
             book_sub_he=None,
             book_sub_en=None,
+            entrypoint="bible_index",
             transcription_credits=None
         )
         
@@ -1552,8 +1556,14 @@ class TestMediawikiXmlToTei(unittest.TestCase):
         from opensiddur.common.xslt import xslt_transform_string
         
         self.xslt_path = MEDIAWIKI_TO_TEI_XSLT
-        self.transform = lambda xml, params=None: xslt_transform_string(self.xslt_path, xml, multiple_results=True, xslt_params=params)
-        
+        # The stylesheet resolves parshah names against this table and terminates on a name it
+        # does not know, so every transformation gets it unless a test overrides it.
+        self.parsha_names = skeleton_map_json()
+        self.transform = lambda xml, params=None: xslt_transform_string(
+            self.xslt_path, xml, multiple_results=True,
+            xslt_params={"parsha_names": self.parsha_names, **(params or {})},
+        )
+
         # Simple test XML that focuses on basic functionality
         self.simple_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <mediawikis xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:j="http://jewishliturgy.org/ns/jlptei/2">
@@ -1563,7 +1573,7 @@ class TestMediawikiXmlToTei(unittest.TestCase):
         <dropinitial>1</dropinitial>
         <verse chapter="1" verse="1">In the beginning God created the heaven and the earth.</verse>
         <verse chapter="1" verse="2">And the earth was without form, and void.</verse>
-        <c><lang>Parashat Bereshit</lang></c>
+        <c><lang>ויצא</lang></c>
         <br>List item 1</br>
         <br>List item 2</br>
         <br>List item 3</br>
@@ -1601,7 +1611,8 @@ class TestMediawikiXmlToTei(unittest.TestCase):
     def test_mediawiki_xml_to_tei_basic_transformation(self):
         """Test basic MediaWiki to TEI transformation."""
         # Test the wrapper function
-        result = mediawiki_xml_to_tei(self.simple_xml)
+        result = mediawiki_xml_to_tei(
+            self.simple_xml, {"parsha_names": self.parsha_names})
         self.assertIn("front", result)
         self.assertIn("body", result)
         self.assertIn("standOff", result)
@@ -1673,9 +1684,13 @@ class TestMediawikiXmlToTei(unittest.TestCase):
         self.assertIn('unit="verse" n="1"', main_output)
         self.assertIn('unit="verse" n="2"', main_output)
         
-        # Test parsha milestone
-        self.assertIn('unit="parsha" n="Parashat Bereshit"', main_output)
-    
+        # Test parsha milestone: the canonical name and the transliterated URN path segment
+        # both come from the parshah table, not from the way the source spells the name.
+        self.assertIn(
+            'unit="parsha" n="ויצא" corresp="urn:x-opensiddur:text:bible:genesis/vayetzei"',
+            main_output,
+        )
+
     def test_mediawiki_xml_to_tei_lists(self):
         """Test transformation of br elements to lists."""
         outputs = self.transform(self.simple_xml)
@@ -1751,6 +1766,124 @@ class TestMediawikiXmlToTei(unittest.TestCase):
         self.assertIn('Existing TEI Head', main_output)
         self.assertIn('Existing TEI paragraph', main_output)
         # Note: The note element might not be in the main output due to XSLT processing
+
+
+class TestParshaMilestones(unittest.TestCase):
+    """A centered Hebrew word is a parshah running head; a centered Hebrew letter followed by
+    its printed Latin name is a Psalm 119 acrostic stanza heading. The two look alike in the
+    source and were both emitted as unit="parsha" until they collided."""
+
+    def setUp(self):
+        from opensiddur.importer.jps1917.convert_wikisource import MEDIAWIKI_TO_TEI_XSLT
+        from opensiddur.common.xslt import xslt_transform_string
+
+        self.parsha_names = skeleton_map_json()
+        self.transform = lambda xml, params=None: xslt_transform_string(
+            MEDIAWIKI_TO_TEI_XSLT, xml, multiple_results=True,
+            xslt_params={"parsha_names": self.parsha_names, **(params or {})},
+        )
+
+    def _wrap(self, content):
+        return f"""<?xml version="1.0" encoding="UTF-8"?>
+<mediawikis xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:j="http://jewishliturgy.org/ns/jlptei/2">
+    <mediawiki>
+        <noinclude><c>1</c></noinclude>
+        {content}
+    </mediawiki>
+</mediawikis>"""
+
+    def _transform_names(self, names, book_name="genesis", params=None):
+        content = "".join(f"<c><lang>{name}</lang></c><p/>text" for name in names)
+        # wrapper_div_type keeps the TEI namespace declaration on the enclosing div rather
+        # than repeating it on every element, so assertions can match whole milestones.
+        return self.transform(
+            self._wrap(content),
+            {"book_name": book_name, "wrapper_div_type": "book", **(params or {})},
+        )[""]
+
+    def test_running_head_becomes_a_parsha_milestone(self):
+        output = self._transform_names(["ויצא"])
+        self.assertIn(
+            '<tei:milestone unit="parsha" n="ויצא" '
+            'corresp="urn:x-opensiddur:text:bible:genesis/vayetzei"/>',
+            output,
+        )
+
+    def test_source_spellings_are_canonicalized(self):
+        # Exactly the @n values the importer used to emit, straight from the 1917 scans.
+        cases = {
+            "לךלך": ('n="לך־לך"', "genesis/lech_lecha"),
+            "נח": ('n="נֹח"', "genesis/noach"),
+            "תולדות": ('n="תולדֹת"', "genesis/toldot"),
+        }
+        for written, (expected_n, expected_path) in cases.items():
+            with self.subTest(written=written):
+                output = self._transform_names([written])
+                self.assertIn(expected_n, output)
+                self.assertIn(f'corresp="urn:x-opensiddur:text:bible:{expected_path}"', output)
+
+    def test_urn_path_segments_are_transliterated(self):
+        # JLPTEI-3.md requires transliterated path segments with _ for spaces; the names below
+        # produced raw Hebrew URNs with literal spaces.
+        output = self._transform_names(["כי תצא", "וזאת הברכה"], book_name="deuteronomy")
+        self.assertIn('corresp="urn:x-opensiddur:text:bible:deuteronomy/ki_teitzei"', output)
+        self.assertIn(
+            'corresp="urn:x-opensiddur:text:bible:deuteronomy/vezot_haberakhah"', output)
+        for corresp in re.findall(r'unit="parsha"[^/]*corresp="([^"]*)"', output):
+            self.assertNotRegex(corresp, r"[֐-׿]")
+            self.assertNotIn(" ", corresp)
+
+    def test_acrostic_stanza_is_not_a_parsha(self):
+        # {{c|{{lang|he|א}} ALEPH.}} — the Latin name printed beside the letter is what
+        # distinguishes a Psalm 119 stanza heading from a parshah running head.
+        output = self.transform(
+            self._wrap("<c><lang>א</lang> ALEPH.</c><p/>Happy are they that are upright"),
+            {"book_name": "psalms", "wrapper_div_type": "book"},
+        )[""]
+        self.assertIn('<tei:milestone unit="acrostic" n="א"/>', output)
+        self.assertNotIn('unit="parsha"', output)
+        self.assertNotIn("corresp", output.split('unit="acrostic"')[1])
+
+    def test_acrostic_stanza_does_not_become_a_head(self):
+        # A tei:head here would make the multiple-head grouping split Psalms into a
+        # sub-book div per stanza.
+        output = self.transform(
+            self._wrap(
+                "<c><larger>Psalm 119</larger></c>"
+                "<c><lang>א</lang> ALEPH.</c><p/>one"
+                "<c><lang>ב</lang> BETH.</c><p/>two"
+            ),
+            {"book_name": "psalms", "wrapper_div_type": "book"},
+        )[""]
+        self.assertEqual(2, output.count('unit="acrostic"'))
+        self.assertEqual(1, output.count("<tei:head>"))
+        self.assertEqual(1, output.count('type="book"'))
+
+    def test_unknown_name_terminates(self):
+        # Rather than inventing a parshah, which is how the acrostic letters became parshiyot.
+        with self.assertRaises(Exception):
+            self._transform_names(["שלום"])
+
+    def test_book_opening_parsha_is_emitted_after_the_head(self):
+        # The first parshah of each book of the Torah has no running head in the source, so it
+        # is supplied by the Book table instead.
+        output = self.transform(
+            self._wrap("<c><larger>GENESIS</larger></c><p/>In the beginning"),
+            {"book_name": "genesis", "wrapper_div_type": "book", "first_parsha": "בראשית"},
+        )[""]
+        self.assertIn(
+            '<tei:milestone unit="parsha" n="בראשית" '
+            'corresp="urn:x-opensiddur:text:bible:genesis/bereshit"/>',
+            output,
+        )
+        self.assertLess(output.index("</tei:head>"), output.index('unit="parsha"'))
+
+    def test_no_opening_parsha_outside_the_torah(self):
+        output = self.transform(
+            self._wrap("<c><larger>JOSHUA</larger></c><p/>Now it came to pass"),
+            {"book_name": "joshua", "wrapper_div_type": "book", "first_parsha": ""},
+        )[""]
+        self.assertNotIn('unit="parsha"', output)
 
 
 class TestMakeProjectDirectory(unittest.TestCase):

--- a/opensiddur/tests/importer/util/test_parshiyot.py
+++ b/opensiddur/tests/importer/util/test_parshiyot.py
@@ -1,0 +1,136 @@
+import json
+import unittest
+
+from opensiddur.importer.util.parshiyot import (
+    COMBINED_PARSHIYOT,
+    HEBCAL_TO_SLUG,
+    PARSHA_NAMES,
+    SLUG_TO_HEBREW,
+    canonical_hebrew,
+    hebcal_for_hebrew,
+    skeleton_map_json,
+    slug_for_hebrew,
+    slugify_reading_name,
+)
+
+
+class TestParshaTable(unittest.TestCase):
+    def test_fifty_four_parshiyot(self):
+        self.assertEqual(54, len(PARSHA_NAMES))
+
+    def test_slugs_are_unique(self):
+        slugs = [slug for _, _, slug in PARSHA_NAMES]
+        self.assertEqual(len(slugs), len(set(slugs)))
+
+    def test_hebrew_names_are_unique(self):
+        names = [hebrew for hebrew, _, _ in PARSHA_NAMES]
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_slugs_are_urn_safe(self):
+        for _, _, slug in PARSHA_NAMES:
+            with self.subTest(slug=slug):
+                self.assertRegex(slug, r"^[a-z][a-z_]*[a-z]$")
+
+    def test_combined_parshiyot_are_in_the_hebcal_map(self):
+        for hebcal_name, slug in COMBINED_PARSHIYOT:
+            self.assertEqual(slug, HEBCAL_TO_SLUG[hebcal_name])
+
+    def test_slug_to_hebrew_round_trips(self):
+        for hebrew, _, slug in PARSHA_NAMES:
+            self.assertEqual(hebrew, SLUG_TO_HEBREW[slug])
+
+
+class TestLookupByHebrew(unittest.TestCase):
+    def test_canonical_spelling_resolves(self):
+        for hebrew, hebcal, slug in PARSHA_NAMES:
+            with self.subTest(hebrew=hebrew):
+                self.assertEqual(hebrew, canonical_hebrew(hebrew))
+                self.assertEqual(slug, slug_for_hebrew(hebrew))
+                self.assertEqual(hebcal, hebcal_for_hebrew(hebrew))
+
+    def test_pointing_is_ignored(self):
+        self.assertEqual("noach", slug_for_hebrew("נֹחַ"))
+        self.assertEqual("lech_lecha", slug_for_hebrew("לֶךְ־לְךָ"))
+
+    def test_jps1917_spellings_resolve(self):
+        # The 1917 scans write the names unpointed, and write the maqaf as a space or not
+        # at all. Each of these is the exact @n the jps1917 importer produced before the fix.
+        cases = {
+            "לךלך": ("לך־לך", "lech_lecha"),
+            "כי תצא": ("כי־תצא", "ki_teitzei"),
+            "כי תבוא": ("כי־תבוא", "ki_tavo"),
+            "נח": ("נֹח", "noach"),
+            "בא": ("בֹא", "bo"),
+            "תולדות": ("תולדֹת", "toldot"),
+            "אמור": ("אמֹר", "emor"),
+            "קדשים": ("קדֹשים", "kedoshim"),
+            "בחקתי": ("בחֻקֹתי", "bechukotai"),
+            "בהעלתך": ("בהעלֹתך", "behaalotcha"),
+            "מצרע": ("מצֹרע", "metzora"),
+            "נשא": ("נשֹא", "nasso"),
+            "שפטים": ("שֹפטים", "shoftim"),
+            "נצבים": ("נִצבים", "nitzavim"),
+            "וזאת הברכה": ("וזאת הברכה", "vezot_haberakhah"),
+        }
+        for written, (expected_name, expected_slug) in cases.items():
+            with self.subTest(written=written):
+                self.assertEqual(expected_name, canonical_hebrew(written))
+                self.assertEqual(expected_slug, slug_for_hebrew(written))
+
+    def test_similar_names_are_not_conflated(self):
+        # Every pair below shares a consonant skeleton prefix or a mater lectionis with
+        # another parshah; folding too aggressively would merge them.
+        self.assertNotEqual(slug_for_hebrew("שלח"), slug_for_hebrew("וישלח"))
+        self.assertNotEqual(slug_for_hebrew("כי תשא"), slug_for_hebrew("כי תצא"))
+        self.assertNotEqual(slug_for_hebrew("כי תצא"), slug_for_hebrew("כי תבוא"))
+
+    def test_unknown_name_raises(self):
+        # The Psalm 119 acrostic letters must not resolve to a parshah.
+        for letter in ("א", "ב", "ת"):
+            with self.subTest(letter=letter):
+                with self.assertRaises(KeyError):
+                    slug_for_hebrew(letter)
+        with self.assertRaises(KeyError):
+            canonical_hebrew("Parashat Bereshit")
+
+
+class TestSkeletonMapJson(unittest.TestCase):
+    def test_every_parshah_is_reachable(self):
+        table = json.loads(skeleton_map_json())
+        slugs = {entry["slug"] for entry in table.values()}
+        self.assertEqual({slug for _, _, slug in PARSHA_NAMES}, slugs)
+
+    def test_entries_carry_the_canonical_name(self):
+        table = json.loads(skeleton_map_json())
+        for hebrew, _, slug in PARSHA_NAMES:
+            entry = next(e for e in table.values() if e["slug"] == slug)
+            self.assertEqual(hebrew, entry["n"])
+
+    def test_jps1917_spellings_are_keys(self):
+        table = json.loads(skeleton_map_json())
+        # The XSLT strips everything but Hebrew letters before looking a name up, so the
+        # skeleton of a source spelling must be a key.
+        self.assertEqual("lech_lecha", table["לךלך"]["slug"])
+        self.assertEqual("toldot", table["תולדות"]["slug"])
+
+    def test_acrostic_letters_are_not_keys(self):
+        table = json.loads(skeleton_map_json())
+        for letter in ("א", "ב", "ג", "ת"):
+            self.assertNotIn(letter, table)
+
+
+class TestSlugifyReadingName(unittest.TestCase):
+    def test_festival_names(self):
+        self.assertEqual("rosh_hashana_i", slugify_reading_name("Rosh Hashana I"))
+        self.assertEqual("shabbat_chol_hamoed", slugify_reading_name("Shabbat Chol Hamoed"))
+
+    def test_apostrophes_are_dropped_not_replaced(self):
+        self.assertEqual("sukkot_shabbat_chol_hamoed", slugify_reading_name(
+            "Sukkot Shabbat Chol Hamoed"))
+        self.assertEqual("erev_rosh_hashana", slugify_reading_name("Erev Rosh Hashana"))
+        self.assertEqual("shmini_atzeret", slugify_reading_name("Shmini Atzeret"))
+        self.assertEqual("reeh", slugify_reading_name("Re'eh"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Closes #44.

The Psalm 119 acrostic and a parshah running head are the same markup in the Wikisource scans — a centered `{{lang|he|…}}` — so the importer emitted the 22 stanza letters of Psalm 119 as `tei:milestone[@unit='parsha']`. They collided with the 49 real ones and would have produced 22 spurious "Parsha: א" footnotes in Psalms once `reledmac.xslt`'s parsha rendering improved. The two are distinguishable: a stanza heading prints the Latin name of the letter beside it (`{{c|{{lang|he|א}} ALEPH.}}`), a running head is the Hebrew word alone (`{{c|{{lang|he|ויצא}}}}`). Acrostic stanzas now become `unit="acrostic"` with no `corresp` — not `tei:head`, which would make the multiple-head grouping split Psalms into a sub-book div per stanza.

Resolving the name against a table rather than copying it off the page fixes the rest of the parsha defects at the same time:

- **URNs** were raw Hebrew with literal spaces (`…:deuteronomy/כי תצא`), against `JLPTEI-3.md`. They are now transliterated slugs (`…:deuteronomy/ki_teitzei`).
- **`@n`** was whatever the scan printed — `לךלך` without its maqaf, `נח` unpointed. It now carries the canonical name.
- **Five parshiyot were missing.** Bereshit, Shemot, Vayikra, Bamidbar and Devarim have no running head, because each book's title heading is printed in its place. They are declared on the `Book` table and emitted after the heading. The count goes from 49 to 54.

An unknown name now terminates the transform rather than becoming a parshah, which is how the acrostic letters got in.

The table lives in `opensiddur/importer/util/parshiyot.py` rather than under `jps1917/` because the humash importer needs the same join between MAM's Hebrew names and hebcal's English ones. Lookups go through the consonant skeleton (`hebrew.normalize_hebrew`), so a source's pointing and separators don't matter; the two plene/defective differences that survive that are listed explicitly, since folding away every mater lectionis would merge וישלח and שלח.

Separately (item 4 of the issue, and broader than reported): **all 44** generated files declared the document URN `urn:x-opensiddur:text:bible:tanakh@jps1917`, not just `the_law.xml` and `index.xml`. Each file now names itself, matching its body div and the `wlc` convention; `index.xml` keeps the `tanakh` URN as the project entry point and its div `corresp` was changed to agree. The two stray `temp.tei.xml` debug writes are gone.

## Verification

Full suite green (`uv run pytest`: 1059 passed, 23 skipped). Against the regenerated output:

- 54 parsha milestones, all in the Torah (genesis 12, exodus 11, leviticus 10, numbers 10, deuteronomy 11); 0 in Psalms
- 22 `unit="acrostic"` in `psalms.xml`
- no parsha URN contains a Hebrew character or a space; 54 unique slugs
- 44 distinct document URNs
- `refdb` sync and `validate_urn_references jps1917` clean — the only unresolved references are the pre-existing malformed `urn:x-opensiddur:text:bible://` targets in standoff notes, identical in count on `main`
- the output diff touches only parsha/acrostic milestones, `idno` URNs, the index div `corresp`, and the five new milestone paragraphs; no verse, chapter, page-break or note markup moved

Regenerated output: opensiddur/opensiddur-projects#3

## Note, not fixed here

Parsha milestones land in a `tei:p` of their own, outside a verse pstart, so `reledmac.xslt`'s `$in-pstart` guard drops them from TeX output today. Worth addressing when parsha rendering lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
