### PR TITLE
Stop range transclusion from emitting content outside the range (#51)

### DIFF
--- a/opensiddur/exporter/external_compiler.py
+++ b/opensiddur/exporter/external_compiler.py
@@ -108,6 +108,12 @@ class ExternalCompilerProcessor(CompilerProcessor):
 
         self.deepest_common_ancestor, self.start_element, self.end_element, self.include_tail_after_end = self._get_deepest_common_ancestor(from_start, to_end, include_tail_after_end)
 
+        # The only elements that are copied before the start is reached are the start's own
+        # ancestors, to rebuild the structure it sits in. Held on self so the proxies stay alive.
+        self.start_ancestors = (
+            frozenset(self.start_element.iterancestors()) if self.start_element is not None else frozenset()
+        )
+
         # None = marker mode off; [] = marker mode active
         self.marker_stack: list[tuple[str, ElementBase]] | None = None
 
@@ -668,7 +674,8 @@ class ExternalCompilerProcessor(CompilerProcessor):
         #      check if this element is the start
         #       if yes, set before_start to False and return COPY_AND_RECURSE,
         #       else
-        #           before start? COPY_ELEMENT_AND_RECURSE
+        #           before start? an ancestor of the start: COPY_ELEMENT_AND_RECURSE
+        #                         anything else: RECURSE
         #           after start? COPY_AND_RECURSE
         #    after end, SKIP
 
@@ -692,7 +699,11 @@ class ExternalCompilerProcessor(CompilerProcessor):
                 context['inside_deepest_common_ancestor'] = True
                 context['command'] = _ProcessingCommand.COPY_ELEMENT_AND_RECURSE
                 return context
-            elif context['inside_deepest_common_ancestor']:
+            elif context['inside_deepest_common_ancestor'] and element in self.start_ancestors:
+                # Skeleton copies exist to rebuild the start element's ancestor chain, and
+                # nothing else. Copying every element that merely precedes the start left an
+                # empty shell of each one -- including verse milestones, which then printed
+                # spurious verse numbers and broke parallel alignment (#51).
                 context['command'] = _ProcessingCommand.COPY_ELEMENT_AND_RECURSE
                 return context
             else:

--- a/opensiddur/exporter/refdb.py
+++ b/opensiddur/exporter/refdb.py
@@ -13,6 +13,57 @@ from opensiddur.common.constants import PROJECT_DIRECTORY, INDEX_DB_DIRECTORY
 
 INDEX_DB_FILE = INDEX_DB_DIRECTORY / "reference.db"
 
+
+def find_end_of_mapping(element: ElementBase) -> tuple[str, bool]:
+    """Find the end element path and tail-inclusion flag for a URN mapping.
+
+    For milestone elements, finds the element just before the next same-level milestone.
+    For non-milestones, the element itself is the end.
+
+    "Just before" is the nearest preceding sibling of the next milestone, or -- when the
+    next milestone is the first element in its parent -- the nearest preceding sibling of
+    the closest ancestor that has one. The end element is always the node whose *tail* is
+    the last text before the next milestone, which is what `include_tail` then picks up.
+    Taking the deepest preceding element instead (`preceding::*[1]`) would land inside a
+    subtree and drop the text between that subtree's close and the milestone.
+
+    Returns:
+        (end_element_path, include_tail)
+    """
+    ns_map = {'tei': 'http://www.tei-c.org/ns/1.0'}
+    include_tail = False
+
+    is_milestone = element.tag == '{http://www.tei-c.org/ns/1.0}milestone'
+    if is_milestone:
+        corresp = element.get('corresp', '')
+        last_part = corresp.split(':')[-1]
+        num_dividers = last_part.count('/')
+        following_milestones = element.xpath(
+            './following::tei:milestone[@corresp][ancestor::tei:text]', namespaces=ns_map)
+        actual_end = None
+        for milestone in following_milestones:
+            following_corresp = milestone.attrib.get('corresp', '')
+            following_last_part = following_corresp.split(':')[-1]
+            if following_last_part.count('/') <= num_dividers:
+                node = milestone
+                while node is not None:
+                    preceding = node.xpath('./preceding-sibling::*[1]')
+                    if preceding:
+                        actual_end = preceding[0]
+                        break
+                    node = node.getparent()
+                include_tail = True
+                break
+        if actual_end is None:
+            siblings = element.xpath('./following-sibling::*[last()]|self::*')
+            actual_end = siblings[-1]
+            include_tail = True
+        return actual_end.getroottree().getpath(actual_end), include_tail
+    else:
+        end_path = element.getroottree().getpath(element)
+        return end_path, include_tail
+
+
 class UrnMapping(BaseModel):
     project: str
     file_name: str
@@ -204,7 +255,7 @@ class ReferenceDatabase:
         if not urn:
             return
         element_path = element.getroottree().getpath(element)
-        end_element_path, end_includes_tail = self._find_end_of_mapping(element)
+        end_element_path, end_includes_tail = find_end_of_mapping(element)
         element_tag = element.tag
         element_type = element.get('type')
         cursor.execute('''
@@ -215,44 +266,6 @@ class ReferenceDatabase:
                 updated_at = CURRENT_TIMESTAMP
         ''', (urn, project, file_name, element_path, element_tag, element_type, end_element_path, end_includes_tail))
         self.conn.commit()
-
-    def _find_end_of_mapping(self, element: ElementBase) -> tuple[str, bool]:
-        """Find the end element path and tail-inclusion flag for a URN mapping.
-
-        For milestone elements, finds the element just before the next same-level milestone.
-        For non-milestones, the element itself is the end.
-
-        Returns:
-            (end_element_path, include_tail)
-        """
-        ns_map = {'tei': 'http://www.tei-c.org/ns/1.0'}
-        include_tail = False
-
-        is_milestone = element.tag == '{http://www.tei-c.org/ns/1.0}milestone'
-        if is_milestone:
-            corresp = element.get('corresp', '')
-            last_part = corresp.split(':')[-1]
-            num_dividers = last_part.count('/')
-            following_milestones = element.xpath(
-                './following::tei:milestone[@corresp][ancestor::tei:text]', namespaces=ns_map)
-            actual_end = None
-            for milestone in following_milestones:
-                following_corresp = milestone.attrib.get('corresp', '')
-                following_last_part = following_corresp.split(':')[-1]
-                if following_last_part.count('/') <= num_dividers:
-                    preceding = milestone.xpath('./preceding::*[1]')
-                    if preceding:
-                        actual_end = preceding[0]
-                    include_tail = True
-                    break
-            if actual_end is None:
-                siblings = element.xpath('./following-sibling::*[last()]|self::*')
-                actual_end = siblings[-1]
-                include_tail = True
-            return actual_end.getroottree().getpath(actual_end), include_tail
-        else:
-            end_path = element.getroottree().getpath(element)
-            return end_path, include_tail
 
     def add_reference(self, project: str, file_name: str, element: ElementBase):
         """ Add a reference to the database.

--- a/opensiddur/tests/exporter/test_external_compiler.py
+++ b/opensiddur/tests/exporter/test_external_compiler.py
@@ -10,7 +10,7 @@ from lxml import etree
 from opensiddur.exporter.external_compiler import ExternalCompilerProcessor
 from opensiddur.exporter.compiler import CompilerProcessor
 from opensiddur.exporter.linear import LinearData, reset_linear_data, get_linear_data
-from opensiddur.exporter.refdb import Reference, ReferenceDatabase, UrnMapping
+from opensiddur.exporter.refdb import Reference, ReferenceDatabase, UrnMapping, find_end_of_mapping
 from opensiddur.exporter.urn import ResolvedUrn, ResolvedUrnRange
 
 TEI_NS = "http://www.tei-c.org/ns/1.0"
@@ -93,41 +93,6 @@ class TestExternalCompilerProcessor(unittest.TestCase):
         for el in out:
             all_notes.extend(el.findall(f".//{{{TEI_NS}}}note"))
         self.assertTrue(all_notes)
-
-    def _get_milestone_end_path(self, milestone_elem: etree._Element) -> tuple[str, bool]:
-        """Compute the end element path for a milestone element.
-
-        Finds the preceding-sibling of the next same-or-higher-level milestone,
-        or the last sibling if no next milestone exists.
-
-        Returns:
-            (end_element_path, include_tail_after_end)
-        """
-        ns_map = {'tei': 'http://www.tei-c.org/ns/1.0'}
-        tree = milestone_elem.getroottree()
-        corresp = milestone_elem.get('corresp', '')
-        last_part = corresp.split(':')[-1]
-        num_dividers = last_part.count('/')
-
-        following_milestones = milestone_elem.xpath(
-            './following::tei:milestone[@corresp][ancestor::tei:text]', namespaces=ns_map)
-
-        for ms in following_milestones:
-            following_corresp = ms.get('corresp', '')
-            following_last_part = following_corresp.split(':')[-1]
-            if following_last_part.count('/') <= num_dividers:
-                # Use preceding-sibling of this milestone as the end element
-                prev_sib = ms.xpath('./preceding-sibling::*[1]')
-                if prev_sib:
-                    return tree.getpath(prev_sib[0]), True
-                break
-
-        # No next milestone or no preceding sibling: use the last following sibling
-        siblings = milestone_elem.xpath('./following-sibling::*[last()]')
-        if siblings:
-            return tree.getpath(siblings[-1]), True
-        # Fallback: end is the milestone itself
-        return tree.getpath(milestone_elem), False
 
     def test_siblings_identity_transform(self):
         """Test that ExternalCompilerProcessor acts as identity transform for siblings."""
@@ -1067,7 +1032,7 @@ class TestExternalCompilerProcessor(unittest.TestCase):
         ext_tree = ext_root.getroottree()
         milestone_elem = ext_root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/1/3']")[0]
         from_start = ext_tree.getpath(milestone_elem)
-        end_element_path, include_tail = self._get_milestone_end_path(milestone_elem)
+        end_element_path, include_tail = find_end_of_mapping(milestone_elem)
 
         # Process with ExternalCompilerProcessor
         processor = ExternalCompilerProcessor(ext_project, ext_file, from_start, end_element_path, include_tail_after_end=include_tail)
@@ -1150,7 +1115,7 @@ class TestExternalCompilerProcessor(unittest.TestCase):
         ext_tree = ext_root.getroottree()
         milestone_elem = ext_root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/1/3']")[0]
         from_start = ext_tree.getpath(milestone_elem)
-        end_element_path, include_tail = self._get_milestone_end_path(milestone_elem)
+        end_element_path, include_tail = find_end_of_mapping(milestone_elem)
 
         # Process with ExternalCompilerProcessor
         processor = ExternalCompilerProcessor(ext_project, ext_file, from_start, end_element_path, include_tail_after_end=include_tail)
@@ -1227,7 +1192,7 @@ class TestExternalCompilerProcessor(unittest.TestCase):
         ext_tree = ext_root.getroottree()
         milestone_elem = ext_root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/1/3']")[0]
         from_start = ext_tree.getpath(milestone_elem)
-        end_element_path, include_tail = self._get_milestone_end_path(milestone_elem)
+        end_element_path, include_tail = find_end_of_mapping(milestone_elem)
 
         # Process with ExternalCompilerProcessor
         processor = ExternalCompilerProcessor(ext_project, ext_file, from_start, end_element_path, include_tail_after_end=include_tail)
@@ -1264,6 +1229,107 @@ class TestExternalCompilerProcessor(unittest.TestCase):
                         "Should not include the next chapter")
         # Should not include the chapter 2 text
         self.assertNotIn("Chapter 2 text", result_str, "Should not include the chapter 2 text")
+
+    # A source shaped like the bible projects: verse milestones are leaves inside several
+    # tei:p under one tei:div, and the paragraph breaks do not line up with the range.
+    # The start and the end therefore have different parents, so the deepest common
+    # ancestor is the tei:div rather than the start element itself.
+    MULTI_PARAGRAPH_SOURCE = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="he">
+    <tei:text>
+        <tei:body>
+            <tei:div>
+                <tei:p><tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/1/1"/> Verse 1 1 text
+                    <tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/1/2"/> Verse 1 2 text</tei:p>
+                <tei:p><tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/1/3"/> Verse 1 3 text</tei:p>
+                <tei:p><tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/2/1"/> Verse 2 1 text
+                    <tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/2/2"/> Verse 2 2 text</tei:p>
+                <tei:p><tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/2/3"/> Verse 2 3 text</tei:p>
+                <tei:p><tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/3/1"/> Verse 3 1 text</tei:p>
+            </tei:div>
+        </tei:body>
+    </tei:text>
+</tei:TEI>'''
+
+    def test_range_does_not_emit_milestones_from_before_the_range(self):
+        """A range starting mid-file must not leave empty shells of what precedes it (#51)."""
+        xml_bytes = self.MULTI_PARAGRAPH_SOURCE.encode('utf-8')
+        project, file_name = self._create_test_file("multi_paragraph.xml", xml_bytes)
+
+        root = etree.fromstring(xml_bytes)
+        tree = root.getroottree()
+        start_milestone = root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/2/1']")[0]
+        end_milestone = root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/2/3']")[0]
+        from_start = tree.getpath(start_milestone)
+        end_path, include_tail = find_end_of_mapping(end_milestone)
+
+        processor = ExternalCompilerProcessor(
+            project, file_name, from_start, end_path, include_tail_after_end=include_tail)
+        result = processor.process()
+        result_str = ''.join(etree.tostring(elem, encoding='unicode') for elem in result)
+
+        # The whole range, and only the range
+        for verse in ("Verse 2 1 text", "Verse 2 2 text", "Verse 2 3 text"):
+            self.assertIn(verse, result_str, f"Should include {verse}")
+        for verse in ("Verse 1 1 text", "Verse 1 2 text", "Verse 1 3 text", "Verse 3 1 text"):
+            self.assertNotIn(verse, result_str, f"Should not include {verse}")
+
+        # No milestone from outside the range, not even an empty one
+        for urn in ("book/1/1", "book/1/2", "book/1/3", "book/3/1"):
+            self.assertNotIn(f'corresp="urn:x-opensiddur:text:bible:{urn}"', result_str,
+                             f"Should not include a milestone for {urn}")
+        for urn in ("book/2/1", "book/2/2", "book/2/3"):
+            self.assertIn(f'corresp="urn:x-opensiddur:text:bible:{urn}"', result_str,
+                          f"Should include the milestone for {urn}")
+
+        milestones = [m for elem in result for m in elem.iter(f"{{{TEI_NS}}}milestone")]
+        self.assertEqual(len(milestones), 3, "Exactly the three in-range milestones")
+
+        # The two paragraphs the range touches, and no empty shells of the ones before it
+        paragraphs = [p for elem in result for p in elem.iter(f"{{{TEI_NS}}}p")]
+        self.assertEqual(len(paragraphs), 2, "Only the paragraphs the range actually covers")
+        for paragraph in paragraphs:
+            self.assertTrue(len(paragraph) or (paragraph.text or "").strip(),
+                            "No empty paragraph shells")
+
+    def test_range_keeps_declarations_made_before_the_start(self):
+        """A j:declare preceding the range inside the DCA is still in scope in the range."""
+        xml_bytes = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:j="http://jewishliturgy.org/ns/jlptei/2" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="he">
+    <tei:text>
+        <tei:body>
+            <tei:div>
+                <j:declare xml:id="d">
+                    <tei:fs type="t:fs"><tei:f name="x"><tei:binary value="true"/></tei:f></tei:fs>
+                </j:declare>
+                <tei:p><tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/1/1"/> Verse 1 text</tei:p>
+                <tei:p><tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/1/2"/> Verse 2 text
+                    <j:conditional xml:id="c">
+                        <tei:fs type="t:fs"><tei:f name="x"><tei:binary value="true"/></tei:f></tei:fs>
+                    </j:conditional> conditional text <j:endConditional target="#c"/></tei:p>
+                <tei:p><tei:milestone unit="verse" corresp="urn:x-opensiddur:text:bible:book/1/3"/> Verse 3 text</tei:p>
+            </tei:div>
+        </tei:body>
+    </tei:text>
+    <j:endDeclare target="#d"/>
+</tei:TEI>'''.encode('utf-8')
+        project, file_name = self._create_test_file("declare_before_range.xml", xml_bytes)
+
+        root = etree.fromstring(xml_bytes)
+        tree = root.getroottree()
+        start_milestone = root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/1/2']")[0]
+        from_start = tree.getpath(start_milestone)
+        end_path, include_tail = find_end_of_mapping(start_milestone)
+
+        processor = ExternalCompilerProcessor(
+            project, file_name, from_start, end_path, include_tail_after_end=include_tail)
+        result = processor.process()
+        result_str = ''.join(etree.tostring(elem, encoding='unicode') for elem in result)
+
+        # The declaration is what makes the condition true. Elements before the start are
+        # traversed rather than skipped precisely so this still resolves.
+        self.assertIn("conditional text", result_str)
+        self.assertIn("Verse 2 text", result_str)
+        self.assertNotIn("Verse 1 text", result_str)
+        self.assertNotIn("Verse 3 text", result_str)
 
     def test_comment_between_range_siblings_is_dropped(self):
         """A comment inside a compiled range is dropped and its tail kept (#41)."""

--- a/opensiddur/tests/exporter/test_inline_compiler.py
+++ b/opensiddur/tests/exporter/test_inline_compiler.py
@@ -9,7 +9,7 @@ from unittest.mock import patch, MagicMock
 from lxml import etree
 from opensiddur.exporter.inline_compiler import InlineCompilerProcessor
 from opensiddur.exporter.linear import LinearData, reset_linear_data, get_linear_data
-from opensiddur.exporter.refdb import Reference, ReferenceDatabase, UrnMapping
+from opensiddur.exporter.refdb import Reference, ReferenceDatabase, UrnMapping, find_end_of_mapping
 from opensiddur.exporter.urn import ResolvedUrn
 
 PROCESSING_NAMESPACE = 'http://jewishliturgy.org/ns/processing'
@@ -65,41 +65,6 @@ class TestInlineCompilerProcessor(unittest.TestCase):
         if not elements:
             raise ValueError(f"Element with identifier '{identifier}' not found in XML")
         return tree.getpath(elements[0])
-
-    def _get_milestone_end_path(self, milestone_elem: etree._Element) -> tuple[str, bool]:
-        """Compute the end element path for a milestone element.
-
-        Finds the preceding-sibling of the next same-or-higher-level milestone,
-        or the last sibling if no next milestone exists.
-
-        Returns:
-            (end_element_path, include_tail_after_end)
-        """
-        ns_map = {'tei': 'http://www.tei-c.org/ns/1.0'}
-        tree = milestone_elem.getroottree()
-        corresp = milestone_elem.get('corresp', '')
-        last_part = corresp.split(':')[-1]
-        num_dividers = last_part.count('/')
-
-        following_milestones = milestone_elem.xpath(
-            './following::tei:milestone[@corresp][ancestor::tei:text]', namespaces=ns_map)
-
-        for ms in following_milestones:
-            following_corresp = ms.get('corresp', '')
-            following_last_part = following_corresp.split(':')[-1]
-            if following_last_part.count('/') <= num_dividers:
-                # Use preceding-sibling of this milestone as the end element
-                prev_sib = ms.xpath('./preceding-sibling::*[1]')
-                if prev_sib:
-                    return tree.getpath(prev_sib[0]), True
-                break
-
-        # No next milestone or no preceding sibling: use the last following sibling
-        siblings = milestone_elem.xpath('./following-sibling::*[last()]')
-        if siblings:
-            return tree.getpath(siblings[-1]), True
-        # Fallback: end is the milestone itself
-        return tree.getpath(milestone_elem), False
 
     def test_start_and_end_are_siblings(self):
         """Test when start and end are sibling elements at the same level."""
@@ -835,7 +800,7 @@ class TestInlineCompilerProcessor(unittest.TestCase):
         ext_tree = ext_root.getroottree()
         milestone_elem = ext_root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/1/3']")[0]
         from_start = ext_tree.getpath(milestone_elem)
-        end_element_path, include_tail = self._get_milestone_end_path(milestone_elem)
+        end_element_path, include_tail = find_end_of_mapping(milestone_elem)
 
         # Process with InlineCompilerProcessor with mocked parse_xml
         with patch.object(self.linear_data.xml_cache, 'parse_xml', side_effect=mock_parse_xml):
@@ -931,7 +896,7 @@ class TestInlineCompilerProcessor(unittest.TestCase):
         ext_tree = ext_root.getroottree()
         milestone_elem = ext_root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/1/3']")[0]
         from_start = ext_tree.getpath(milestone_elem)
-        end_element_path, include_tail = self._get_milestone_end_path(milestone_elem)
+        end_element_path, include_tail = find_end_of_mapping(milestone_elem)
 
         # Process with InlineCompilerProcessor with mocked parse_xml
         with patch.object(self.linear_data.xml_cache, 'parse_xml', side_effect=mock_parse_xml):
@@ -1023,7 +988,7 @@ class TestInlineCompilerProcessor(unittest.TestCase):
         ext_tree = ext_root.getroottree()
         milestone_elem = ext_root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/1/3']")[0]
         from_start = ext_tree.getpath(milestone_elem)
-        end_element_path, include_tail = self._get_milestone_end_path(milestone_elem)
+        end_element_path, include_tail = find_end_of_mapping(milestone_elem)
 
         # Process with InlineCompilerProcessor with mocked parse_xml
         with patch.object(self.linear_data.xml_cache, 'parse_xml', side_effect=mock_parse_xml):

--- a/opensiddur/tests/exporter/test_refdb.py
+++ b/opensiddur/tests/exporter/test_refdb.py
@@ -7,7 +7,7 @@ import time
 import os
 from lxml import etree
 from lxml.etree import ElementBase
-from opensiddur.exporter.refdb import ReferenceDatabase, UrnMapping, Reference
+from opensiddur.exporter.refdb import ReferenceDatabase, UrnMapping, Reference, find_end_of_mapping
 
 
 class TestReferenceDatabaseBasics(unittest.TestCase):
@@ -1044,6 +1044,94 @@ class TestReferenceDatabaseContextManager(unittest.TestCase):
                 self.assertEqual(len(results), 1)
             
             # Connection should be closed after context
+
+
+class TestFindEndOfMapping(unittest.TestCase):
+    """Test the end-of-range computation that backs milestone-scoped URNs."""
+
+    def _end_of(self, xml: str, corresp: str) -> tuple[str, bool]:
+        """Return (end path, include_tail) for the element carrying `corresp`."""
+        root = etree.fromstring(xml.encode('utf-8'))
+        element = root.xpath(f"//*[@corresp='{corresp}']")[0]
+        return find_end_of_mapping(element)
+
+    def test_non_milestone_ends_at_itself(self):
+        """A non-milestone URN scopes to its own element and excludes its tail."""
+        xml = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text><tei:body><tei:div corresp="urn:a"><tei:p>text</tei:p></tei:div></tei:body></tei:text>
+</tei:TEI>'''
+        end_path, include_tail = self._end_of(xml, "urn:a")
+        self.assertEqual(end_path, "/tei:TEI/tei:text/tei:body/tei:div")
+        self.assertFalse(include_tail)
+
+    def test_ends_at_preceding_sibling_of_next_milestone(self):
+        """A milestone scopes up to the element just before the next same-level one."""
+        xml = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text><tei:body><tei:div>
+        <tei:milestone unit="verse" corresp="urn:book/1/1"/> one
+        <tei:seg>segment</tei:seg> more
+        <tei:milestone unit="verse" corresp="urn:book/1/2"/> two
+    </tei:div></tei:body></tei:text>
+</tei:TEI>'''
+        end_path, include_tail = self._end_of(xml, "urn:book/1/1")
+        self.assertEqual(end_path, "/tei:TEI/tei:text/tei:body/tei:div/tei:seg")
+        self.assertTrue(include_tail)
+
+    def test_ends_at_the_element_whose_tail_is_the_last_text(self):
+        """The end is the preceding sibling itself, never a node nested inside it.
+
+        Ending at the deepest preceding element would drop the text between that
+        element's close and the next milestone -- here, ' more'.
+        """
+        xml = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text><tei:body><tei:div>
+        <tei:milestone unit="verse" corresp="urn:book/1/1"/> one
+        <tei:choice><tei:abbr>abbr</tei:abbr><tei:expan>expansion</tei:expan></tei:choice> more
+        <tei:milestone unit="verse" corresp="urn:book/1/2"/> two
+    </tei:div></tei:body></tei:text>
+</tei:TEI>'''
+        end_path, include_tail = self._end_of(xml, "urn:book/1/1")
+        self.assertEqual(end_path, "/tei:TEI/tei:text/tei:body/tei:div/tei:choice")
+        self.assertTrue(include_tail)
+
+    def test_next_milestone_in_another_parent_ends_at_that_parents_predecessor(self):
+        """When the next milestone opens a paragraph, the range ends with the previous one."""
+        xml = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text><tei:body><tei:div>
+        <tei:p><tei:milestone unit="verse" corresp="urn:book/1/1"/> one</tei:p>
+        <tei:p><tei:milestone unit="verse" corresp="urn:book/1/2"/> two</tei:p>
+        <tei:p><tei:milestone unit="verse" corresp="urn:book/1/3"/> three</tei:p>
+    </tei:div></tei:body></tei:text>
+</tei:TEI>'''
+        end_path, include_tail = self._end_of(xml, "urn:book/1/2")
+        self.assertEqual(end_path, "/tei:TEI/tei:text/tei:body/tei:div/tei:p[2]")
+        self.assertTrue(include_tail)
+
+    def test_higher_level_milestone_ends_the_range(self):
+        """A chapter milestone terminates a verse range."""
+        xml = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text><tei:body><tei:div>
+        <tei:milestone unit="verse" corresp="urn:book/1/1"/> one
+        <tei:seg>segment</tei:seg> more
+        <tei:milestone unit="chapter" corresp="urn:book/2"/> next chapter
+    </tei:div></tei:body></tei:text>
+</tei:TEI>'''
+        end_path, include_tail = self._end_of(xml, "urn:book/1/1")
+        self.assertEqual(end_path, "/tei:TEI/tei:text/tei:body/tei:div/tei:seg")
+        self.assertTrue(include_tail)
+
+    def test_no_following_milestone_ends_at_the_last_sibling(self):
+        """The last milestone in a file scopes to the end of its parent."""
+        xml = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <tei:text><tei:body><tei:div>
+        <tei:milestone unit="verse" corresp="urn:book/1/1"/> one
+        <tei:seg>segment</tei:seg>
+        <tei:p>last</tei:p>
+    </tei:div></tei:body></tei:text>
+</tei:TEI>'''
+        end_path, include_tail = self._end_of(xml, "urn:book/1/1")
+        self.assertEqual(end_path, "/tei:TEI/tei:text/tei:body/tei:div/tei:p")
+        self.assertTrue(include_tail)
 
 
 if __name__ == '__main__':

--- a/specs/COMPILER_SPECIFICATION.md
+++ b/specs/COMPILER_SPECIFICATION.md
@@ -43,7 +43,6 @@ _ProcessingContext = {
     before_start: bool,              # True if before start element in range
     after_end: bool,                 # True if after end element in range
     include_tail_after_end: bool,    # Include tail text after end element
-    exclusive_end: bool,              # End is exclusive (before milestone)
     inside_deepest_common_ancestor: bool,  # Inside DCA for external transclusions
     command: _ProcessingCommand      # Current processing command
 }
@@ -78,8 +77,14 @@ The `command` field determines how an element is processed:
 
 State machine tracks position relative to transclusion range:
 
-1. **Before Start**: `before_start=True`, `command=RECURSE` (skip content)
+1. **Before Start**: `before_start=True`, `command=RECURSE` (traverse, emit nothing)
    - When reaching deepest common ancestor: `inside_deepest_common_ancestor=True`, `command=COPY_ELEMENT_AND_RECURSE`
+   - Inside the DCA, an **ancestor of the start element**: `command=COPY_ELEMENT_AND_RECURSE`
+   - Inside the DCA, anything else: `command=RECURSE`. Skeleton copies exist only to
+     rebuild the structure the start element sits in; copying every element that merely
+     precedes the start leaves empty shells of them in the output (#51). `RECURSE` rather
+     than `SKIP` so that `j:declare` / `j:conditional` scopes opened before the range are
+     still evaluated.
    - When reaching start element: `before_start=False`, `command=COPY_AND_RECURSE`
 
 2. **Between Start and End**: `before_start=False`, `after_end=False`, `command=COPY_AND_RECURSE`
@@ -325,7 +330,12 @@ Elements are marked with their source file when processing context changes:
 When end URN is a milestone, the actual end is exclusive:
 
 - Find next milestone at same or higher level
-- If found: end before that milestone
+- If found: end at the nearest preceding sibling of that milestone, or -- when the
+  milestone is the first element in its parent -- the nearest preceding sibling of its
+  closest ancestor that has one. The end element is always the node whose *tail* is the
+  last text before the milestone, so `include_tail_after_end` picks that text up. Ending
+  at the deepest preceding element instead would land inside a subtree and drop the text
+  between that subtree's close and the milestone.
 - If not found: include all siblings up to last sibling
 
 ### Tail Text Handling
@@ -373,6 +383,10 @@ The compiled output:
     | Yes
     v
 [inside_deepest_common_ancestor=True, command=COPY_ELEMENT_AND_RECURSE]
+    |
+    | (inside the DCA: ancestors of the start element are copied as empty
+    |  skeletons; everything else before the start is traversed but not emitted)
+    |
     |
     | (continue traversal)
     |


### PR DESCRIPTION
Fixes #51.

## The bug

`ExternalCompilerProcessor._update_processing_context_before` copied **every** element inside the deepest common ancestor that preceded the start element as an empty skeleton (tag + attributes, no text). Skeleton copies (`COPY_ELEMENT_AND_RECURSE`) exist only to rebuild the ancestor chain the start element sits in.

For the humash that meant an empty `tei:milestone` for every verse before the range, each carrying a real `@corresp` — which prints a spurious `\vno{}`, adds a phantom `\pstart` in `align-verses` mode, and makes `@corresp`-based alignment ambiguous. The empty `tei:p` shells around them were strays too, which the issue didn't count.

It stayed hidden because `_get_deepest_common_ancestor` short-circuits to the start element itself when start and end are siblings, making `inside_deepest_common_ancestor` unreachable. Every project before the humash transcluded whole files or whole books, so every range hit that shortcut.

`RECURSE` rather than `SKIP` for the non-ancestor case: it emits nothing either way, but `RECURSE` keeps descending, so a `j:declare` or `j:conditional` scope opened before the range is still registered. There's a test pinning that.

## A second defect, exposed by the tests

The tests computed the end of a milestone range with their own copy of `_find_end_of_mapping` — duplicated in `test_external_compiler.py` and `test_inline_compiler.py` — which used `preceding-sibling::*[1]` where production used `preceding::*[1]`. On the tests' fixtures the sibling form returns a sibling of the start milestone, which trips the shortcut. That divergence is precisely what hid #51.

Deleting both copies and calling the production function made two existing tests fail on a *second* count: `preceding::*[1]` lands on the deepest preceding element, which can be nested inside a subtree, so the text between that subtree's close and the next milestone was silently dropped (`Verse 3 text part 2` vanished). Fixing it was a precondition for the test swap, so it's in this PR: the end of a range is now the nearest preceding sibling of the next milestone, walking up to an ancestor when the milestone is first in its parent, so the end element's tail is always the last text before the boundary.

`find_end_of_mapping` is now a module-level function in `refdb.py` with direct unit tests — its milestone branch previously had none.

## Verification

- 547 exporter tests pass. The 47 failures in the full suite are pre-existing on `main` (importer schema validation; needs `build-schema.sh`).
- Both new regression tests confirmed non-vacuous: reverting the state-machine branch fails the stray-milestone test, substituting `SKIP` for `RECURSE` fails the declaration test.
- Real data, Genesis 3:1-3:21 out of `miqra_al_pi_hamasorah` — before: 77 milestones, 56 strays (`genesis/1/1`, `1/2`, …); after: exactly 21, no strays, no duplicates, and the text matches the source word-for-word both ways.
- No regression to existing projects: rebuilt the reference database on both branches — identical key sets, 9,595 end paths move outward, all to equivalent or wider coverage — then compiled `heidenheim_haggadah_1822`, both examples, and the 2.9 MB `miqra_al_pi_hamasorah/the_law.xml` on each. Byte-identical.

The issue's own reproduction (`-p humash -f parashat_bereshit.xml`) can't be run here: the humash project isn't in `opensiddur-projects` on any branch yet. The checks above stand in for it, and the humash should be re-compiled against this branch before #6 lands.

## Out of scope

A `j:transclude` that precedes the start element is still compiled and emitted, because `_process_element` calls `_transclude`/`_annotate` before consulting `context['command']`. Pre-existing, unchanged here, filed as #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)