### PR TITLE
Document the setup a fresh worktree needs before tests are meaningful

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,15 @@ Any specifications for agents to build code should be stored in the specs/ direc
 
 ## Commands
 
+**Set up a fresh checkout or worktree** — run both before trusting a test run:
+```bash
+uv sync --all-groups
+bash scripts/build-schema.sh
+```
+The compiled schema artifacts are gitignored, so a new worktree has none. Without them
+~47 validation tests fail in a way that looks like a real regression rather than missing
+setup.
+
 **Run code:**
 ```bash
 uv run python <script.py>
@@ -154,3 +163,5 @@ Contributor credits are **not** a `j:` element. They belong in the TEI header as
 - Write tests in `unittest` style.
 - Mock external calls (LLM APIs, file I/O where appropriate).
 - The CI runs `unittest discover`, but `uv run pytest` also works locally.
+- A pile of validation failures in a new worktree usually means the schema has not been
+  compiled yet — see the setup step at the top of Commands.


### PR DESCRIPTION
`schema/jlptei.odd.xml.relaxng` and friends are gitignored, so a new worktree starts without them and ~47 validation tests fail. The failures look like a real regression rather than missing setup — I lost time to exactly this while working on #46.

Adds the two setup commands as one step at the top of Commands, and a pointer from Testing Conventions, where someone staring at the failures is more likely to be looking.

Docs only; `uv run pytest` passes on this branch (after the documented setup, naturally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)