### PR TITLE
Render parsha boundaries instead of dropping them

### DIFF
--- a/opensiddur/exporter/tex/reledmac.xslt
+++ b/opensiddur/exporter/tex/reledmac.xslt
@@ -123,6 +123,25 @@
              tei:div[@type='book'] (Bible exports), where the chapter exists solely as a
              milestone and would otherwise be invisible. -->
         <xsl:text>\newcommand{\chno}[1]{{\large\bfseries{\textdir TLT\selectlanguage{english}#1}}\,}&#10;</xsl:text>
+        <!-- Parsha name, run-in at the head of the text the parsha opens. A parsha is a
+             division containing the chapters and verses that follow it, so it is marked
+             once, here, and deliberately not doubled with an apparatus entry: a page
+             carrying a boundary would otherwise announce it twice.
+
+             Callers who want a different treatment redefine the macro through the
+             additional-preamble parameter — the emitted \OSParsha{name} is the only thing
+             this stylesheet produces for a boundary. For an apparatus entry instead of a
+             visible header:
+
+               \renewcommand{\OSParsha}[1]{\leavevmode{\OSRTLfalse%
+                 \edtext{\mbox{}}{\Bfootnote{Parsha: #1}}}}
+
+             (an empty-lemma \edtext{} is fragile in bidi/RTL contexts and can make
+             reledmac drop surrounding text or corrupt its .1 aux file, hence the explicit
+             zero-width \mbox{} lemma), or to suppress the boundary entirely:
+
+               \renewcommand{\OSParsha}[1]{} -->
+        <xsl:text>\newcommand{\OSParsha}[1]{{\normalfont\large\bfseries #1}\quad}&#10;</xsl:text>
 
         <!-- Section headings (tei:head).
              reledmac's \eledchapter/\eledsection/\eledsubsection are deliberately NOT used:
@@ -604,19 +623,37 @@
                         </xsl:choose>
                     </xsl:when>
                     <xsl:when test="self::tei:milestone[@unit='parsha']">
-                        <!-- Parsha boundary: emit as a B-series footnote anchored
-                             to the current verse. Only meaningful inside a pstart. -->
-                        <xsl:if test="$in-pstart">
-                            <!-- Empty-lemma \edtext{} is fragile in bidi/RTL contexts and
-                                 can cause reledmac to drop surrounding text or corrupt
-                                 its .1 aux file. Use an explicit zero-width box lemma
-                                 to keep the argument structure stable. -->
-                            <xsl:text>\leavevmode{\OSRTLfalse\edtext{\mbox{}}{\Bfootnote{Parsha: </xsl:text>
-                            <xsl:value-of select="f:escape-tex(string(@n))"/>
-                            <xsl:text>}}}</xsl:text>
+                        <!-- Parsha boundary: a division that contains the chapters and
+                             verses following it, so it legitimately sits *between*
+                             paragraphs. Open a pstart when none is open, the way the
+                             chapter and verse branches do — a boundary outside a pstart
+                             would otherwise be silently dropped. Leaving in-pstart true
+                             is what makes the name run in: the following paragraph's
+                             chapter/verse milestones join this pstart rather than opening
+                             their own, so the name shares a line with the parsha's first
+                             verse. -->
+                        <xsl:if test="not($in-pstart)">
+                            <xsl:text>\pstart </xsl:text>
                         </xsl:if>
+                        <xsl:text>\OSParsha{</xsl:text>
+                        <xsl:choose>
+                            <!-- Parsha names are Hebrew in an otherwise LTR stream (the
+                                 JPS 1917 translation), so give them the same direction
+                                 wrapper tei:foreign[@xml:lang='he'] gets. Wrapping here
+                                 rather than inside the macro keeps it in place for a
+                                 caller's \renewcommand. -->
+                            <xsl:when test="matches(string(@n), '\p{IsHebrew}')">
+                                <xsl:text>\texthebrew{</xsl:text>
+                                <xsl:value-of select="f:escape-tex(string(@n))"/>
+                                <xsl:text>}</xsl:text>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="f:escape-tex(string(@n))"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        <xsl:text>}</xsl:text>
                         <xsl:next-iteration>
-                            <xsl:with-param name="in-pstart" select="$in-pstart"/>
+                            <xsl:with-param name="in-pstart" select="true()"/>
                         </xsl:next-iteration>
                     </xsl:when>
                     <xsl:when test="self::tei:milestone[@rend='****']">

--- a/opensiddur/importer/jps1917/mediawiki_to_tei.xslt
+++ b/opensiddur/importer/jps1917/mediawiki_to_tei.xslt
@@ -125,6 +125,17 @@
                         <!-- ab can't appear in p and is already a block -->
                         <xsl:apply-templates select="current-group()" mode="copy"/>
                     </xsl:when>
+                    <xsl:when test="
+                        not(current-group()[not(self::p)]
+                            [self::text()[normalize-space(.)] or (self::* and not(self::tei:milestone))])">
+                        <!-- Nothing here but milestones: a parshah running head, a Psalm
+                        119 acrostic letter or an asterisk dinkus. A milestone standing
+                        alone is not paragraph content — it marks a boundary between
+                        paragraphs, and the division it opens contains the chapter and
+                        verse milestones that follow — so leave it as a child of the
+                        enclosing div rather than inventing a paragraph for it. -->
+                        <xsl:apply-templates select="current-group()" mode="copy"/>
+                    </xsl:when>
                     <xsl:otherwise>
                         <tei:p>
                             <xsl:apply-templates select="current-group()" mode="copy"/>
@@ -174,16 +185,14 @@
                             <xsl:choose>
                                 <xsl:when test="$first_parsha">
                                     <!-- The book's opening parshah, which the source does not
-                                    mark, goes after the title heading and before the text, in
-                                    a tei:p of its own like every parshah milestone the running
+                                    mark, goes after the title heading and before the text, as
+                                    a child of the div like every parshah milestone the running
                                     heads produce. -->
                                     <xsl:variable name="head"
                                         select="$wrapped-content/self::tei:head[1]"/>
                                     <xsl:copy-of select="
                                         $wrapped-content[exists($head) and (. &lt;&lt; $head or . is $head)]"/>
-                                    <tei:p>
-                                        <xsl:sequence select="f:parsha-milestone($first_parsha)"/>
-                                    </tei:p>
+                                    <xsl:sequence select="f:parsha-milestone($first_parsha)"/>
                                     <xsl:copy-of select="
                                         $wrapped-content[empty($head) or . &gt;&gt; $head]"/>
                                 </xsl:when>

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -814,8 +814,10 @@ class TestStructuralElements(unittest.TestCase):
             r"\texthebrew{רות}\quad RUTH}}",
             out,
         )
-        # ...but a line break in body text is still a line break.
-        self.assertNotIn(r"\quad", out.split(r"\OSheadA", 1)[0])
+        # ...but a line break in body text is still a line break. Scoped to the typeset
+        # material: the preamble defines macros that legitimately use \quad themselves.
+        body = out.split(r"\begin{document}", 1)[1]
+        self.assertNotIn(r"\quad", body.split(r"\OSheadA", 1)[0])
         # The bookmark still takes the flattened form: \addcontentsline builds a PDF
         # string and cannot carry markup.
         self.assertIn(
@@ -1015,6 +1017,85 @@ class TestFrontMatter(unittest.TestCase):
         out = _transform(xml)
         body = out.split(r"\begin{document}", 1)[1]
         self.assertNotIn("Stray", body)
+
+
+class TestParshaMilestones(unittest.TestCase):
+    """A parsha is a division containing the chapters and verses that follow it, so its
+    milestone legitimately sits between paragraphs rather than inside one. It used to be
+    rendered only when a \\pstart happened to be open, which meant every boundary in the
+    JPS 1917 Torah — all of them between paragraphs — was silently dropped."""
+
+    def _transform_book(self, body: str) -> str:
+        """A div[@type='book'], which is what makes chapter milestones render too."""
+        return _transform(
+            f"""<?xml version="1.0" encoding="UTF-8"?>
+            <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en">
+              <tei:text><tei:body>
+                <tei:div type="book">{body}</tei:div>
+              </tei:body></tei:text>
+            </tei:TEI>"""
+        )
+
+    @staticmethod
+    def _document_body(tex: str) -> str:
+        """Just the typeset material: the preamble always defines every macro."""
+        return tex.split(r"\begin{document}", 1)[1]
+
+    BETWEEN_PARAGRAPHS = """
+        <tei:p><tei:milestone unit="verse" n="8"/>But Noah found grace.</tei:p>
+        <tei:milestone unit="parsha" n="Noach"/>
+        <tei:p><tei:milestone unit="verse" n="9"/>These are the generations.</tei:p>"""
+
+    def test_a_milestone_between_paragraphs_is_rendered(self):
+        body = self._document_body(self._transform_book(self.BETWEEN_PARAGRAPHS))
+        self.assertIn(r"\OSParsha{Noach}", body)
+
+    def test_a_milestone_inside_a_paragraph_is_still_rendered(self):
+        """The shape that happened to work before must keep working."""
+        body = self._document_body(self._transform_book(
+            """<tei:p><tei:milestone unit="verse" n="8"/>But Noah found grace.</tei:p>
+               <tei:p><tei:milestone unit="verse" n="9"/><tei:milestone unit="parsha"
+                 n="Noach"/>These are the generations.</tei:p>"""
+        ))
+        self.assertIn(r"\OSParsha{Noach}", body)
+
+    def test_a_milestone_before_the_first_paragraph_is_rendered(self):
+        body = self._document_body(self._transform_book(
+            """<tei:head>GENESIS</tei:head>
+               <tei:milestone unit="parsha" n="Bereshit"/>
+               <tei:p><tei:milestone unit="verse" n="1"/>In the beginning.</tei:p>"""
+        ))
+        self.assertIn(r"\OSParsha{Bereshit}", body)
+
+    def test_the_name_runs_in_with_the_verse_it_opens(self):
+        """The pstart opened for the boundary is the one the following verse uses, so the
+        name shares a line with the parsha's first verse instead of standing alone."""
+        body = self._document_body(self._transform_book(self.BETWEEN_PARAGRAPHS))
+        after = body.split(r"\OSParsha{Noach}", 1)[1]
+        block = after.split(r"\pend", 1)[0]
+        self.assertIn(r"\vno{9}", block)
+        self.assertNotIn(r"\pstart", block)
+
+    def test_a_boundary_is_announced_only_once(self):
+        """The B-series footnote this used to emit alongside would repeat the name on the
+        same page. The apparatus form is available by \\renewcommand instead."""
+        body = self._document_body(self._transform_book(self.BETWEEN_PARAGRAPHS))
+        self.assertNotIn(r"\Bfootnote", body)
+        self.assertEqual(1, body.count("Noach"))
+
+    def test_the_parsha_macro_is_defined_in_the_preamble(self):
+        out = self._transform_book(self.BETWEEN_PARAGRAPHS)
+        preamble = out.split(r"\begin{document}", 1)[0]
+        self.assertIn(r"\newcommand{\OSParsha}", preamble)
+
+    def test_a_hebrew_name_gets_a_direction_wrapper(self):
+        """Parsha names are Hebrew in an otherwise LTR stream and would render reversed."""
+        body = self._document_body(self._transform_book(
+            """<tei:p><tei:milestone unit="verse" n="8"/>But Noah found grace.</tei:p>
+               <tei:milestone unit="parsha" n="נֹח"/>
+               <tei:p><tei:milestone unit="verse" n="9"/>These are the generations.</tei:p>"""
+        ))
+        self.assertIn("\\OSParsha{\\texthebrew{נֹח}}", body)
 
 
 if __name__ == "__main__":

--- a/opensiddur/tests/importer/jps1917/test_convert_wikisource.py
+++ b/opensiddur/tests/importer/jps1917/test_convert_wikisource.py
@@ -5,6 +5,9 @@ import tempfile
 import os
 from pathlib import Path
 
+from lxml import etree
+
+from opensiddur.exporter.constants import TEI_NS
 from opensiddur.importer.jps1917.convert_wikisource import (
     get_credits_pages, header, tei_file, process_mediawiki, validate_and_write_tei_file,
     book_file, index_file, Book, Index, mediawiki_xml_to_tei, main, make_project_directory,
@@ -1564,15 +1567,18 @@ class TestMediawikiXmlToTei(unittest.TestCase):
             xslt_params={"parsha_names": self.parsha_names, **(params or {})},
         )
 
-        # Simple test XML that focuses on basic functionality
+        # Simple test XML that focuses on basic functionality. Verse text is a *sibling*
+        # of the verse marker, which is the shape the real intermediate XML has: the verse
+        # template emits milestones only and never recurses into the element, so text
+        # written inside it would silently vanish and leave the fixture textless.
         self.simple_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <mediawikis xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:j="http://jewishliturgy.org/ns/jlptei/2">
     <mediawiki>
         <noinclude><c>1</c></noinclude>
         <c><larger>Chapter 1</larger></c>
         <dropinitial>1</dropinitial>
-        <verse chapter="1" verse="1">In the beginning God created the heaven and the earth.</verse>
-        <verse chapter="1" verse="2">And the earth was without form, and void.</verse>
+        <verse chapter="1" verse="1"/>In the beginning God created the heaven and the earth.
+        <verse chapter="1" verse="2"/>And the earth was without form, and void.
         <c><lang>ויצא</lang></c>
         <br>List item 1</br>
         <br>List item 2</br>
@@ -1582,7 +1588,7 @@ class TestMediawikiXmlToTei(unittest.TestCase):
         <noinclude><c>2</c></noinclude>
         <c><larger>Chapter 2</larger></c>
         <dropinitial>2</dropinitial>
-        <verse chapter="2" verse="1">Thus the heavens and the earth were finished.</verse>
+        <verse chapter="2" verse="1"/>Thus the heavens and the earth were finished.
     </mediawiki>
 </mediawikis>"""
         
@@ -1676,8 +1682,10 @@ class TestMediawikiXmlToTei(unittest.TestCase):
             {"book_name": "genesis"}
         )
         main_output = outputs[""]
-        # Test chapter milestones
-        self.assertIn('<tei:milestone unit="chapter" n="1"', main_output)
+        # Test chapter milestones. Matched without the element name: a chapter milestone
+        # standing between paragraphs is not wrapped in a tei:p, so with no enclosing
+        # wrapper div to carry the namespace it is serialized with its own declaration.
+        self.assertIn('unit="chapter" n="1"', main_output)
         # Note: Chapter 2 milestone is in the second page, so it might not be in the same output
         
         # Test verse milestones
@@ -1877,6 +1885,41 @@ class TestParshaMilestones(unittest.TestCase):
             output,
         )
         self.assertLess(output.index("</tei:head>"), output.index('unit="parsha"'))
+        self.assertEqual("div", self._parent_tag(output, 'unit="parsha"'))
+
+    def test_a_milestone_alone_is_not_wrapped_in_a_paragraph(self):
+        """A milestone standing alone marks a boundary between paragraphs — it is not
+        paragraph content, and the division it opens contains the chapter and verse
+        milestones that follow. The tei:p the running heads used to produce also hid the
+        boundary from the PDF exporter, which only rendered milestones inside a pstart."""
+        output = self._transform_names(["ויצא"])
+        self.assertNotIn("<tei:p><tei:milestone", output)
+        self.assertEqual("div", self._parent_tag(output, 'unit="parsha"'))
+
+    def test_an_acrostic_milestone_alone_is_not_wrapped_either(self):
+        output = self.transform(
+            self._wrap("<c><lang>א</lang> ALEPH.</c><p/>Happy are they that are upright"),
+            {"book_name": "psalms", "wrapper_div_type": "book"},
+        )[""]
+        self.assertEqual("div", self._parent_tag(output, 'unit="acrostic"'))
+
+    def test_text_beside_a_milestone_is_still_a_paragraph(self):
+        """The unwrapping must key on "nothing but milestones", not on "contains a
+        milestone" — verse milestones live inside the paragraphs they number."""
+        output = self._transform_names(["ויצא"])
+        root = etree.fromstring(output.encode("utf-8"))
+        paragraphs = root.xpath("//tei:p", namespaces={"tei": TEI_NS})
+        self.assertEqual(1, len(paragraphs))
+        self.assertEqual("text", paragraphs[0].text.strip())
+
+    @staticmethod
+    def _parent_tag(output, needle):
+        """Local name of the element containing the first match of `needle`."""
+        root = etree.fromstring(output.encode("utf-8"))
+        attr, value = re.match(r'(\w+)="([^"]*)"', needle).groups()
+        found = root.xpath(f"//tei:milestone[@{attr}=$v]",
+                           namespaces={"tei": TEI_NS}, v=value)[0]
+        return etree.QName(found.getparent()).localname
 
     def test_no_opening_parsha_outside_the_torah(self):
         output = self.transform(


### PR DESCRIPTION
Fixes #49.

## The bug

`tei:milestone[@unit='parsha']` was the one content-producing branch in `numbered-stream` *guarded* by `$in-pstart` instead of opening a `\pstart`, the way the chapter, verse and generic-content branches do. In the default flow `f:para-break` closes the pstart and leaves it closed until real content arrives, so a boundary sitting between paragraphs produced nothing. Every parsha in the JPS 1917 Torah sits there, so none of the 54 reached the PDF.

## The fix

**Exporter.** The parsha branch opens a `\pstart` when none is open and keeps it open. That is also what makes the name run in: the following paragraph's chapter/verse milestones join that pstart, so the parsha name shares a line with the verse it opens.

A boundary is worth more than an invisible `\mbox{}` apparatus anchor, so it renders through `\OSParsha` — the single thing emitted per boundary. Emitting a visible header *and* the old `\Bfootnote` would announce the same boundary twice on one page, so the footnote form and a suppressed form are documented in the preamble as `\renewcommand` alternatives for `additional-preamble`:

```latex
\renewcommand{\OSParsha}[1]{\leavevmode{\OSRTLfalse\edtext{\mbox{}}{\Bfootnote{Parsha: #1}}}}
\renewcommand{\OSParsha}[1]{}
```

**Importer.** A milestone standing alone is not paragraph content — it marks a boundary *between* paragraphs, and the division it opens contains the chapter and verse milestones that follow. Milestone-only groups are no longer wrapped in a `tei:p`. This also covers the Psalm 119 acrostic letters and the asterisk dinkus.

## Incidental

The `simple_xml` fixture had verse text as a *child* of `<verse>`, which the verse template never recurses into — the fixture was silently textless and its paragraph-wrapping assertions were vacuous. Text is now a sibling, as in the real intermediate XML.

## Verification

- Full suite green: 1087 passed. 10 new tests across the two layers.
- End-to-end on regenerated `project/jps1917/genesis.xml` through LuaLaTeX: all 12 Genesis parshiyot reach the PDF (previously 0), rendering as e.g. `נֹח 9 These are the generations of Noah.` — the name on the same line as the verse it opens.

Regenerated output: opensiddur/opensiddur-projects#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
