### PR TITLE
Compute the special Shabbatot from the Hebrew date

### DIFF
--- a/opensiddur/exporter/calendar/compute.py
+++ b/opensiddur/exporter/calendar/compute.py
@@ -107,8 +107,10 @@ _TISHREI = 7
 _ADAR = 12
 _ADAR_II = 13
 
-# The modern triennial cycle as reckoned by the CJLS, whose first year was 5756.
+# The modern triennial cycle as reckoned by the CJLS, whose first year was 5756. The cycle
+# turns over on Simhat Torah; see _triennial_year for why the Israel date serves both rites.
 _TRIENNIAL_EPOCH_YEAR = 5756
+_SIMHAT_TORAH_DAY = 22
 
 SERVICE_TIME_FEATURES = (
     "shaharit",
@@ -591,10 +593,21 @@ def _shabbat_on_or_before(heb: pyluach_dates.HebrewDate) -> pyluach_dates.Hebrew
 def _triennial_year(heb: pyluach_dates.HebrewDate) -> int:
     """Which of the three years of the modern triennial cycle `heb` falls in (1, 2 or 3).
 
-    The reading year turns over at Simhat Torah rather than at Rosh Hashanah, but both fall in
-    Tishrei, so the Hebrew year identifies the cycle year for every Shabbat that has a reading.
+    The reading year turns over at Simhat Torah, not at Rosh Hashanah, so the Shabbatot of
+    early Tishrei — Shabbat Shuva above all, which reads an ordinary parshah — still belong to
+    the outgoing cycle year.
+
+    Simhat Torah is 22 Tishrei in Israel and 23 in the diaspora, but a single turnover on the
+    22nd serves both. The two reckonings can disagree only on 22 Tishrei itself, and lo ADU
+    rosh forces that day to share Rosh Hashanah's weekday while barring the 23rd from ever
+    being Shabbat. So no Shabbat carrying a weekly reading falls in the disputed window: over
+    5756-5855 the reckonings differ on 29 Shabbatot, every one of them 22 Tishrei, where the
+    festival reading is selected and no parshah is read.
     """
-    return ((heb.year - _TRIENNIAL_EPOCH_YEAR) % 3) + 1
+    year = heb.year
+    if heb.month == _TISHREI and heb.day < _SIMHAT_TORAH_DAY:
+        year -= 1
+    return ((year - _TRIENNIAL_EPOCH_YEAR) % 3) + 1
 
 
 def compute_torah_reading(snapshot: SettingSnapshot) -> dict[str, Any] | None:

--- a/opensiddur/exporter/calendar/compute.py
+++ b/opensiddur/exporter/calendar/compute.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import hdate
 import tzfpy
 from pyluach import dates as pyluach_dates
+from pyluach import hebrewcal
 from pyluach import parshios
 
 from opensiddur.exporter.linear import NumericValue
@@ -84,15 +85,30 @@ AGGREGATE_FEATURES = (
 TORAH_FEATURES = (
     "diaspora-parsha",
     "israel-parsha",
+    "triennial-year",
     "shabbat-shuva",
     "shabbat-shira",
     "shabbat-shkalim",
     "shabbat-zachor",
+    "shabbat-parah",
     "shabbat-hahodesh",
     "shabbat-hagadol",
     "shabbat-hazon",
     "shabbat-nahamu",
+    "shabbat-rosh-hodesh",
+    "shabbat-mahar-hodesh",
 )
+
+# Hebrew month numbers as pyluach counts them: 1 = Nisan through 12 = Adar, with Adar I as 12
+# and Adar II as 13 in a leap year.
+_NISAN = 1
+_AV = 5
+_TISHREI = 7
+_ADAR = 12
+_ADAR_II = 13
+
+# The modern triennial cycle as reckoned by the CJLS, whose first year was 5756.
+_TRIENNIAL_EPOCH_YEAR = 5756
 
 SERVICE_TIME_FEATURES = (
     "shaharit",
@@ -551,6 +567,36 @@ def _parsha_slug(name: str) -> str:
     return name.lower().replace(" ", "-").replace(",", "")
 
 
+def _adar_of_purim(year: int) -> int:
+    """The Adar in which Purim falls: Adar II in a leap year, Adar otherwise."""
+    return _ADAR_II if hebrewcal.Year(year).leap else _ADAR
+
+
+def _containing_shabbat(heb: pyluach_dates.HebrewDate) -> pyluach_dates.HebrewDate:
+    """The Shabbat of `heb`'s week — itself if it is Shabbat, else the one that follows.
+
+    The Torah reading belongs to a week, not to a day: pyluach reckons the parshah the same
+    way (Sunday through Shabbat), so a document compiled on a Thursday selects the reading of
+    the coming Shabbat rather than none at all.
+    """
+    # pyluach weekdays run Sunday = 1 through Shabbat = 7.
+    return heb.add(days=7 - heb.weekday())
+
+
+def _shabbat_on_or_before(heb: pyluach_dates.HebrewDate) -> pyluach_dates.HebrewDate:
+    """The latest Shabbat that is not after `heb`."""
+    return heb.subtract(days=heb.weekday() % 7)
+
+
+def _triennial_year(heb: pyluach_dates.HebrewDate) -> int:
+    """Which of the three years of the modern triennial cycle `heb` falls in (1, 2 or 3).
+
+    The reading year turns over at Simhat Torah rather than at Rosh Hashanah, but both fall in
+    Tishrei, so the Hebrew year identifies the cycle year for every Shabbat that has a reading.
+    """
+    return ((heb.year - _TRIENNIAL_EPOCH_YEAR) % 3) + 1
+
+
 def compute_torah_reading(snapshot: SettingSnapshot) -> dict[str, Any] | None:
     gdate = snapshot.gregorian_date()
     if gdate is None:
@@ -558,23 +604,49 @@ def compute_torah_reading(snapshot: SettingSnapshot) -> dict[str, Any] | None:
     g = _pyluach_from_gregorian(gdate)
     diaspora = parshios.getparsha_string(g, israel=False) or ""
     israel = parshios.getparsha_string(g, israel=True) or ""
+
+    shabbat = _containing_shabbat(g.to_heb())
+    year = shabbat.year
+    adar = _adar_of_purim(year)
+    rosh_hodesh_adar = pyluach_dates.HebrewDate(year, adar, 1)
+    rosh_hodesh_nisan = pyluach_dates.HebrewDate(year, _NISAN, 1)
+    hahodesh = _shabbat_on_or_before(rosh_hodesh_nisan)
+    tisha_bav = _shabbat_on_or_before(pyluach_dates.HebrewDate(year, _AV, 9))
+    tomorrow = shabbat.add(days=1)
+
     result: dict[str, Any] = {
         "diaspora-parsha": _parsha_slug(diaspora),
         "israel-parsha": _parsha_slug(israel),
+        "triennial-year": _triennial_year(shabbat),
+        # Between Rosh Hashanah and Yom Kippur. Anchoring on 9 Tishrei rather than on a range
+        # keeps the case where Erev Yom Kippur is itself Shabbat.
+        "shabbat-shuva": shabbat == _shabbat_on_or_before(
+            pyluach_dates.HebrewDate(year, _TISHREI, 9)
+        ),
+        # Shirat ha-Yam is in Beshalach, so this one really is defined by the parshah.
+        "shabbat-shira": _parsha_slug(diaspora) == "beshalach",
+        # The four parshiyot. Each is the Shabbat on or before a fixed date, except Parah,
+        # which is simply the Shabbat before ha-Hodesh.
+        "shabbat-shkalim": shabbat == _shabbat_on_or_before(rosh_hodesh_adar),
+        "shabbat-zachor": shabbat == _shabbat_on_or_before(
+            pyluach_dates.HebrewDate(year, adar, 13)
+        ),
+        "shabbat-parah": shabbat == hahodesh.subtract(days=7),
+        "shabbat-hahodesh": shabbat == hahodesh,
+        # Erev Pesah falling on Shabbat is itself Shabbat ha-Gadol.
+        "shabbat-hagadol": shabbat == _shabbat_on_or_before(
+            pyluach_dates.HebrewDate(year, _NISAN, 14)
+        ),
+        # When 9 Av is Shabbat the fast is deferred, but the haftarah of Hazon is read that day.
+        "shabbat-hazon": shabbat == tisha_bav,
+        "shabbat-nahamu": shabbat == tisha_bav.add(days=7),
+        # Rosh Hodesh and Mahar Hodesh each carry their own haftarah.
+        "shabbat-rosh-hodesh": shabbat.day in (1, 30),
+        "shabbat-mahar-hodesh": tomorrow.day in (1, 30),
     }
     for feature in TORAH_FEATURES:
         if feature not in result:
             result[feature] = False
-    # Special Shabbatot detection via parsha names (simplified).
-    lower = diaspora.lower()
-    result["shabbat-shuva"] = "haazinu" in lower and gdate.month == 9
-    result["shabbat-shira"] = "beshalach" in lower
-    result["shabbat-shkalim"] = "shekalim" in lower
-    result["shabbat-zachor"] = "zachor" in lower or "zachor" in lower
-    result["shabbat-hahodesh"] = "hachodesh" in lower or "hahodesh" in lower
-    result["shabbat-hagadol"] = "hagadol" in lower
-    result["shabbat-hazon"] = "hazon" in lower
-    result["shabbat-nahamu"] = "nahamu" in lower or "vaetchanan" in lower
     return result
 
 

--- a/opensiddur/tests/exporter/test_calendar_compute.py
+++ b/opensiddur/tests/exporter/test_calendar_compute.py
@@ -228,6 +228,8 @@ class TestComputeFunctions(unittest.TestCase):
         result = compute_torah_reading(snap)
         self.assertIn("diaspora-parsha", result)
         self.assertIn("shabbat-shuva", result)
+        # 18 Elul: an ordinary Shabbat, so no special reading is selected.
+        self.assertFalse(result["shabbat-shuva"])
 
     def test_holiday_multiday_pesach_and_sukkot(self):
         pesach_ii = _snapshot({
@@ -538,3 +540,111 @@ class TestQuorumDerivation(unittest.TestCase):
         """Quorum features stay undefined so that unset conditions are retained, not dropped."""
         self.assertIsNone(compute_quorum(_snapshot({})))
         self.assertIsNone(compute_quorum(_snapshot({(FS_QUORUM, "minyan"): False})))
+
+
+class TestSpecialShabbatot(unittest.TestCase):
+    """The special Shabbatot that select a Torah reading or haftarah of their own.
+
+    Each is defined by the Hebrew date, not by which parshah happens to be read that week, so
+    they are computed as "the Shabbat on or before <fixed date>" rather than matched by name.
+    """
+
+    def _reading(self, year: int, month: int, day: int) -> dict:
+        return compute_torah_reading(_snapshot({
+            (FS_GREGORIAN, "year"): year,
+            (FS_GREGORIAN, "month"): month,
+            (FS_GREGORIAN, "day"): day,
+        }))
+
+    def _assert_only(self, gregorian: tuple[int, int, int], *expected: str):
+        """Assert exactly `expected` special-Shabbat flags are set on that date."""
+        result = self._reading(*gregorian)
+        actual = {
+            name for name, value in result.items()
+            if name.startswith("shabbat-") and value is True
+        }
+        self.assertEqual(actual, set(expected))
+
+    def test_four_parshiyot_in_a_leap_year(self):
+        """5784 is a leap year, so these hang off Adar II rather than Adar."""
+        self._assert_only((2024, 3, 9), "shabbat-shkalim", "shabbat-mahar-hodesh")
+        self._assert_only((2024, 3, 23), "shabbat-zachor")
+        self._assert_only((2024, 3, 30), "shabbat-parah")
+        self._assert_only((2024, 4, 6), "shabbat-hahodesh")
+
+    def test_four_parshiyot_in_an_ordinary_year(self):
+        """5785 is not a leap year, so the same readings hang off Adar."""
+        # 1 Adar: Rosh Hodesh Adar is itself Shabbat, so it is also Shabbat Shekalim.
+        self._assert_only((2025, 3, 1), "shabbat-shkalim", "shabbat-rosh-hodesh")
+        # 8 Adar: Purim falls on the Friday, so Zachor is the Shabbat six days before.
+        self._assert_only((2025, 3, 8), "shabbat-zachor")
+        self._assert_only((2025, 3, 22), "shabbat-parah")
+        # 29 Adar, the last Shabbat before 1 Nisan — which is therefore also Mahar Hodesh.
+        self._assert_only((2025, 3, 29), "shabbat-hahodesh", "shabbat-mahar-hodesh")
+
+    def test_shabbat_hagadol_shuva_hazon_and_nahamu(self):
+        self._assert_only((2024, 4, 20), "shabbat-hagadol")
+        self._assert_only((2024, 10, 5), "shabbat-shuva")
+        self._assert_only((2024, 8, 10), "shabbat-hazon")
+        self._assert_only((2024, 8, 17), "shabbat-nahamu")
+
+    def test_erev_pesah_on_shabbat_is_shabbat_hagadol(self):
+        """In 5785 Erev Pesah is itself Shabbat; ha-Gadol is that day, not the week before."""
+        self._assert_only((2025, 4, 12), "shabbat-hagadol")
+        self.assertFalse(self._reading(2025, 4, 5)["shabbat-hagadol"])
+
+    def test_shabbat_shira_is_defined_by_the_parshah(self):
+        """Shirat ha-Yam is in Beshalach, so this one really does follow the reading."""
+        self._assert_only((2024, 1, 27), "shabbat-shira")
+        self.assertEqual(self._reading(2024, 1, 27)["diaspora-parsha"], "beshalach")
+
+    def test_shekalim_is_not_matched_by_parshah_name(self):
+        """No parshah is called Shekalim; matching on the name left this permanently false."""
+        self.assertTrue(self._reading(2024, 3, 9)["shabbat-shkalim"])
+        self.assertNotIn("shekalim", self._reading(2024, 3, 9)["diaspora-parsha"])
+
+    def test_a_weekday_selects_the_coming_shabbat(self):
+        """A volume compiled midweek must still choose that week's reading."""
+        for day in range(1, 7):  # Mon 2024-04-01 through Shabbat ha-Hodesh on the 6th
+            with self.subTest(day=day):
+                self.assertTrue(self._reading(2024, 4, day)["shabbat-hahodesh"])
+        # The following Sunday belongs to the next week and so to the next reading.
+        self.assertFalse(self._reading(2024, 4, 7)["shabbat-hahodesh"])
+
+    def test_each_special_shabbat_occurs_once_a_year(self):
+        """Sweep whole Hebrew years, leap and ordinary, and count the Shabbatot."""
+        names = (
+            "shabbat-shkalim", "shabbat-zachor", "shabbat-parah", "shabbat-hahodesh",
+            "shabbat-hagadol", "shabbat-hazon", "shabbat-nahamu", "shabbat-shuva",
+            "shabbat-shira",
+        )
+        for hebrew_year in (5784, 5785, 5786, 5787):
+            counts = {name: 0 for name in names}
+            day = pyluach_dates.HebrewDate(hebrew_year, 7, 1).to_pydate()
+            end = pyluach_dates.HebrewDate(hebrew_year + 1, 7, 1).to_pydate()
+            while day < end:
+                if day.weekday() == 5:  # Saturday
+                    result = self._reading(day.year, day.month, day.day)
+                    for name in names:
+                        counts[name] += bool(result[name])
+                day += timedelta(days=1)
+            for name in names:
+                with self.subTest(hebrew_year=hebrew_year, feature=name):
+                    self.assertEqual(counts[name], 1)
+
+    def test_rosh_hodesh_and_mahar_hodesh(self):
+        """Both carry their own haftarah, and Mahar Hodesh looks at the following day."""
+        rosh_hodesh = self._reading(2025, 3, 1)  # 1 Adar 5785, a Shabbat
+        self.assertTrue(rosh_hodesh["shabbat-rosh-hodesh"])
+        self.assertFalse(rosh_hodesh["shabbat-mahar-hodesh"])
+        # 29 Adar I 5784: Rosh Hodesh Adar II falls the next day.
+        mahar_hodesh = self._reading(2024, 3, 9)
+        self.assertTrue(mahar_hodesh["shabbat-mahar-hodesh"])
+        self.assertFalse(mahar_hodesh["shabbat-rosh-hodesh"])
+
+    def test_triennial_year_cycles_one_to_three(self):
+        """The cycle is anchored on 5756, the first year of the modern triennial reading."""
+        self.assertEqual(self._reading(2023, 11, 4)["triennial-year"], 2)  # 5784
+        self.assertEqual(self._reading(2024, 11, 2)["triennial-year"], 3)  # 5785
+        self.assertEqual(self._reading(2025, 11, 1)["triennial-year"], 1)  # 5786
+        self.assertEqual(self._reading(2026, 11, 7)["triennial-year"], 2)  # 5787

--- a/opensiddur/tests/exporter/test_calendar_compute.py
+++ b/opensiddur/tests/exporter/test_calendar_compute.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from pyluach import dates as pyluach_dates
+from pyluach import parshios
 
 from opensiddur.exporter.calendar.compute import (
     FS_GREGORIAN,
@@ -648,3 +649,42 @@ class TestSpecialShabbatot(unittest.TestCase):
         self.assertEqual(self._reading(2024, 11, 2)["triennial-year"], 3)  # 5785
         self.assertEqual(self._reading(2025, 11, 1)["triennial-year"], 1)  # 5786
         self.assertEqual(self._reading(2026, 11, 7)["triennial-year"], 2)  # 5787
+
+    def test_triennial_year_turns_over_at_simhat_torah(self):
+        """Early Tishrei still reads the outgoing cycle, though the Hebrew year has advanced."""
+        # 5785 is cycle year 3, but its first Shabbatot belong to 5784's cycle year 2.
+        self.assertEqual(self._reading(2024, 10, 5)["triennial-year"], 2)   # 3 Tishrei, Shuva
+        self.assertEqual(self._reading(2024, 10, 12)["triennial-year"], 2)  # 10 Tishrei
+        self.assertEqual(self._reading(2024, 10, 19)["triennial-year"], 2)  # 17 Tishrei
+        # 24 Tishrei: the first Shabbat past Simhat Torah, which reads Bereshit.
+        self.assertEqual(self._reading(2024, 10, 26)["triennial-year"], 3)
+
+    def test_triennial_year_is_continuous_across_every_turnover(self):
+        """Sweep Shabbatot with a parshah and assert the cycle advances once per year, in order.
+
+        A turnover keyed to the Hebrew year rather than to Simhat Torah puts the step three
+        weeks early, which this catches as a cycle year changing on a Shabbat that reads a
+        parshah belonging to the outgoing year.
+        """
+        previous = None
+        day = pyluach_dates.HebrewDate(5784, 7, 1).to_pydate()
+        end = pyluach_dates.HebrewDate(5795, 7, 1).to_pydate()
+        transitions = 0
+        while day < end:
+            if day.weekday() == 5:  # Saturday
+                g = pyluach_dates.GregorianDate(day.year, day.month, day.day)
+                # Festival Shabbatot have no weekly parshah and so select no triennial reading.
+                if parshios.getparsha_string(g, israel=False):
+                    reading = self._reading(day.year, day.month, day.day)
+                    current = reading["triennial-year"]
+                    self.assertIn(current, (1, 2, 3))
+                    if previous is not None and current != previous:
+                        with self.subTest(date=day.isoformat()):
+                            # Bereshit is the first parshah of a cycle year, and the step is +1.
+                            # pyluach transliterates it "Bereishis".
+                            self.assertEqual(current, (previous % 3) + 1)
+                            self.assertEqual(reading["diaspora-parsha"], "bereishis")
+                        transitions += 1
+                    previous = current
+            day += timedelta(days=1)
+        self.assertEqual(transitions, 11)

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -846,6 +846,9 @@ The weekly parsha and special additions can also be calculated:
    <tei:f name="israel-parsha">
       <tei:string/>
    </tei:f>
+   <tei:f name="triennial-year">
+      <tei:numeric value="1"/>
+   </tei:f>
    <tei:f name="shabbat-shuva">
       <tei:binary/>
    </tei:f>
@@ -856,6 +859,9 @@ The weekly parsha and special additions can also be calculated:
       <tei:binary/>
    </tei:f>
    <tei:f name="shabbat-zachor">
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="shabbat-parah">
       <tei:binary/>
    </tei:f>
    <tei:f name="shabbat-hahodesh">
@@ -870,8 +876,24 @@ The weekly parsha and special additions can also be calculated:
    <tei:f name="shabbat-nahamu">
       <tei:binary/>
    </tei:f>
+   <tei:f name="shabbat-rosh-hodesh">
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="shabbat-mahar-hodesh">
+      <tei:binary/>
+   </tei:f>
 </tei:fs>
 ```
+
+The reading belongs to a week rather than to a day, so a document compiled on any day from
+Sunday onward selects the reading of that week's Shabbat.
+
+Every `shabbat-` feature except `shabbat-shira` is defined by the Hebrew date — each is the
+Shabbat on or before a fixed date — not by which parshah falls that week. `shabbat-shira` is
+the exception, since Shirat ha-Yam is in Beshalach. More than one may be true at once: in
+5785, 1 Adar falls on Shabbat and is both `shabbat-shkalim` and `shabbat-rosh-hodesh`.
+
+`triennial-year` is `1`, `2` or `3`, counting the modern triennial cycle from 5756.
 
 There are also special manual overrides available, which
 are never set automatically (they default to the `false` value)

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -893,7 +893,11 @@ Shabbat on or before a fixed date — not by which parshah falls that week. `sha
 the exception, since Shirat ha-Yam is in Beshalach. More than one may be true at once: in
 5785, 1 Adar falls on Shabbat and is both `shabbat-shkalim` and `shabbat-rosh-hodesh`.
 
-`triennial-year` is `1`, `2` or `3`, counting the modern triennial cycle from 5756.
+`triennial-year` is `1`, `2` or `3`, counting the modern triennial cycle from 5756. The cycle
+turns over at Simhat Torah rather than at Rosh Hashanah, so the Shabbatot of early Tishrei —
+Shabbat Shuva among them — still report the outgoing year. A single turnover date serves both
+rites: Simhat Torah is 22 Tishrei in Israel and 23 in the diaspora, but no Shabbat carrying a
+weekly parshah ever falls between the two.
 
 There are also special manual overrides available, which
 are never set automatically (they default to the `false` value)


### PR DESCRIPTION
`compute_torah_reading` detected the special Shabbatot by substring-matching the parshah name, which cannot work for occasions defined by the calendar: no parshah is named Shekalim, ha-Hodesh or ha-Gadol, so those three were permanently false, and `shabbat-zachor` tested the same substring twice. Only `shabbat-shira`, which really is defined by its parshah, behaved correctly.

## What changed

- Each occasion is now expressed as "the Shabbat on or before *fixed date*", which also handles the cases where the anchor date is itself Shabbat: Erev Pesah on Shabbat is Shabbat ha-Gadol, and 9 Av on Shabbat still reads Hazon. Adar II is used in leap years.
- Adds `shabbat-parah`, missing so that only three of the four parshiyot could be selected, and `shabbat-rosh-hodesh` / `shabbat-mahar-hodesh`, which carry their own haftarot. Several may be true at once: in 5785, 1 Adar is both Shekalim and Rosh Hodesh.
- Adds `triennial-year` (1–3, counted from 5756) for the modern triennial cycle.
- Resolves a date to its week's Shabbat, so a volume compiled midweek selects that week's reading rather than none.
- `schema/JLPTEI-3.md` documents the new features and the week-based resolution.

## Testing

New `TestSpecialShabbatot` covers the four parshiyot in both a leap and an ordinary year, the anchor-on-Shabbat edge cases, midweek resolution, and a sweep of Hebrew years 5784–5787 asserting each occasion falls exactly once a year.

`uv run pytest opensiddur/tests/exporter` passes (564). The 47 failures in the importer validation tests are the pre-existing missing compiled-schema artifacts in a fresh worktree documented in #57, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)