### PR TITLE
Emit the triennial haftarot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source's spelling of a parshah name to a canonical Hebrew name and a URN slug.
 - The humash emits the triennial haftarot: 150 readings over 51 parshiyot, each a headed
   alternative to the annual haftarah of its week rather than an addition to it.
-- `opensiddur:reading-cycle`, the feature structure by which a volume says it reads the
-  triennial cycle and which year of it. `opensiddur:torah-reading` gains `triennial-year`,
-  the cycle year of the declared date.
+- `opensiddur:reading-cycle`, the feature structure by which a volume says which haftarot it
+  carries: `annual`, and one binary per year of the triennial cycle, so that a volume may be
+  for one Shabbat or for a whole three-year cycle. `opensiddur:torah-reading` gains
+  `triennial-year`, the cycle year of the declared date.
 
 ### Fixed
 - `readings.triennial_haftarot` was read but never called, and dropped the 36 readings hebcal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Shared table of the 54 weekly parshiyot (`opensiddur/importer/util/parshiyot.py`), mapping any
   source's spelling of a parshah name to a canonical Hebrew name and a URN slug.
+- The humash emits the triennial haftarot: 150 readings over 51 parshiyot, each a headed
+  alternative to the annual haftarah of its week rather than an addition to it.
+- `opensiddur:reading-cycle`, the feature structure by which a volume says it reads the
+  triennial cycle and which year of it. `opensiddur:torah-reading` gains `triennial-year`,
+  the cycle year of the declared date.
 
 ### Fixed
+- `readings.triennial_haftarot` was read but never called, and dropped the 36 readings hebcal
+  records as a list of pieces. A piece lying inside one already listed is the verse the pairing
+  with the parshah turns on, and is no longer taken for a continuation of the reading.
+- `parse_hebcal_ref` no longer raises on a boundary stated inside a verse, such as the
+  Nachum 2:2b-2:3a of Emor's third year.
 - Miqra al pi ha-Masorah importer: the `{{מ:כפול}}` template, which carries a verse in both
   cantillations (ta'am elyon and ta'am tachton), was discarded by the stylesheet, emitting the
   Ten Commandments as empty verses in Exodus 20 and Deuteronomy 5. The two readings now become a

--- a/doc/humash-settings.example.yaml
+++ b/doc/humash-settings.example.yaml
@@ -58,6 +58,26 @@ declarations:
   #   month: 3
   #   day: 1
 
+  # Which cycle of readings this volume follows. Leaving it out reads annually, which is the
+  # one place the humash decides rather than keeping every variant: 51 parshiyot have a
+  # haftarah of their own for each year of the triennial cycle, and those are alternatives to
+  # the annual haftarah of the same Shabbat rather than additions to it, so a volume that kept
+  # them all would print four haftarot for one week.
+  #
+  # Set triennial true and declare a date to get that year's haftarah; or name the year here
+  # instead, for a volume that reads triennially but is not for one particular Shabbat. Either
+  # way the parshiyot with no triennial haftarah keep their annual one — Devarim, Vaetchanan
+  # and Vezot Haberakhah, which never have one; the pairs, which have none of their own; and
+  # Tazria, Achrei Mot and Behar in year 3, when they are read with their partner.
+  #
+  # The triennial *Torah* divisions do not go through this: they are markers over the annual
+  # text rather than a separate reading, so every year's are always present, marked with the
+  # cycle year in the margin.
+  #
+  # opensiddur:reading-cycle:
+  #   triennial: true
+  #   triennial-year: 2
+
 typography:
   hebrew_font: "Frank Ruehl CLM"
   latin_font: "Linux Libertine O"

--- a/doc/humash-settings.example.yaml
+++ b/doc/humash-settings.example.yaml
@@ -58,25 +58,35 @@ declarations:
   #   month: 3
   #   day: 1
 
-  # Which cycle of readings this volume follows. Leaving it out reads annually, which is the
-  # one place the humash decides rather than keeping every variant: 51 parshiyot have a
-  # haftarah of their own for each year of the triennial cycle, and those are alternatives to
-  # the annual haftarah of the same Shabbat rather than additions to it, so a volume that kept
-  # them all would print four haftarot for one week.
+  # Which haftarot this volume carries. Leaving the group out reads annually, which is the one
+  # place the humash decides rather than keeping every variant: 51 parshiyot have a haftarah of
+  # their own for each year of the triennial cycle, and those are alternatives to the annual
+  # haftarah of the same Shabbat rather than additions to it, so a volume that kept them all
+  # would print four haftarot for one week.
   #
-  # Set triennial true and declare a date to get that year's haftarah; or name the year here
-  # instead, for a volume that reads triennially but is not for one particular Shabbat. Either
-  # way the parshiyot with no triennial haftarah keep their annual one — Devarim, Vaetchanan
-  # and Vezot Haberakhah, which never have one; the pairs, which have none of their own; and
-  # Tazria, Achrei Mot and Behar in year 3, when they are read with their partner.
+  # For one Shabbat, set triennial true and declare a date above — that settles which of the
+  # three years is read, and drops the annual haftarah:
+  #
+  # opensiddur:reading-cycle:
+  #   triennial: true
+  #
+  # For a volume covering a whole three-year cycle, name the years instead. Each is its own
+  # setting, so any combination is possible; keep annual as well to print all four.
+  #
+  # opensiddur:reading-cycle:
+  #   annual: false
+  #   triennial-year-1: true
+  #   triennial-year-2: true
+  #   triennial-year-3: true
+  #
+  # Either way the parshiyot with no triennial haftarah keep their annual one — Devarim,
+  # Vaetchanan and Vezot Haberakhah, which never have one; the pairs, which have none of their
+  # own; and Tazria, Achrei Mot and Behar in year 3, when they are read with their partner. So
+  # no week is ever left without a haftarah, whichever years are chosen.
   #
   # The triennial *Torah* divisions do not go through this: they are markers over the annual
   # text rather than a separate reading, so every year's are always present, marked with the
   # cycle year in the margin.
-  #
-  # opensiddur:reading-cycle:
-  #   triennial: true
-  #   triennial-year: 2
 
 typography:
   hebrew_font: "Frank Ruehl CLM"

--- a/opensiddur/exporter/calendar/compute.py
+++ b/opensiddur/exporter/calendar/compute.py
@@ -116,21 +116,27 @@ TORAH_FEATURES = (
     "shabbat-nahamu",
 )
 
-# Which cycle of readings the volume follows.
+# Which readings the volume carries: the annual haftarah of each week, or the triennial one of
+# a given cycle year, or several at once. One binary per year rather than a single year number,
+# so that a volume for a whole three-year cycle can turn on all three — a printed humash is a
+# durable book, and covering a cycle is at least as natural as being for one Shabbat. Several
+# may be true together, the way several rites may be.
 #
-# Whether to read triennially is a choice a volume makes and not something a date settles:
-# every date falls in some year of the triennial cycle, including the dates an annual volume is
-# compiled for. So `triennial` is never derived and is false unless declared, and the year is
-# NO_TRIENNIAL_YEAR until a triennial volume names a date to take it from.
+# `triennial` is the volume's opt-in, and is what makes a date mean anything here: every date
+# falls in some year of the cycle, including the dates a volume that reads annually is compiled
+# for, so the date alone can never select a reading. It is never derived.
 #
-# Both need a value rather than staying undefined, unlike most features: the annual haftarah
-# and the three triennial ones are alternatives for one Shabbat, and an undefined condition
-# keeps its text, so leaving these open would print all four. See importer/humash/build.py.
-NO_TRIENNIAL_YEAR = 0
+# These take a value rather than staying undefined, unlike most features. The annual haftarah
+# and the three triennial ones are read on the same Shabbat, and an undefined condition keeps
+# its text, so leaving them open would print four haftarot for one week.
+TRIENNIAL_YEARS = (1, 2, 3)
+
+TRIENNIAL_YEAR_FEATURES = tuple(f"triennial-year-{year}" for year in TRIENNIAL_YEARS)
 
 READING_CYCLE_DEFAULTS: dict[str, Any] = {
+    "annual": True,
     "triennial": False,
-    "triennial-year": NO_TRIENNIAL_YEAR,
+    **dict.fromkeys(TRIENNIAL_YEAR_FEATURES, False),
 }
 
 SERVICE_TIME_FEATURES = (
@@ -681,16 +687,22 @@ def compute_service_time(snapshot: SettingSnapshot) -> dict[str, Any] | None:
 
 
 def compute_reading_cycle(snapshot: SettingSnapshot) -> dict[str, Any] | None:
-    """Which year of the triennial cycle the volume reads, once it has said it reads one.
+    """Turn a triennial volume's date into the one cycle year it reads.
 
-    The cycle year of the date is on ``opensiddur:torah-reading`` whatever cycle the volume
-    follows, so it cannot select a reading on its own; this is where the volume's choice and
-    the date meet. An annual volume keeps NO_TRIENNIAL_YEAR however its date falls.
+    This is where the volume's choice of cycle and its date meet: the cycle year of the date
+    sits on ``opensiddur:torah-reading`` whatever cycle the volume follows, so it cannot select
+    a reading by itself. A volume that reads annually is left alone however its date falls.
+
+    Only the volume compiled for a particular Shabbat is derived. One that turns the year
+    features on itself — a volume for a whole cycle, which turns on all three — says so
+    explicitly and is not overridden, since a declared value beats a derived one.
     """
-    if snapshot.get_bool(FS_READING_CYCLE, "triennial") is not True:
-        return {"triennial-year": NO_TRIENNIAL_YEAR}
-    year = snapshot.get_int(FS_TORAH, "triennial-year")
-    return {"triennial-year": NO_TRIENNIAL_YEAR if year is None else year}
+    triennial = snapshot.get_bool(FS_READING_CYCLE, "triennial") is True
+    year = snapshot.get_int(FS_TORAH, "triennial-year") if triennial else None
+    return {
+        "annual": year is None,
+        **{f"triennial-year-{n}": n == year for n in TRIENNIAL_YEARS},
+    }
 
 
 def compute_quorum(snapshot: SettingSnapshot) -> dict[str, Any] | None:

--- a/opensiddur/exporter/calendar/compute.py
+++ b/opensiddur/exporter/calendar/compute.py
@@ -27,6 +27,7 @@ FS_DAY_OF_WEEK = "opensiddur:day-of-week"
 FS_HOLIDAY = "opensiddur:holiday"
 FS_HOLIDAY_AGG = "opensiddur:holiday-aggregate"
 FS_TORAH = "opensiddur:torah-reading"
+FS_READING_CYCLE = "opensiddur:reading-cycle"
 FS_SERVICE_TIME = "opensiddur:service-time"
 FS_QUORUM = "opensiddur:quorum"
 FS_HOUSEHOLD = "opensiddur:household"
@@ -103,6 +104,7 @@ TRIENNIAL_PATTERN_FEATURES = tuple(
 TORAH_FEATURES = (
     "diaspora-parsha",
     "israel-parsha",
+    "triennial-year",
     *TRIENNIAL_PATTERN_FEATURES,
     "shabbat-shuva",
     "shabbat-shira",
@@ -113,6 +115,23 @@ TORAH_FEATURES = (
     "shabbat-hazon",
     "shabbat-nahamu",
 )
+
+# Which cycle of readings the volume follows.
+#
+# Whether to read triennially is a choice a volume makes and not something a date settles:
+# every date falls in some year of the triennial cycle, including the dates an annual volume is
+# compiled for. So `triennial` is never derived and is false unless declared, and the year is
+# NO_TRIENNIAL_YEAR until a triennial volume names a date to take it from.
+#
+# Both need a value rather than staying undefined, unlike most features: the annual haftarah
+# and the three triennial ones are alternatives for one Shabbat, and an undefined condition
+# keeps its text, so leaving these open would print all four. See importer/humash/build.py.
+NO_TRIENNIAL_YEAR = 0
+
+READING_CYCLE_DEFAULTS: dict[str, Any] = {
+    "triennial": False,
+    "triennial-year": NO_TRIENNIAL_YEAR,
+}
 
 SERVICE_TIME_FEATURES = (
     "shaharit",
@@ -571,6 +590,15 @@ def _parsha_slug(name: str) -> str:
     return name.lower().replace(" ", "-").replace(",", "")
 
 
+def _triennial_year(hebrew_year: int) -> int:
+    """Which of the three years of the modern triennial cycle a Hebrew year is (1, 2 or 3).
+
+    The reading year turns over at Simhat Torah rather than at Rosh Hashanah, but both fall in
+    Tishrei, so the Hebrew year identifies the cycle year for every Shabbat that has a reading.
+    """
+    return ((hebrew_year - _TRIENNIAL_EPOCH_YEAR) % 3) + 1
+
+
 def _triennial_cycle_patterns(hebrew_year: int, israel: bool) -> dict[str, str]:
     """For each pair, whether it was read [T]ogether or [S]eparately in each year of the cycle.
 
@@ -607,6 +635,7 @@ def compute_torah_reading(snapshot: SettingSnapshot) -> dict[str, Any] | None:
     result: dict[str, Any] = {
         "diaspora-parsha": _parsha_slug(diaspora),
         "israel-parsha": _parsha_slug(israel),
+        "triennial-year": _triennial_year(g.to_heb().year),
     }
     patterns = _triennial_cycle_patterns(
         g.to_heb().year, israel=not snapshot.is_diaspora()
@@ -649,6 +678,19 @@ def compute_service_time(snapshot: SettingSnapshot) -> dict[str, Any] | None:
         "neila": holidays.get("yom-kippur", 0) > 0 and aware_dt >= z.plag_hamincha.local,
         "slihot": z.alot_hashachar.local <= aware_dt < z.netz_hachama.local,
     }
+
+
+def compute_reading_cycle(snapshot: SettingSnapshot) -> dict[str, Any] | None:
+    """Which year of the triennial cycle the volume reads, once it has said it reads one.
+
+    The cycle year of the date is on ``opensiddur:torah-reading`` whatever cycle the volume
+    follows, so it cannot select a reading on its own; this is where the volume's choice and
+    the date meet. An annual volume keeps NO_TRIENNIAL_YEAR however its date falls.
+    """
+    if snapshot.get_bool(FS_READING_CYCLE, "triennial") is not True:
+        return {"triennial-year": NO_TRIENNIAL_YEAR}
+    year = snapshot.get_int(FS_TORAH, "triennial-year")
+    return {"triennial-year": NO_TRIENNIAL_YEAR if year is None else year}
 
 
 def compute_quorum(snapshot: SettingSnapshot) -> dict[str, Any] | None:

--- a/opensiddur/exporter/derivation_graph.py
+++ b/opensiddur/exporter/derivation_graph.py
@@ -15,6 +15,7 @@ from opensiddur.exporter.calendar.compute import (
     FS_ISRAEL,
     FS_LOCATION,
     FS_QUORUM,
+    FS_READING_CYCLE,
     FS_SERVICE_TIME,
     FS_TIME,
     FS_TORAH,
@@ -28,6 +29,7 @@ from opensiddur.exporter.calendar.compute import (
     compute_israel,
     compute_location,
     compute_quorum,
+    compute_reading_cycle,
     compute_service_time,
     compute_torah_reading,
 )
@@ -122,6 +124,12 @@ DERIVATION_SPECS: tuple[DerivationSpec, ...] = (
         fs_type=FS_SERVICE_TIME,
         required_inputs=_gregorian_inputs() | _location_inputs() | _time_inputs(),
         compute=compute_service_time,
+    ),
+    # After the Torah reading, whose cycle year it draws on when the volume reads triennially.
+    DerivationSpec(
+        fs_type=FS_READING_CYCLE,
+        required_inputs=frozenset({(FS_READING_CYCLE, "triennial"), (FS_TORAH, "triennial-year")}),
+        compute=compute_reading_cycle,
     ),
     DerivationSpec(
         fs_type=FS_QUORUM,

--- a/opensiddur/exporter/derived_settings.py
+++ b/opensiddur/exporter/derived_settings.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any
 
-from opensiddur.exporter.calendar.compute import SettingSnapshot
+from opensiddur.exporter.calendar.compute import (
+    FS_READING_CYCLE,
+    READING_CYCLE_DEFAULTS,
+    SettingSnapshot,
+)
 from opensiddur.exporter.conditional_settings import INIT_DECLARE_ID
 from opensiddur.exporter.derivation_graph import DerivationSpec, topological_derivation_order
 from opensiddur.exporter.linear import ConditionalSettingEntry, LinearData, Undefined
@@ -19,6 +23,15 @@ OVERRIDE_FEATURES = (
     "wedding",
     "sheva-brachot",
 )
+
+# Features that are never computed from anything and take a fixed value unless the volume
+# declares otherwise. An undeclared feature is normally *undefined*, which keeps every variant
+# of a conditional text; these are the ones that instead have to answer true or false, because
+# leaving them open would keep alternatives that contradict one another.
+STATIC_DEFAULTS: dict[str, dict[str, Any]] = {
+    FS_OVERRIDE: dict.fromkeys(OVERRIDE_FEATURES, False),
+    FS_READING_CYCLE: READING_CYCLE_DEFAULTS,
+}
 
 
 class SettingChangeTrigger(StrEnum):
@@ -88,23 +101,24 @@ def _collect_contributors(
     return contributors, True
 
 
-def _push_static_override_defaults(linear_data: LinearData) -> None:
-    for feature_name in OVERRIDE_FEATURES:
-        if get_active_setting_entry(linear_data, FS_OVERRIDE, feature_name) is not None:
-            continue
-        declare_id = derived_declare_id(FS_OVERRIDE, feature_name)
-        _remove_derived_for_feature(linear_data, FS_OVERRIDE, feature_name)
-        register_derived_entry(
-            linear_data,
-            ConditionalSettingEntry(
-                declare_id=declare_id,
-                fs_type=FS_OVERRIDE,
-                feature_name=feature_name,
-                value=False,
-                source="derived",
-                contributors={INIT_DECLARE_ID},
-            ),
-        )
+def _push_static_defaults(linear_data: LinearData) -> None:
+    for fs_type, features in STATIC_DEFAULTS.items():
+        for feature_name, value in features.items():
+            if get_active_setting_entry(linear_data, fs_type, feature_name) is not None:
+                continue
+            declare_id = derived_declare_id(fs_type, feature_name)
+            _remove_derived_for_feature(linear_data, fs_type, feature_name)
+            register_derived_entry(
+                linear_data,
+                ConditionalSettingEntry(
+                    declare_id=declare_id,
+                    fs_type=fs_type,
+                    feature_name=feature_name,
+                    value=value,
+                    source="derived",
+                    contributors={INIT_DECLARE_ID},
+                ),
+            )
 
 
 def _apply_derivation_spec(
@@ -171,7 +185,7 @@ def recalculate_derived_settings(
     del declare_id  # reserved for incremental invalidation in future
 
     if trigger == SettingChangeTrigger.INIT:
-        _push_static_override_defaults(linear_data)
+        _push_static_defaults(linear_data)
 
     snapshot = SettingSnapshot(
         get_setting=lambda fs_type, feature_name: _get_setting_from_linear_data(

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -190,6 +190,10 @@ def _transclude(target: str) -> str:
     return f'<j:transclude type="external" target="{target}"/>'
 
 
+def _instruction(text: str) -> str:
+    return f'<tei:note type="instruction" xml:lang="he">{_escape(text)}</tei:note>'
+
+
 _CONDITION_INDEX = {"value": 0}
 
 
@@ -231,6 +235,26 @@ def _pattern_conditional(pair_slug: str, patterns: list[str], content: str) -> s
         f'<j:conditional xml:id="{identifier}"><j:any>{alternatives}</j:any></j:conditional>'
         f"{content}"
         f'<j:endConditional target="#{identifier}"/>'
+    )
+
+
+# Which year of the triennial cycle the volume reads. It answers zero unless the volume both
+# declares the triennial cycle and settles a year — normally by declaring a date, since the
+# cycle year of a date alone cannot select a reading: an annual volume's date has one too. See
+# exporter/calendar/compute.py.
+CYCLE_FS = "opensiddur:reading-cycle"
+TRIENNIAL_YEAR_FEATURE = "triennial-year"
+
+
+def _triennial_year_condition(year: int) -> str:
+    """The test for a volume reading year `year` of the triennial cycle.
+
+    One feature and not two, so that the answer is decisive: ``j:all`` over a false test and an
+    undefined one is undefined, which would keep the reading rather than drop it.
+    """
+    return (
+        f'<tei:fs type="{CYCLE_FS}"><tei:f name="{TRIENNIAL_YEAR_FEATURE}">'
+        f'<tei:numeric value="{year}"/></tei:f></tei:fs>'
     )
 
 
@@ -278,9 +302,7 @@ def _segment_xml(
             if condition is not None else marker
         )
     if segment.duplicate:
-        parts.append(
-            f'<tei:note type="instruction" xml:lang="he">{_escape("חוזרים על הפסוק")}</tei:note>'
-        )
+        parts.append(_instruction("חוזרים על הפסוק"))
     parts.append(_transclude(segment.start.range_urn(segment.end)))
     return "".join(parts)
 
@@ -444,44 +466,104 @@ def pair_file(
     )
 
 
+# hebcal states a few boundaries inside a verse — Emor's third year names Nachum 2:2b-2:3a —
+# and a URN reaches no further than a whole verse. Every such reference in the data today is on
+# an anchor verse that readings.triennial_haftarot drops, so nothing emits these yet; they are
+# here because the alternative, if hebcal moves one into a span that is read, is to silently
+# read half a verse too much.
+HALF_VERSE_START_INSTRUCTION = "מתחילים מאמצע הפסוק"
+HALF_VERSE_END_INSTRUCTION = "מסיימים באמצע הפסוק"
+
+
 def _passage_xml(passage: Passage, urn_base: str) -> str:
     """A haftarah or megillah: its spans in order, then any repeated closing verse."""
     parts: list[str] = []
     for span in passage.spans:
+        if span.start_half == "b":
+            parts.append(_instruction(HALF_VERSE_START_INSTRUCTION))
         parts.append(_transclude(span.start.range_urn(span.end)))
+        if span.end_half == "a":
+            parts.append(_instruction(HALF_VERSE_END_INSTRUCTION))
     if passage.repeated is not None:
-        parts.append(
-            f'<tei:note type="instruction" xml:lang="he">'
-            f"{_escape(REPEATED_VERSE_INSTRUCTION)}</tei:note>"
-        )
+        parts.append(_instruction(REPEATED_VERSE_INSTRUCTION))
         parts.append(_transclude(
             passage.repeated.start.range_urn(passage.repeated.end)
         ))
     return "".join(parts)
 
 
-def haftarah_file(slug: str, passages: list[Passage]) -> tuple[str, str]:
-    """The haftarah of one parshah, with a division per rite where the rites differ."""
+# The heading over a triennial haftarah. Unlike the triennial Torah divisions, which are
+# markers in the margin of the annual text, these are whole alternative readings.
+TRIENNIAL_HAFTARAH_TITLE = "מַחֲזוֹר תְּלַת־שְׁנָתִי, שָׁנָה {year}"
+
+
+def haftarah_file(
+    slug: str,
+    passages: list[Passage],
+    triennial_passages: dict[int, Passage] | None = None,
+) -> tuple[str, str]:
+    """The haftarah of one parshah: the annual reading, and the triennial ones as alternatives.
+
+    The annual haftarah has a division per rite where the rites differ. The triennial readings
+    have none — hebcal records a single reading per cycle year — so each is one headed division
+    conditioned on the volume reading that year of the cycle.
+
+    The four are alternatives for the same Shabbat, so the annual one is dropped exactly when a
+    triennial one takes its place: the test is ``j:none`` over the years actually recorded for
+    this parshah. Tazria, Achrei Mot and Behar have years 1 and 2 only, being read alone only
+    in those years, and in year 3 of a triennial cycle they keep the annual haftarah; a parshah
+    with no triennial reading at all keeps it unconditionally, as do the pairs, which have no
+    triennial haftarah of their own.
+
+    This is the one place the humash decides rather than keeping every variant. A volume that
+    declares no cycle year gets the annual reading, not all four: they are the same Shabbat's,
+    and a volume printing four haftarot for one week would be wrong however it was headed.
+    """
     urn_base = f"{URN_PREFIX}:haftarah/{slug}"
     hebrew = SLUG_TO_HEBREW.get(slug, slug)
     title = f"הַפְטָרַת {hebrew}"
 
-    inner: list[str] = []
+    annual: list[str] = []
     for passage in passages:
         content = _passage_xml(passage, urn_base)
         if passage.rite is None:
-            inner.append(content)
+            annual.append(content)
             continue
         variant = (
             f'<tei:div corresp="{urn_base}/{passage.rite}" n="{passage.rite}">'
             f"<tei:head>{_escape(passage.title or passage.rite)}</tei:head>"
             f"{content}</tei:div>"
         )
-        inner.append(_conditional("opensiddur:rite", passage.rite, variant, "rite"))
+        annual.append(_conditional("opensiddur:rite", passage.rite, variant, "rite"))
+
+    years = sorted(triennial_passages or {})
+    inner = "".join(annual)
+    if years:
+        identifier = _condition_id("annual_haftarah")
+        alternatives = "".join(_triennial_year_condition(year) for year in years)
+        inner = (
+            f'<j:conditional xml:id="{identifier}"><j:none>{alternatives}</j:none>'
+            f"</j:conditional>{inner}"
+            f'<j:endConditional target="#{identifier}"/>'
+        )
+    for year in years:
+        identifier = _condition_id("triennial_haftarah")
+        year_title = TRIENNIAL_HAFTARAH_TITLE.format(year=TRIENNIAL_YEARS.get(year, year))
+        division = (
+            f'<tei:div corresp="{urn_base}/triennial/{year}" n="triennial_{year}">'
+            f"<tei:head>{_escape(year_title)}</tei:head>"
+            f"{_passage_xml(triennial_passages[year], urn_base)}</tei:div>"
+        )
+        inner += (
+            f'<j:conditional xml:id="{identifier}">'
+            f"{_triennial_year_condition(year)}</j:conditional>"
+            f"{division}"
+            f'<j:endConditional target="#{identifier}"/>'
+        )
 
     body = (
         f'<tei:div corresp="{urn_base}" n="haftarah_{slug}">'
-        f"<tei:head>{_escape(title)}</tei:head>{''.join(inner)}</tei:div>"
+        f"<tei:head>{_escape(title)}</tei:head>{inner}</tei:div>"
     )
     header = _header(title, f"Haftarah for {slug.replace('_', ' ').title()}", f"haftarah/{slug}")
     return f"haftarat_{slug}", _document(header, body)
@@ -497,10 +579,7 @@ def megillah_file(book: str, hebrew: str, holiday: str) -> tuple[str, str]:
     if repeat is not None:
         chapter, verse = repeat
         ref = VerseRef(book, chapter, verse)
-        parts.append(
-            f'<tei:note type="instruction" xml:lang="he">'
-            f"{_escape(REPEATED_VERSE_INSTRUCTION)}</tei:note>"
-        )
+        parts.append(_instruction(REPEATED_VERSE_INSTRUCTION))
         parts.append(_transclude(ref.range_urn(ref)))
 
     content = (
@@ -638,6 +717,7 @@ def build(
 
     parshiyot, pairs = parse_readings(sourcetexts_root)
     all_haftarot = haftarot(sourcetexts_root)
+    all_triennial_haftarot = triennial_haftarot(sourcetexts_root)
     all_triennial = triennial(sourcetexts_root)
     all_patterns = triennial_patterns(sourcetexts_root)
     festivals = festival_readings(sourcetexts_root)
@@ -665,8 +745,19 @@ def build(
 
     extra_urns: list[str] = []
     for slug, passages in sorted(all_haftarot.items()):
-        documents.append(haftarah_file(slug, passages))
+        documents.append(
+            haftarah_file(slug, passages, all_triennial_haftarot.get(slug, {}))
+        )
         extra_urns.append(f"{URN_PREFIX}:haftarah/{slug}")
+
+    unplaced = sorted(set(all_triennial_haftarot) - set(all_haftarot))
+    if unplaced:
+        # Nothing to hang them off: a parshah with a triennial haftarah but no annual one would
+        # have no file of its own, so say so rather than dropping it silently.
+        logger.warning(
+            "No haftarah file for %s, so their triennial haftarot were not emitted",
+            ", ".join(unplaced),
+        )
     for book, hebrew, holiday in MEGILLOT:
         documents.append(megillah_file(book, hebrew, holiday))
         extra_urns.append(f"{URN_PREFIX}:megillah/{book}")

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -238,24 +238,29 @@ def _pattern_conditional(pair_slug: str, patterns: list[str], content: str) -> s
     )
 
 
-# Which year of the triennial cycle the volume reads. It answers zero unless the volume both
-# declares the triennial cycle and settles a year — normally by declaring a date, since the
-# cycle year of a date alone cannot select a reading: an annual volume's date has one too. See
-# exporter/calendar/compute.py.
+# Which readings the volume carries: `annual`, and one feature per year of the triennial cycle.
+# All are false by default but `annual`, and several may be true at once, so one volume may be
+# for a single Shabbat and another for a whole cycle. See exporter/calendar/compute.py.
 CYCLE_FS = "opensiddur:reading-cycle"
-TRIENNIAL_YEAR_FEATURE = "triennial-year"
+ANNUAL_FEATURE = "annual"
+CYCLE_YEARS = tuple(TRIENNIAL_YEARS)
 
 
-def _triennial_year_condition(year: int) -> str:
-    """The test for a volume reading year `year` of the triennial cycle.
+def _cycle_condition(feature: str) -> str:
+    """The test for one reading-cycle feature being true.
 
-    One feature and not two, so that the answer is decisive: ``j:all`` over a false test and an
-    undefined one is undefined, which would keep the reading rather than drop it.
+    Always a single feature, so that the answer is decisive. ``j:all`` over a false test and an
+    undefined one is undefined per the truth tables, and undefined keeps the text it guards —
+    which for readings that are alternatives to one another would print several at once.
     """
     return (
-        f'<tei:fs type="{CYCLE_FS}"><tei:f name="{TRIENNIAL_YEAR_FEATURE}">'
-        f'<tei:numeric value="{year}"/></tei:f></tei:fs>'
+        f'<tei:fs type="{CYCLE_FS}"><tei:f name="{feature}">'
+        f'<tei:binary value="true"/></tei:f></tei:fs>'
     )
+
+
+def _triennial_year_feature(year: int) -> str:
+    return f"triennial-year-{year}"
 
 
 def _default_numbering_conditional(content: str) -> str:
@@ -508,16 +513,15 @@ def haftarah_file(
     have none — hebcal records a single reading per cycle year — so each is one headed division
     conditioned on the volume reading that year of the cycle.
 
-    The four are alternatives for the same Shabbat, so the annual one is dropped exactly when a
-    triennial one takes its place: the test is ``j:none`` over the years actually recorded for
-    this parshah. Tazria, Achrei Mot and Behar have years 1 and 2 only, being read alone only
-    in those years, and in year 3 of a triennial cycle they keep the annual haftarah; a parshah
-    with no triennial reading at all keeps it unconditionally, as do the pairs, which have no
-    triennial haftarah of their own.
+    They are alternatives for the same Shabbat, so the annual reading is kept when the volume
+    asks for it and also whenever the volume's cycle year has nothing to put in its place.
+    Tazria, Achrei Mot and Behar are read alone only in years 1 and 2 and so have no reading
+    for year 3; a parshah with no triennial reading at all is unconditional, as are the pairs,
+    which have no triennial haftarah of their own.
 
     This is the one place the humash decides rather than keeping every variant. A volume that
-    declares no cycle year gets the annual reading, not all four: they are the same Shabbat's,
-    and a volume printing four haftarot for one week would be wrong however it was headed.
+    asks for nothing gets the annual reading, not all four: they belong to one week, and
+    printing four haftarot for it would be wrong however they were headed.
     """
     urn_base = f"{URN_PREFIX}:haftarah/{slug}"
     hebrew = SLUG_TO_HEBREW.get(slug, slug)
@@ -539,10 +543,16 @@ def haftarah_file(
     years = sorted(triennial_passages or {})
     inner = "".join(annual)
     if years:
+        # The annual reading also stands in for the cycle years this parshah has none of, so a
+        # triennial volume is never left with no haftarah at all for the week.
+        missing = [year for year in CYCLE_YEARS if year not in years]
         identifier = _condition_id("annual_haftarah")
-        alternatives = "".join(_triennial_year_condition(year) for year in years)
+        alternatives = "".join(
+            _cycle_condition(feature) for feature in
+            [ANNUAL_FEATURE, *(_triennial_year_feature(year) for year in missing)]
+        )
         inner = (
-            f'<j:conditional xml:id="{identifier}"><j:none>{alternatives}</j:none>'
+            f'<j:conditional xml:id="{identifier}"><j:any>{alternatives}</j:any>'
             f"</j:conditional>{inner}"
             f'<j:endConditional target="#{identifier}"/>'
         )
@@ -556,7 +566,7 @@ def haftarah_file(
         )
         inner += (
             f'<j:conditional xml:id="{identifier}">'
-            f"{_triennial_year_condition(year)}</j:conditional>"
+            f"{_cycle_condition(_triennial_year_feature(year))}</j:conditional>"
             f"{division}"
             f'<j:endConditional target="#{identifier}"/>'
         )

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import functools
 import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -29,9 +30,12 @@ from opensiddur.importer.humash.refs import (
     triennial_unit,
     ReadingSpan,
     VerseRef,
+    hebcal_ref_half,
     parse_hebcal_ref,
 )
 from opensiddur.importer.util.pages import hebcal_leyning_data_directory
+
+logger = logging.getLogger(__name__)
 
 # The rites hebcal distinguishes. "haft" is what it gives without qualification, which is the
 # Ashkenazi reading; "seph" is the Sephardi one. Other rites are not in this data.
@@ -103,8 +107,39 @@ def _haftarah_spans(raw, unit: str = "haftarah") -> list[ReadingSpan]:
             end=parse_hebcal_ref(book, part["e"]),
             note=part.get("note"),
             numbering=NUMBERING_COMMON,
+            start_half=hebcal_ref_half(part["b"]),
+            end_half=hebcal_ref_half(part["e"]),
         ))
     return spans
+
+
+def _without_anchor_verses(key: str, spans: list[ReadingSpan]) -> list[ReadingSpan]:
+    """The spans actually read, dropping any that an earlier span already covers.
+
+    Eight of the triennial haftarot end with a piece inside one already listed — Nasso
+    year 1 is Joshua 6:5-14 and then 6:12, Emor year 3 is Nachum 2:1-3 and then 2:2b-3a. That
+    is the verse the pairing with the parshah turns on, recorded beside the reading rather than
+    appended to it: taking it as a continuation would read those verses a second time.
+
+    A piece that merely runs backwards is left alone. The haftarot really do that — Mishpatim
+    reads Jeremiah 34:12-22 and then 33:25-26 — and only containment marks an anchor.
+    """
+    kept: list[ReadingSpan] = []
+    for span in spans:
+        anchor = any(
+            earlier.book == span.book
+            and earlier.start <= span.start
+            and span.end <= earlier.end
+            for earlier in kept
+        )
+        if anchor:
+            logger.debug(
+                "%s: %s-%s lies inside an earlier span, so it is the verse the pairing turns "
+                "on rather than part of the reading", key, span.start, span.end,
+            )
+            continue
+        kept.append(span)
+    return kept
 
 
 def _repeated_span(key: str, spans: list[ReadingSpan]) -> ReadingSpan | None:
@@ -301,7 +336,23 @@ def triennial_patterns(sourcetexts_root: Path | None = None) -> dict[str, dict[s
 
 
 def triennial_haftarot(sourcetexts_root: Path | None = None) -> dict[str, dict[int, Passage]]:
-    """The triennial haftarah of each parshah, by slug then cycle year."""
+    """The triennial haftarah of each parshah, by slug then cycle year.
+
+    These are alternatives to the annual haftarah, not additions to it, and unlike the Torah
+    divisions they are keyed by plain cycle year: the reading follows the year alone, so none
+    of the variation machinery of ``triennial`` applies.
+
+    Coverage is not uniform, and the caller has to allow for it.
+
+    * Only 51 parshiyot have any. Devarim and Vaetchanan always fall on Shabbat Hazon and
+      Shabbat Nahamu, whose haftarot are fixed, and Vezot Haberakhah is read on Simhat Torah;
+      those three keep their annual haftarah in every year.
+    * Tazria, Achrei Mot and Behar carry years 1 and 2 only, being read alone only in those
+      years, and the pairs have no triennial haftarah of their own — so on a year a pair is
+      read together the annual haftarah of that week stands.
+    * ``Tish'a B'Av`` is in the file but is not a parshah, and is dropped here with everything
+      else the parshah table does not name.
+    """
     data = _load("triennial-haft.json", sourcetexts_root)
     result: dict[str, dict[int, Passage]] = {}
     for name, entry in data.items():
@@ -310,12 +361,18 @@ def triennial_haftarot(sourcetexts_root: Path | None = None) -> dict[str, dict[i
             continue
         years: dict[int, Passage] = {}
         for year_key, value in entry.items():
-            if not year_key.isdigit() or not isinstance(value, dict) or "k" not in value:
+            # A year is one reading object, or a list of them where the reading is
+            # discontinuous — Toldot's third year is Judges 3:15-27 and then 3:30. The
+            # mnemonic hebcal notes against each piece rides along on the span.
+            parts = value if isinstance(value, list) else [value]
+            if not year_key.isdigit() or not parts or not all(
+                isinstance(part, dict) and "k" in part for part in parts
+            ):
                 continue
+            passage_key = f"{name}:triennial:{year_key}"
             years[int(year_key)] = Passage(
-                key=f"{name}:triennial:{year_key}",
-                spans=_haftarah_spans(value),
-                note=value.get("note"),
+                key=passage_key,
+                spans=_without_anchor_verses(passage_key, _haftarah_spans(value)),
             )
         if years:
             result[slug] = years

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import functools
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -200,6 +201,12 @@ class ReadingSpan:
     # for the two parshiyot of a pair, which share a file but keep their own URN spaces:
     # without it their identically numbered aliyot would both be .../vayakhel_pekudei/1.
     owner: str | None = None
+    # Where the span really begins or ends, when that is inside a verse rather than at its
+    # edge: "b" on `start_half` means it begins at the second half of `start`, and "a" on
+    # `end_half` that it ends at the first half of `end`. The whole verse is transcluded either
+    # way — a URN addresses no less than a verse — and the reading says where to stop.
+    start_half: str | None = None
+    end_half: str | None = None
 
     @property
     def book(self) -> str:
@@ -277,7 +284,27 @@ def previous_verse(
     )
 
 
+# hebcal writes a boundary that falls inside a verse as a letter after the verse number: the
+# triennial haftarah of Emor in year 3 runs from Nachum 2:2b to 2:3a, the second half of one
+# verse to the first half of the next. Three references in the data are of this form.
+_HEBCAL_REF = re.compile(r"\s*(\d+)\s*:\s*(\d+)\s*([ab]?)\s*\Z")
+
+
 def parse_hebcal_ref(book: str, spec: str) -> VerseRef:
-    """Parse hebcal's ``"chapter:verse"`` form against an opensiddur book slug."""
-    chapter, _, verse = spec.partition(":")
-    return VerseRef(book, int(chapter), int(verse))
+    """Parse hebcal's ``"chapter:verse"`` form against an opensiddur book slug.
+
+    A half-verse marker is read as the whole verse containing it, since a URN addresses whole
+    verses; ``hebcal_ref_half`` recovers which half was meant so the reading can say so.
+    """
+    match = _HEBCAL_REF.match(spec)
+    if match is None:
+        raise ValueError(f"Unparseable hebcal reference {spec!r} in {book}")
+    return VerseRef(book, int(match.group(1)), int(match.group(2)))
+
+
+def hebcal_ref_half(spec: str) -> str | None:
+    """Which half of the verse a reference names — ``"a"``, ``"b"``, or None for the whole."""
+    match = _HEBCAL_REF.match(spec)
+    if match is None:
+        raise ValueError(f"Unparseable hebcal reference {spec!r}")
+    return match.group(3) or None

--- a/opensiddur/tests/exporter/test_derived_settings.py
+++ b/opensiddur/tests/exporter/test_derived_settings.py
@@ -75,6 +75,84 @@ class TestDerivedSettingsFramework(unittest.TestCase):
         self.assertTrue(entry.value)
         self.assertEqual(entry.source, "init")
 
+    def test_reading_cycle_defaults_to_annual(self):
+        """A volume reads annually unless it says otherwise, so no triennial year is selected.
+
+        These cannot be left undefined the way opensiddur:rite is: the annual haftarah and the
+        three triennial ones are alternatives for the same Shabbat, and an undefined condition
+        keeps its text, so an open feature here would print all four.
+        """
+        recalculate_derived_settings(self.linear_data, trigger=SettingChangeTrigger.INIT)
+        cycle = "opensiddur:reading-cycle"
+        self.assertFalse(get_active_setting_entry(self.linear_data, cycle, "triennial").value)
+        self.assertEqual(
+            get_active_setting_entry(self.linear_data, cycle, "triennial-year").value, 0
+        )
+
+    def test_a_date_alone_selects_no_triennial_year(self):
+        """Every date falls in some year of the cycle, including an annual volume's."""
+        CompilerProcessor.load_init_settings(
+            self.linear_data,
+            yaml_to_declaration_entries({
+                "opensiddur:gregorian-date": {"year": 2026, "month": 1, "day": 3},
+            }),
+        )
+        self.assertEqual(
+            get_active_setting_entry(
+                self.linear_data, "opensiddur:reading-cycle", "triennial-year"
+            ).value,
+            0,
+        )
+
+    def test_a_triennial_volume_takes_its_year_from_the_date(self):
+        CompilerProcessor.load_init_settings(
+            self.linear_data,
+            yaml_to_declaration_entries({
+                "opensiddur:gregorian-date": {"year": 2028, "month": 1, "day": 8},
+                "opensiddur:reading-cycle": {"triennial": True},
+            }),
+        )
+        self.assertEqual(
+            get_active_setting_entry(
+                self.linear_data, "opensiddur:reading-cycle", "triennial-year"
+            ).value,
+            3,
+        )
+
+    def test_a_declared_year_wins_over_the_date(self):
+        """A volume may name the cycle year without compiling for one particular Shabbat."""
+        CompilerProcessor.load_init_settings(
+            self.linear_data,
+            yaml_to_declaration_entries({
+                "opensiddur:gregorian-date": {"year": 2026, "month": 1, "day": 3},
+                "opensiddur:reading-cycle": {"triennial": True, "triennial-year": 2},
+            }),
+        )
+        entry = get_active_setting_entry(
+            self.linear_data, "opensiddur:reading-cycle", "triennial-year"
+        )
+        self.assertEqual(entry.value, 2)
+
+    def test_triennial_year_is_derived_from_the_date(self):
+        """The cycle is counted from 5756, so 5786 opens one and 5788 closes it."""
+        for gregorian, expected in (((2026, 1, 3), 1), ((2028, 1, 8), 3)):
+            with self.subTest(date=gregorian):
+                reset_linear_data()
+                linear_data = get_linear_data()
+                year, month, day = gregorian
+                CompilerProcessor.load_init_settings(
+                    linear_data,
+                    yaml_to_declaration_entries({
+                        "opensiddur:gregorian-date": {
+                            "year": year, "month": month, "day": day
+                        },
+                    }),
+                )
+                entry = get_active_setting_entry(
+                    linear_data, "opensiddur:torah-reading", "triennial-year"
+                )
+                self.assertEqual(entry.value, expected)
+
     def test_secular_day_from_gregorian_init(self):
         CompilerProcessor.load_init_settings(
             self.linear_data,

--- a/opensiddur/tests/exporter/test_derived_settings.py
+++ b/opensiddur/tests/exporter/test_derived_settings.py
@@ -75,19 +75,29 @@ class TestDerivedSettingsFramework(unittest.TestCase):
         self.assertTrue(entry.value)
         self.assertEqual(entry.source, "init")
 
-    def test_reading_cycle_defaults_to_annual(self):
-        """A volume reads annually unless it says otherwise, so no triennial year is selected.
+    CYCLE = "opensiddur:reading-cycle"
 
-        These cannot be left undefined the way opensiddur:rite is: the annual haftarah and the
-        three triennial ones are alternatives for the same Shabbat, and an undefined condition
-        keeps its text, so an open feature here would print all four.
+    def _cycle(self) -> dict[str, object]:
+        """Which readings the volume carries, as a plain dict."""
+        return {
+            feature: get_active_setting_entry(self.linear_data, self.CYCLE, feature).value
+            for feature in
+            ("annual", "triennial-year-1", "triennial-year-2", "triennial-year-3")
+        }
+
+    def test_reading_cycle_defaults_to_the_annual_reading_alone(self):
+        """These cannot be left undefined the way opensiddur:rite is.
+
+        The annual haftarah and the three triennial ones are read on the same Shabbat, and an
+        undefined condition keeps its text, so an open feature here would print all four.
         """
         recalculate_derived_settings(self.linear_data, trigger=SettingChangeTrigger.INIT)
-        cycle = "opensiddur:reading-cycle"
-        self.assertFalse(get_active_setting_entry(self.linear_data, cycle, "triennial").value)
-        self.assertEqual(
-            get_active_setting_entry(self.linear_data, cycle, "triennial-year").value, 0
-        )
+        self.assertEqual(self._cycle(), {
+            "annual": True,
+            "triennial-year-1": False,
+            "triennial-year-2": False,
+            "triennial-year-3": False,
+        })
 
     def test_a_date_alone_selects_no_triennial_year(self):
         """Every date falls in some year of the cycle, including an annual volume's."""
@@ -97,14 +107,11 @@ class TestDerivedSettingsFramework(unittest.TestCase):
                 "opensiddur:gregorian-date": {"year": 2026, "month": 1, "day": 3},
             }),
         )
-        self.assertEqual(
-            get_active_setting_entry(
-                self.linear_data, "opensiddur:reading-cycle", "triennial-year"
-            ).value,
-            0,
-        )
+        self.assertEqual(self._cycle()["annual"], True)
+        self.assertEqual(self._cycle()["triennial-year-1"], False)
 
     def test_a_triennial_volume_takes_its_year_from_the_date(self):
+        """5788 is the third year of the cycle, and the annual reading gives way to it."""
         CompilerProcessor.load_init_settings(
             self.linear_data,
             yaml_to_declaration_entries({
@@ -112,26 +119,42 @@ class TestDerivedSettingsFramework(unittest.TestCase):
                 "opensiddur:reading-cycle": {"triennial": True},
             }),
         )
-        self.assertEqual(
-            get_active_setting_entry(
-                self.linear_data, "opensiddur:reading-cycle", "triennial-year"
-            ).value,
-            3,
+        self.assertEqual(self._cycle(), {
+            "annual": False,
+            "triennial-year-1": False,
+            "triennial-year-2": False,
+            "triennial-year-3": True,
+        })
+
+    def test_a_volume_for_a_whole_cycle_keeps_all_three_years(self):
+        """A printed humash covering a cycle turns on every year; a date would allow only one."""
+        CompilerProcessor.load_init_settings(
+            self.linear_data,
+            yaml_to_declaration_entries({
+                "opensiddur:reading-cycle": {
+                    "annual": False,
+                    "triennial-year-1": True,
+                    "triennial-year-2": True,
+                    "triennial-year-3": True,
+                },
+            }),
         )
+        self.assertEqual(self._cycle(), {
+            "annual": False,
+            "triennial-year-1": True,
+            "triennial-year-2": True,
+            "triennial-year-3": True,
+        })
 
     def test_a_declared_year_wins_over_the_date(self):
-        """A volume may name the cycle year without compiling for one particular Shabbat."""
         CompilerProcessor.load_init_settings(
             self.linear_data,
             yaml_to_declaration_entries({
                 "opensiddur:gregorian-date": {"year": 2026, "month": 1, "day": 3},
-                "opensiddur:reading-cycle": {"triennial": True, "triennial-year": 2},
+                "opensiddur:reading-cycle": {"triennial": True, "triennial-year-2": True},
             }),
         )
-        entry = get_active_setting_entry(
-            self.linear_data, "opensiddur:reading-cycle", "triennial-year"
-        )
-        self.assertEqual(entry.value, 2)
+        self.assertEqual(self._cycle()["triennial-year-2"], True)
 
     def test_triennial_year_is_derived_from_the_date(self):
         """The cycle is counted from 5756, so 5786 opens one and 5788 closes it."""

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -189,10 +189,11 @@ class TestHaftarahFile(unittest.TestCase):
         _, document = build.haftarah_file(slug, self.ANNUAL, triennial_passages)
         return etree.fromstring(document.encode("utf-8"))
 
-    def _cycle_years(self, conditional) -> list[str]:
-        """The cycle years a conditional tests for, in order."""
+    def _features(self, conditional) -> list[str]:
+        """The reading-cycle features a conditional tests for, in order."""
         return [
-            numeric.get("value") for numeric in conditional.iter(f"{TEI}numeric")
+            f.get("name") for f in conditional.iter(f"{TEI}f")
+            if f.getparent().get("type") == "opensiddur:reading-cycle"
         ]
 
     def test_a_parshah_with_no_triennial_haftarah_is_unconditioned(self):
@@ -226,21 +227,38 @@ class TestHaftarahFile(unittest.TestCase):
         """Two tests would be undefined where one is false, and undefined keeps the text."""
         tree = self._tree("bereshit", {1: _passage("isaiah", (42, 5), (42, 21))})
         conditional = tree.findall(f".//{J}conditional")[-1]
+        self.assertEqual(self._features(conditional), ["triennial-year-1"])
         self.assertEqual(
-            [(f.getparent().get("type"), f.get("name")) for f in conditional.iter(f"{TEI}f")],
-            [("opensiddur:reading-cycle", "triennial-year")],
+            [b.get("value") for b in conditional.iter(f"{TEI}binary")], ["true"]
         )
-        self.assertEqual(self._cycle_years(conditional), ["1"])
 
-    def test_the_annual_reading_gives_way_only_to_the_years_that_exist(self):
-        """Tazria is read alone in years 1 and 2 only, and keeps its annual haftarah in year 3."""
+    def test_a_year_is_selected_independently_of_the_others(self):
+        """A volume for a whole cycle turns on all three, so they cannot be one year number."""
+        tree = self._tree("bereshit", {
+            year: _passage("isaiah", (40, year), (40, year)) for year in (1, 2, 3)
+        })
+        triennial = tree.findall(f".//{J}conditional")[1:]
+        self.assertEqual(
+            [self._features(c) for c in triennial],
+            [["triennial-year-1"], ["triennial-year-2"], ["triennial-year-3"]],
+        )
+
+    def test_the_annual_reading_stands_in_for_the_years_that_have_none(self):
+        """Tazria is read alone in years 1 and 2 only, so year 3 falls back to the annual."""
         tree = self._tree("tazria", {
             1: _passage("isaiah", (46, 3), (46, 13)),
             2: _passage("jeremiah", (30, 1), (30, 9)),
         })
         annual = tree.findall(f".//{J}conditional")[0]
-        self.assertEqual(annual.find(f"{J}none").tag, f"{J}none")
-        self.assertEqual(self._cycle_years(annual), ["1", "2"])
+        self.assertEqual(annual.find(f"{J}any").tag, f"{J}any")
+        self.assertEqual(self._features(annual), ["annual", "triennial-year-3"])
+
+    def test_a_parshah_with_every_year_yields_the_annual_only_to_the_annual_feature(self):
+        tree = self._tree("bereshit", {
+            year: _passage("isaiah", (40, year), (40, year)) for year in (1, 2, 3)
+        })
+        annual = tree.findall(f".//{J}conditional")[0]
+        self.assertEqual(self._features(annual), ["annual"])
 
     def test_every_conditional_is_closed(self):
         tree = self._tree("bereshit", {

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -12,6 +12,7 @@ from lxml import etree
 
 from opensiddur.importer.humash import build
 from opensiddur.importer.humash.aliyot import CombinedParsha, Parsha
+from opensiddur.importer.humash.readings import Passage
 from opensiddur.importer.humash.refs import (
     UNIT_ALIYAH,
     UNIT_ALIYAH_COMBINED,
@@ -22,6 +23,7 @@ from opensiddur.importer.humash.refs import (
 
 TEI = "{http://www.tei-c.org/ns/1.0}"
 J = "{http://jewishliturgy.org/ns/jlptei/2}"
+XML = "{http://www.w3.org/XML/1998/namespace}"
 
 PAIR = "tazria_metzora"
 PATTERNS = {"TTS": "A", "TST": "B", "STT": "C"}
@@ -166,6 +168,104 @@ class TestPairFile(unittest.TestCase):
         self.assertEqual(ranges[-1][1], (15, 17))
         for earlier, later in zip(ranges, ranges[1:]):
             self.assertGreater(later[0], earlier[1], "the text is emitted more than once")
+
+
+def _passage(book: str, start, end, **kwargs) -> Passage:
+    return Passage(
+        key="test",
+        spans=[ReadingSpan(
+            unit="haftarah", label="1",
+            start=VerseRef(book, *start), end=VerseRef(book, *end), **kwargs,
+        )],
+    )
+
+
+class TestHaftarahFile(unittest.TestCase):
+    """The annual haftarah and the triennial ones are alternatives for the same Shabbat."""
+
+    ANNUAL = [_passage("isaiah", (42, 5), (43, 10))]
+
+    def _tree(self, slug: str, triennial_passages=None):
+        _, document = build.haftarah_file(slug, self.ANNUAL, triennial_passages)
+        return etree.fromstring(document.encode("utf-8"))
+
+    def _cycle_years(self, conditional) -> list[str]:
+        """The cycle years a conditional tests for, in order."""
+        return [
+            numeric.get("value") for numeric in conditional.iter(f"{TEI}numeric")
+        ]
+
+    def test_a_parshah_with_no_triennial_haftarah_is_unconditioned(self):
+        """Devarim, Vaetchanan and Vezot Haberakhah keep the annual reading in every year."""
+        tree = self._tree("devarim")
+        self.assertEqual(tree.findall(f".//{J}conditional"), [])
+
+    def test_each_year_becomes_a_headed_division_of_its_own(self):
+        tree = self._tree("bereshit", {
+            1: _passage("isaiah", (42, 5), (42, 21)),
+            2: _passage("isaiah", (40, 25), (40, 31)),
+            3: _passage("kings_2", (2, 1), (2, 13)),
+        })
+        divisions = [
+            div for div in tree.iter(f"{TEI}div")
+            if (div.get("n") or "").startswith("triennial_")
+        ]
+        self.assertEqual(
+            [div.get("corresp") for div in divisions],
+            [f"urn:x-opensiddur:text:bible:haftarah/bereshit/triennial/{year}"
+             for year in (1, 2, 3)],
+        )
+        self.assertEqual(
+            [div.find(f"{J}transclude").get("target") for div in divisions],
+            ["urn:x-opensiddur:text:bible:isaiah/42/5-42/21",
+             "urn:x-opensiddur:text:bible:isaiah/40/25-40/31",
+             "urn:x-opensiddur:text:bible:kings_2/2/1-2/13"],
+        )
+
+    def test_a_triennial_reading_turns_on_one_decisive_feature(self):
+        """Two tests would be undefined where one is false, and undefined keeps the text."""
+        tree = self._tree("bereshit", {1: _passage("isaiah", (42, 5), (42, 21))})
+        conditional = tree.findall(f".//{J}conditional")[-1]
+        self.assertEqual(
+            [(f.getparent().get("type"), f.get("name")) for f in conditional.iter(f"{TEI}f")],
+            [("opensiddur:reading-cycle", "triennial-year")],
+        )
+        self.assertEqual(self._cycle_years(conditional), ["1"])
+
+    def test_the_annual_reading_gives_way_only_to_the_years_that_exist(self):
+        """Tazria is read alone in years 1 and 2 only, and keeps its annual haftarah in year 3."""
+        tree = self._tree("tazria", {
+            1: _passage("isaiah", (46, 3), (46, 13)),
+            2: _passage("jeremiah", (30, 1), (30, 9)),
+        })
+        annual = tree.findall(f".//{J}conditional")[0]
+        self.assertEqual(annual.find(f"{J}none").tag, f"{J}none")
+        self.assertEqual(self._cycle_years(annual), ["1", "2"])
+
+    def test_every_conditional_is_closed(self):
+        tree = self._tree("bereshit", {
+            year: _passage("isaiah", (40, year), (40, year)) for year in (1, 2, 3)
+        })
+        opened = [c.get(f"{XML}id") for c in tree.findall(f".//{J}conditional")]
+        closed = [
+            c.get("target").lstrip("#") for c in tree.findall(f".//{J}endConditional")
+        ]
+        self.assertEqual(len(opened), 4)  # the annual one, and one per year
+        self.assertEqual(sorted(opened), sorted(closed))
+
+    def test_a_boundary_inside_a_verse_reads_the_whole_verse_and_says_where_to_stop(self):
+        tree = self._tree("emor", {
+            3: _passage("nahum", (2, 2), (2, 3), start_half="b", end_half="a"),
+        })
+        division = tree.findall(f".//{TEI}div[@n='triennial_3']")[0]
+        self.assertEqual(
+            [child.tag for child in division][1:],
+            [f"{TEI}note", f"{J}transclude", f"{TEI}note"],
+        )
+        self.assertEqual(
+            division.find(f"{J}transclude").get("target"),
+            "urn:x-opensiddur:text:bible:nahum/2/2-2/3",
+        )
 
 
 class TestBookFile(unittest.TestCase):

--- a/opensiddur/tests/importer/humash/test_readings.py
+++ b/opensiddur/tests/importer/humash/test_readings.py
@@ -12,7 +12,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from opensiddur.importer.humash.readings import triennial, triennial_patterns
+from opensiddur.importer.humash.readings import (
+    triennial,
+    triennial_haftarot,
+    triennial_patterns,
+)
 
 
 def _aliyot(chapter: int) -> dict[str, list[str]]:
@@ -117,3 +121,84 @@ class TestTriennialPatterns(unittest.TestCase):
 
     def test_a_hyphenated_single_parshah_is_not_taken_for_a_pair(self):
         self.assertNotIn("lech_lecha", self.patterns)
+
+
+# A synthetic triennial-haft.json in hebcal's shape: a year is one reading object, or a list of
+# them where the reading is discontinuous. Every quirk the real file has is represented once.
+TRIENNIAL_HAFT_FIXTURE = {
+    "Bereshit": {
+        "1": {"k": "Isaiah", "b": "42:5", "e": "42:21", "note": "creation"},
+        "2": {"k": "Isaiah", "b": "40:25", "e": "40:31"},
+        # Discontinuous, and closing with the verse the pairing turns on — which lies inside
+        # the piece before it and is not read a second time.
+        "3": [
+            {"k": "II Kings", "b": "2:1", "e": "2:13"},
+            {"k": "II Kings", "b": "2:14", "e": "2:18"},
+            {"k": "II Kings", "b": "2:15", "e": "2:16"},
+        ],
+    },
+    # Read alone only in the first two years of a cycle, so it has no third.
+    "Tazria": {
+        "1": {"k": "Isaiah", "b": "46:3", "e": "46:13"},
+        # A boundary inside a verse, and a stray space of the kind the real file has.
+        "2": {"k": "Jeremiah", "b": "30:1b", "e": " 30:9a"},
+    },
+    # Runs backwards, which the haftarot really do and which is not an anchor verse.
+    "Noach": {"1": [{"k": "Isaiah", "b": "54:1", "e": "54:10"},
+                    {"k": "Isaiah", "b": "53:1", "e": "53:2"}]},
+    # In the file but not a parshah, so it has nowhere to go.
+    "Tish'a B'Av": {"1": {"k": "Jeremiah", "b": "8:13", "e": "8:23"}},
+}
+
+
+class TestTriennialHaftarot(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "triennial-haft.json").write_text(
+            json.dumps(TRIENNIAL_HAFT_FIXTURE), encoding="utf-8"
+        )
+        self.haftarot = triennial_haftarot(self.root)
+
+    def _spans(self, slug: str, year: int) -> list[tuple[str, str]]:
+        return [
+            (str(span.start), str(span.end))
+            for span in self.haftarot[slug][year].spans
+        ]
+
+    def test_each_year_is_keyed_by_plain_cycle_year(self):
+        self.assertEqual(sorted(self.haftarot["bereshit"]), [1, 2, 3])
+
+    def test_a_single_reading_object_becomes_one_span(self):
+        self.assertEqual(self._spans("bereshit", 1), [("isaiah 42:5", "isaiah 42:21")])
+
+    def test_a_list_of_readings_becomes_a_span_each(self):
+        """A list year was dropped entirely before, losing 36 of the 150 readings."""
+        self.assertEqual(
+            self._spans("bereshit", 3),
+            [("kings_2 2:1", "kings_2 2:13"), ("kings_2 2:14", "kings_2 2:18")],
+        )
+
+    def test_a_piece_inside_an_earlier_one_is_not_read_again(self):
+        self.assertNotIn(("kings_2 2:15", "kings_2 2:16"), self._spans("bereshit", 3))
+
+    def test_a_piece_that_runs_backwards_is_kept(self):
+        self.assertEqual(
+            self._spans("noach", 1),
+            [("isaiah 54:1", "isaiah 54:10"), ("isaiah 53:1", "isaiah 53:2")],
+        )
+
+    def test_a_half_verse_boundary_reads_the_whole_verse_and_says_so(self):
+        span = self.haftarot["tazria"][2].spans[0]
+        self.assertEqual((str(span.start), str(span.end)), ("jeremiah 30:1", "jeremiah 30:9"))
+        self.assertEqual((span.start_half, span.end_half), ("b", "a"))
+
+    def test_a_parshah_read_alone_in_two_years_has_only_those(self):
+        self.assertEqual(sorted(self.haftarot["tazria"]), [1, 2])
+
+    def test_an_occasion_that_is_not_a_parshah_is_dropped(self):
+        self.assertNotIn("tisha_bav", self.haftarot)
+        self.assertEqual(sorted(self.haftarot), ["bereshit", "noach", "tazria"])

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -846,6 +846,10 @@ The weekly parsha and special additions can also be calculated:
    <tei:f name="israel-parsha">
       <tei:string/>
    </tei:f>
+   <!-- Which of the three years of the modern triennial cycle the date falls in. -->
+   <tei:f name="triennial-year">
+      <tei:numeric/>
+   </tei:f>
    <!-- One per pair of parshiyot that is sometimes read combined; see below. -->
    <tei:f name="triennial-pattern-vayakhel-pekudei">
       <tei:string/>
@@ -916,6 +920,44 @@ The value is reckoned for the diaspora or for Israel according to `opensiddur:is
 the two diverge whenever a festival falling on Shabbat puts them a week apart. No separate
 test on `opensiddur:israel` is needed alongside the pattern: a pattern that can only arise in
 Israel selects an Israel division on its own.
+
+Which cycle of readings a volume follows is a choice it makes rather than something the date
+settles — every date falls in some year of the triennial cycle, including the dates a volume
+that reads annually is compiled for. It is declared:
+```xml
+<tei:fs type="opensiddur:reading-cycle">
+   <tei:f name="triennial">
+      <!-- true if this volume reads the modern triennial cycle. Defaults to false. -->
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="triennial-year">
+      <!-- Which year of the cycle this volume is for, 1 to 3, or 0 for none. Derived from
+      opensiddur:torah-reading/triennial-year when triennial is true and a date is declared,
+      and 0 otherwise, so that an annual volume compiled for a date selects nothing here. May
+      also be declared directly, by a volume that reads triennially but is not for one
+      particular Shabbat. -->
+      <tei:numeric/>
+   </tei:f>
+</tei:fs>
+```
+
+Unlike most features these take a value rather than staying `undefined`, because the readings
+they select are alternatives to one another. The annual haftarah of a parshah and its three
+triennial ones are all read on the same Shabbat, and an undefined condition keeps its text, so
+an open feature here would print four haftarot for one week. A volume that says nothing gets
+the annual reading. The humash conditions its haftarot this way:
+
+```xml
+<j:conditional xml:id="triennial_haftarah_1">
+   <tei:fs type="opensiddur:reading-cycle">
+      <tei:f name="triennial-year"><tei:numeric value="1"/></tei:f>
+   </tei:fs>
+</j:conditional>
+```
+
+One feature and not two: `j:all` over a false test and an undefined one is `undefined` rather
+than false, per the truth tables below, so a condition that has to be decisive must turn on a
+single feature that always has a value.
 
 There are also special manual overrides available, which
 are never set automatically (they default to the `false` value)

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -926,20 +926,40 @@ settles — every date falls in some year of the triennial cycle, including the 
 that reads annually is compiled for. It is declared:
 ```xml
 <tei:fs type="opensiddur:reading-cycle">
-   <tei:f name="triennial">
-      <!-- true if this volume reads the modern triennial cycle. Defaults to false. -->
+   <tei:f name="annual">
+      <!-- true if this volume carries the annual haftarah of each week. Defaults to true. -->
       <tei:binary/>
    </tei:f>
-   <tei:f name="triennial-year">
-      <!-- Which year of the cycle this volume is for, 1 to 3, or 0 for none. Derived from
-      opensiddur:torah-reading/triennial-year when triennial is true and a date is declared,
-      and 0 otherwise, so that an annual volume compiled for a date selects nothing here. May
-      also be declared directly, by a volume that reads triennially but is not for one
-      particular Shabbat. -->
-      <tei:numeric/>
+   <tei:f name="triennial">
+      <!-- true if this volume reads the modern triennial cycle. Defaults to false. This is
+      the opt-in that gives a declared date meaning here; on its own it selects nothing. -->
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="triennial-year-1">
+      <!-- true if this volume carries the first year's triennial readings. Defaults to false.
+      Derived, along with its siblings and with annual, from
+      opensiddur:torah-reading/triennial-year when triennial is true and a date is declared. -->
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="triennial-year-2">
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="triennial-year-3">
+      <tei:binary/>
    </tei:f>
 </tei:fs>
 ```
+
+One binary per year rather than a single year number, because several may be true at once, the
+way several rites may be. A volume for one Shabbat has one year; a volume covering a whole
+three-year cycle turns on all three, which a year number could not express:
+
+| volume | declares | carries |
+| --- | --- | --- |
+| annual | nothing | the annual haftarah |
+| one Shabbat | `triennial` and a date | that cycle year's |
+| a whole cycle | the three year features, `annual` false | all three years' |
+| complete reference | the three year features | all four |
 
 Unlike most features these take a value rather than staying `undefined`, because the readings
 they select are alternatives to one another. The annual haftarah of a parshah and its three
@@ -950,14 +970,16 @@ the annual reading. The humash conditions its haftarot this way:
 ```xml
 <j:conditional xml:id="triennial_haftarah_1">
    <tei:fs type="opensiddur:reading-cycle">
-      <tei:f name="triennial-year"><tei:numeric value="1"/></tei:f>
+      <tei:f name="triennial-year-1"><tei:binary value="true"/></tei:f>
    </tei:fs>
 </j:conditional>
 ```
 
-One feature and not two: `j:all` over a false test and an undefined one is `undefined` rather
-than false, per the truth tables below, so a condition that has to be decisive must turn on a
-single feature that always has a value.
+Always one feature per test: `j:all` over a false test and an undefined one is `undefined`
+rather than false, per the truth tables below, so a condition that has to be decisive must turn
+on a single feature that always has a value. Where a reading covers several cases — the humash's
+annual haftarah stands in for the cycle years a parshah has no reading for — the tests are
+combined with `j:any`, which does answer true as soon as one of them is true.
 
 There are also special manual overrides available, which
 are never set automatically (they default to the `false` value)


### PR DESCRIPTION
Closes #55.

`readings.triennial_haftarot` was imported by `build.py` but never called, so no
haftarah file carried a triennial reading: a volume compiled for a triennial cycle
printed that year's third of the Torah beside the annual haftarah of the whole parshah.

## Reading the data

Calling the existing function turned up three things that had never been exercised.

- **The list-valued years were dropped.** hebcal records a discontinuous reading as a list
  of pieces, and the year filter accepted only a single object — losing 36 of the 150 slots.
- **Eight readings end with a piece inside one already listed.** Nasso year 1 is
  Joshua 6:5-14 and then 6:12; Emor year 3 is Nachum 2:1-3 and then 2:2b-3a. That is the
  verse the pairing with the parshah turns on, recorded beside the reading rather than
  appended to it, and taking it as a continuation would read those verses twice. A piece
  that merely runs *backwards* is kept — the haftarot really do that, as Mishpatim's
  Jeremiah 34:12-22 then 33:25-26 — so only containment marks an anchor.
- **`parse_hebcal_ref` raised on a boundary inside a verse.** It now reads the whole verse
  containing it and keeps which half was meant on the span, so the reading can say where it
  really starts and stops.

## Selecting one

This is where the haftarot differ from the Torah divisions of #52. Those are markers over one
text and can sit side by side in their own unit-spaces; the annual haftarah and the three
triennial ones are alternatives for the same Shabbat, and a volume printing all four would be
wrong however it was headed.

So `opensiddur:reading-cycle` carries the volume's choice — `triennial`, and the
`triennial-year` derived from the new `opensiddur:torah-reading/triennial-year` once the
volume has said it reads triennially. A date alone settles nothing, since an annual volume's
date falls in a cycle year too, and a volume that declares neither keeps the annual reading.

Two consequences worth review attention, neither of them in the issue:

- **The condition turns on one feature, not two.** Testing cycle-and-year with `j:all` kept
  everything: per the truth tables in `JLPTEI-3.md`, `j:all` over a false test and an
  undefined one is *undefined*, and undefined keeps the text. That is the spec, not a bug, so
  a condition that must be decisive has to turn on a single feature that always has a value.
  Hence `triennial-year` defaulting to `0` rather than staying undefined.
- **A triennial volume that names no year gets the annual reading**, not all three. This
  breaks the `opensiddur:rite` precedent of "unset keeps every variant", deliberately. The
  year can be declared directly, for a volume that reads triennially but is not for one
  particular Shabbat.

The annual reading gives way only to the years actually recorded, so Tazria, Achrei Mot and
Behar keep it in year 3 when they are read with their partner, and Devarim, Vaetchanan, Vezot
Haberakhah and the pairs — which have no triennial haftarah of their own — keep it always.

## Verification

- Full suite: 1157 passed, 23 skipped. New tests cover the data quirks against a synthetic
  `triennial-haft.json`, the emitted conditional shape, and the feature derivation.
- All 225 humash files regenerate and validate against RelaxNG + Schematron.
- The five interesting settings combinations were evaluated through the real condition
  evaluator: annual with and without a date, triennial without a year, triennial in year 1,
  and a year-1 volume meeting a parshah that has no year-1 reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)