### PR TITLE
Anchor the Miqra nav/scaffold standOff notes (#46)

### DIFF
--- a/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
@@ -90,14 +90,30 @@
 
   <!-- Flatten each TSV row into nav markers + verse runs. -->
   <xsl:template match="miqra:row" mode="flatten">
-    <!-- Column C: only parashah markers structure paragraphs; // line breaks are cosmetic. -->
-    <xsl:apply-templates select="miqra:nav/miqra:parashah" mode="flatten"/>
+    <!-- Column C: only parashah markers structure paragraphs; // line breaks are cosmetic.
+         A break the source wrapped in {{נוסח}} — because another witness reads it
+         differently — is still MAM's own break and must reach the body. -->
+    <xsl:apply-templates
+        select="miqra:nav/(miqra:parashah | miqra:variant[miqra:display/miqra:parashah])"
+        mode="flatten"/>
     <!-- The row's own identity, bound before any grouping: inside xsl:for-each-group the
          context item is a member of the group, not the row. -->
     <xsl:variable name="chapter" select="string(@chapter)"/>
     <xsl:variable name="verse" select="string(@verse)"/>
     <xsl:variable name="fileName" select="string(ancestor::miqra:book/@fileName)"/>
+    <!-- The rest of the column C/D notes annotate the row — a break another witness has
+         but MAM does not, a seder marker, a free {{מ:הערה}} — rather than a point in the
+         verse, so they anchor at the head of the verse. Without this the standOff note
+         survives and its target does not resolve. -->
+    <xsl:variable name="row-anchors" as="element()*">
+      <xsl:for-each select="
+        (miqra:nav | miqra:scaffold)/miqra:variant[@noteId][not(miqra:display/miqra:parashah)]">
+        <miqra:anchor xml:id="{@noteId}-ref"/>
+      </xsl:for-each>
+      <xsl:copy-of select="(miqra:nav | miqra:scaffold)//miqra:anchor"/>
+    </xsl:variable>
     <xsl:variable name="text-nodes" as="node()*">
+      <xsl:sequence select="$row-anchors"/>
       <xsl:apply-templates select="miqra:text/node()" mode="hoist"/>
     </xsl:variable>
     <xsl:choose>
@@ -137,6 +153,15 @@
 
   <xsl:template match="miqra:parashah" mode="flatten">
     <xsl:copy-of select="."/>
+  </xsl:template>
+
+  <!-- The anchor follows the break so it becomes the first member of the new group, which
+       puts it at the head of the paragraph the break opens. -->
+  <xsl:template match="miqra:variant[miqra:display/miqra:parashah]" mode="flatten">
+    <xsl:copy-of select="miqra:display/miqra:parashah"/>
+    <xsl:if test="@noteId">
+      <miqra:anchor xml:id="{@noteId}-ref"/>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="miqra:lb" mode="flatten">
@@ -300,6 +325,14 @@
 
   <xsl:template match="miqra:anchor" mode="inline">
     <!-- Use tei:seg instead of tei:anchor because annotations get inserted as children. -->
+    <tei:seg>
+      <xsl:copy-of select="@xml:id"/>
+    </tei:seg>
+  </xsl:template>
+
+  <!-- An anchor lifted out of column C sits beside the parashah breaks, not inside a verse,
+       so it reaches mode="block"; without this rule the built-in one would discard it. -->
+  <xsl:template match="miqra:anchor" mode="block">
     <tei:seg>
       <xsl:copy-of select="@xml:id"/>
     </tei:seg>

--- a/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
+++ b/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
@@ -31,11 +31,17 @@ def _book(*rows: str) -> str:
     )
 
 
-def _row(verse: str, text: str, chapter: str = "20") -> str:
+def _row(
+    verse: str,
+    text: str,
+    chapter: str = "20",
+    nav: str = "",
+    scaffold: str = "",
+) -> str:
     return (
         f'<miqra:row source="s" pageKey="p" rowId="{verse}"'
         f' chapter="{chapter}" verse="{verse}">'
-        "<miqra:nav/><miqra:scaffold/>"
+        f"<miqra:nav>{nav}</miqra:nav><miqra:scaffold>{scaffold}</miqra:scaffold>"
         f"<miqra:text>{text}</miqra:text>"
         "</miqra:row>"
     )
@@ -66,6 +72,13 @@ def _verse_text(body: etree._Element, chapter: str, verse: str) -> str:
         if collecting and node.tail:
             collected.append(node.tail)
     return re.sub(r"\s+", " ", "".join(collected)).strip()
+
+
+def _anchor_ids(element: etree._Element) -> list[str]:
+    return [
+        seg.get(f"{{http://www.w3.org/XML/1998/namespace}}id")
+        for seg in element.findall(f".//{{{TEI_NS}}}seg")
+    ]
 
 
 class TestDualAccent(unittest.TestCase):
@@ -162,6 +175,105 @@ class TestMidVerseParashah(unittest.TestCase):
     def test_plain_verse_is_unaffected(self):
         body, _ = _transform(_row("14", "CCC"))
         self.assertEqual("CCC", _verse_text(body, "20", "14"))
+
+
+class TestNavAndScaffoldNotes(unittest.TestCase):
+    """Notes from columns C (nav) and D (scaffold) reach the standOff, so the anchors they
+    target have to exist in the body — the columns themselves are never rendered."""
+
+    def assertNoDanglingTargets(self, body, stand_off):
+        ids = set(body.xpath("//*/@xml:id"))
+        dangling = [
+            n.get("target")
+            for n in (stand_off if stand_off is not None else [])
+            if n.get("target", "").lstrip("#") not in ids
+        ]
+        self.assertEqual([], dangling)
+
+    def test_nav_variant_wrapping_a_break_keeps_the_break_and_anchors_the_note(self):
+        """{{נוסח}} around a parashah break records another witness's reading; the break is
+        still MAM's own, so it opens a paragraph and the note anchors at its head."""
+        nav = (
+            '<miqra:variant noteId="n1">'
+            '<miqra:display><miqra:parashah type="close"/></miqra:display>'
+            "</miqra:variant>"
+            '<miqra:note xml:id="n1">ל=פרשה פתוחה</miqra:note>'
+        )
+        body, stand_off = _transform(_row("1", "AAA"), _row("2", "BBB", nav=nav))
+        paragraphs = body.findall(f"{{{TEI_NS}}}div/{{{TEI_NS}}}p")
+        self.assertEqual(2, len(paragraphs))
+        self.assertEqual("closed-1", paragraphs[1].get("type"))
+        self.assertEqual(
+            "n1-ref",
+            paragraphs[1][0].get(f"{{http://www.w3.org/XML/1998/namespace}}id"),
+        )
+        self.assertNoDanglingTargets(body, stand_off)
+
+    def test_a_wrapped_break_structures_the_text_like_a_bare_one(self):
+        """Regression: the nav lift used to select miqra:nav/miqra:parashah only, so every
+        break the source wrapped in {{נוסח}} was dropped from the body."""
+        bare = '<miqra:parashah type="open"/>'
+        wrapped = (
+            '<miqra:variant noteId="n1">'
+            f"<miqra:display>{bare}</miqra:display>"
+            "</miqra:variant>"
+            '<miqra:note xml:id="n1">ל=פרשה סתומה</miqra:note>'
+        )
+        expected, _ = _transform(_row("1", "AAA"), _row("2", "BBB", nav=bare))
+        actual, _ = _transform(_row("1", "AAA"), _row("2", "BBB", nav=wrapped))
+        self.assertEqual(
+            [(p.tag, p.get("type")) for p in expected.iter(f"{{{TEI_NS}}}p")],
+            [(p.tag, p.get("type")) for p in actual.iter(f"{{{TEI_NS}}}p")],
+        )
+        self.assertEqual(_verse_text(expected, "20", "2"), _verse_text(actual, "20", "2"))
+
+    def test_nav_note_without_a_break_anchors_at_the_verse(self):
+        """MAM prints no break here — the note only reports that another witness has one —
+        so there is nothing in the body to anchor to but the verse itself."""
+        nav = (
+            '<miqra:variant noteId="n2"><miqra:display/></miqra:variant>'
+            '<miqra:note xml:id="n2">ל=פרשה סתומה</miqra:note>'
+        )
+        body, stand_off = _transform(_row("2", "BBB", nav=nav))
+        paragraphs = body.findall(f"{{{TEI_NS}}}div/{{{TEI_NS}}}p")
+        self.assertEqual(1, len(paragraphs))
+        self.assertIn("n2-ref", _anchor_ids(paragraphs[0]))
+        self.assertEqual("BBB", _verse_text(body, "20", "2"))
+        self.assertNoDanglingTargets(body, stand_off)
+
+    def test_scaffold_note_anchors_at_the_verse(self):
+        """Column D notes annotate the row's seder/aliyah marker, which is scaffolding for
+        the verse rather than a point inside it."""
+        scaffold = (
+            '<miqra:variant noteId="n3"><miqra:display/></miqra:variant>'
+            '<miqra:note xml:id="n3">תחילת סדר מצויינת כאן</miqra:note>'
+        )
+        body, stand_off = _transform(_row("2", "BBB", scaffold=scaffold))
+        self.assertIn("n3-ref", _anchor_ids(body))
+        self.assertEqual("BBB", _verse_text(body, "20", "2"))
+        self.assertNoDanglingTargets(body, stand_off)
+
+    def test_mam_note_anchor_in_nav_is_lifted(self):
+        """{{מ:הערה}} mints its own anchor next to the note; in column C that anchor was
+        discarded with the column."""
+        nav = (
+            '<miqra:anchor xml:id="n4-ref"/>'
+            '<miqra:note xml:id="n4">הערה</miqra:note>'
+        )
+        body, stand_off = _transform(_row("2", "BBB", nav=nav))
+        self.assertIn("n4-ref", _anchor_ids(body))
+        self.assertNoDanglingTargets(body, stand_off)
+
+    def test_column_c_text_is_still_not_rendered(self):
+        """Anchoring the notes must not leak the navigation column into the text."""
+        nav = (
+            "ניווט"
+            '<miqra:variant noteId="n5"><miqra:display/></miqra:variant>'
+            '<miqra:note xml:id="n5">הערה</miqra:note>'
+        )
+        body, _ = _transform(_row("2", "BBB", nav=nav))
+        self.assertEqual("BBB", _verse_text(body, "20", "2"))
+        self.assertNotIn("הערה", "".join(body.itertext()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #46.

183 of the 2659 `tei:note` elements in `miqra_al_pi_hamasorah` targeted an `xml:id` that existed nowhere in the body, so the reference database and the compiler could not resolve them.

The notes come from TSV columns C (`miqra:nav`) and D (`miqra:scaffold`). The standOff is built from `/miqra:book//miqra:note`, which reaches into both columns, but the body discards them, so the `-ref` anchor was never emitted.

This takes direction 2 from the issue — anchor the notes rather than drop them. Classifying all 183 gave two shapes with two natural anchor points:

| shape | count | anchor |
|---|---|---|
| `miqra:nav/miqra:variant[@noteId]` whose display holds a `miqra:parashah` | 86 | the parashah break |
| `miqra:nav/miqra:variant[@noteId]` with empty display | 72 | head of the row's verse |
| `miqra:scaffold/miqra:variant[@noteId]` with empty display | 21 | head of the row's verse |
| `miqra:nav//miqra:anchor` from `{{מ:הערה}}` | 4 | head of the row's verse |

### A second bug, fixed here too

The first group's break is MAM's own — the note only records that another witness reads it differently — and it was being **dropped from the body entirely**. The nav lift selected `miqra:nav/miqra:parashah`, which does not match `miqra:nav/miqra:variant/miqra:display/miqra:parashah`, so every parashah break the source wrapped in `{{נוסח}}` vanished. Genesis emitted 76 of its 90 nav breaks. Lifting the break is also what gives those 86 notes something to anchor to, so the two fixes are the same change.

### Changes

All in `miqra_to_tei.xslt`:

1. Widen the nav lift to `miqra:nav/(miqra:parashah | miqra:variant[miqra:display/miqra:parashah])`, with a template emitting the break followed by its anchor so the anchor heads the paragraph the break opens.
2. Build row-level anchors from the remaining nav/scaffold notes and prepend them to `$text-nodes`, so they sit inside `miqra:verse` and are rendered by the existing mode `inline` anchor rule.
3. Add a `miqra:anchor` rule in mode `block` — the anchors from (1) arrive beside the parashah breaks rather than inside a verse, and the built-in rule would discard them.

### Verification

Full suite passes. Five new tests in `TestNavAndScaffoldNotes` cover one case per row of the table plus a regression test that a wrapped break structures the text identically to a bare one; all five fail against the previous stylesheet.

Regenerating all 39 books (each validated against RelaxNG + Schematron on write):

- **0 dangling targets**, down from 183; note count still 2659.
- Verse milestone sequences unchanged; body letters unchanged — the only text delta is whitespace at new paragraph boundaries.
- New `tei:seg` count per book matches the issue's table exactly (genesis 19, numbers 32, psalms 41, …).
- Paragraph counts rise in the seven books with wrapped breaks (Genesis 78 → 92, Numbers 135 → 160) and are unchanged in psalms/ezekiel/proverbs, whose notes carried no break.

Regenerated project XML: opensiddur/opensiddur-projects#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
