### PR TITLE
Document the opensiddur:rite setting for rite-varying passages

### DIFF
--- a/doc/exporter-settings.example.yaml
+++ b/doc/exporter-settings.example.yaml
@@ -61,6 +61,14 @@ declarations:
   # Textual variants are selected by URN; see the URN section of schema/JLPTEI-3.md.
   opensiddur:variant:
     urn:x-opensiddur:condition:haggadah:magid/lefikach/shira_chadasha: true
+  # Rite, for passages that differ by custom (most often the haftarah). Each rite is its own
+  # binary, so several may be true at once and every selected variant is kept. Omitting this
+  # group entirely leaves rite undefined, which keeps *all* variants along with the headings
+  # naming whose custom they are — usually what a printed volume wants. The list is open;
+  # see schema/JLPTEI-3.md for the known names.
+  opensiddur:rite:
+    ashkenaz: true
+    teimani_baladi: true
 
 # Output-format settings consumed by the TeX/PDF stage only.
 typography:

--- a/opensiddur/tests/exporter/test_conditional_integration.py
+++ b/opensiddur/tests/exporter/test_conditional_integration.py
@@ -330,5 +330,90 @@ class TestInlineConditionalTails(unittest.TestCase):
         self.assertNotIn("dropped", out)
 
 
+class TestRiteConditions(unittest.TestCase):
+    """The opensiddur:rite feature structure, as used by haftarah rite variants.
+
+    Rites are one independently settable binary feature each rather than a single
+    enumerated value, so that a comparative edition can select several at once and get
+    every selected variant. See schema/JLPTEI-3.md, "Rite".
+    """
+
+    def setUp(self):
+        reset_linear_data()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.base = Path(self.temp_dir.name)
+        self.project_dir = self.base / "test_project"
+        self.project_dir.mkdir(parents=True)
+        get_linear_data().xml_cache.base_path = self.base
+
+    def _variant(self, rite: str, heading: str, text: str) -> str:
+        return f'''
+            <j:conditional xml:id="rite_{rite}">
+                <tei:fs type="opensiddur:rite">
+                    <tei:f name="{rite}"><tei:binary value="true"/></tei:f>
+                </tei:fs>
+            </j:conditional>
+            <tei:div><tei:head>{heading}</tei:head><tei:p>{text}</tei:p></tei:div>
+            <j:endConditional target="#rite_{rite}"/>
+        '''
+
+    def _compile_with_rites(self, **rites: bool) -> str:
+        """Write a haftarah with three rite variants and compile it under the given rites."""
+        body = (
+            self._variant("ashkenaz", "מנהג אשכנז", "ashkenazi haftarah")
+            + self._variant("sepharad", "מנהג ספרד", "sephardi haftarah")
+            + self._variant("teimani_baladi", "מנהג תימן בלדי", "teimani haftarah")
+        )
+        path = self.project_dir / "haftarah.xml"
+        path.write_bytes(_text_xml(body))
+        if rites:
+            CompilerProcessor.load_init_settings(
+                get_linear_data(),
+                yaml_to_declaration_entries({"opensiddur:rite": dict(rites)}),
+            )
+        return etree.tostring(
+            CompilerProcessor("test_project", "haftarah.xml").process(), encoding="unicode"
+        )
+
+    def test_unset_rite_keeps_every_variant_with_its_heading(self):
+        """The default for a printed humash: no rite chosen, so all variants stay.
+
+        An undefined feature evaluates to UNDEFINED rather than false, which keeps the
+        passage together with the heading that says whose custom it is.
+        """
+        out = self._compile_with_rites()
+        for text in ("ashkenazi haftarah", "sephardi haftarah", "teimani haftarah"):
+            self.assertIn(text, out)
+        for heading in ("מנהג אשכנז", "מנהג ספרד", "מנהג תימן בלדי"):
+            self.assertIn(heading, out)
+
+    def test_single_rite_selects_only_that_variant(self):
+        out = self._compile_with_rites(ashkenaz=True, sepharad=False, teimani_baladi=False)
+        self.assertIn("ashkenazi haftarah", out)
+        self.assertNotIn("sephardi haftarah", out)
+        self.assertNotIn("teimani haftarah", out)
+
+    def test_two_rites_true_at_once_keep_both_variants(self):
+        """The reason rites are per-rite binaries: a comparative edition wants several."""
+        out = self._compile_with_rites(ashkenaz=True, sepharad=False, teimani_baladi=True)
+        self.assertIn("ashkenazi haftarah", out)
+        self.assertIn("teimani haftarah", out)
+        self.assertNotIn("sephardi haftarah", out)
+
+    def test_unlisted_rite_name_is_accepted(self):
+        """The rite list is open: a rite absent from the documented set still works."""
+        path = self.project_dir / "romaniote.xml"
+        path.write_bytes(_text_xml(self._variant("romaniote", "מנהג רומניוט", "romaniote haftarah")))
+        CompilerProcessor.load_init_settings(
+            get_linear_data(),
+            yaml_to_declaration_entries({"opensiddur:rite": {"romaniote": True}}),
+        )
+        out = etree.tostring(
+            CompilerProcessor("test_project", "romaniote.xml").process(), encoding="unicode"
+        )
+        self.assertIn("romaniote haftarah", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -933,6 +933,34 @@ and one setting selects it in both.
 </tei:fs>
 ```
 
+Passages that differ by rite — most commonly the haftarah read for a given parshah, but also
+some aliyah divisions — are selected by `opensiddur:rite`:
+```xml
+<tei:fs type="opensiddur:rite">
+   <tei:f name="ashkenaz">
+      <tei:binary value="true"/>
+   </tei:f>
+   <tei:f name="teimani_baladi">
+      <tei:binary value="true"/>
+   </tei:f>
+</tei:fs>
+```
+
+Each rite is its **own binary feature**, not a value of one enumerated feature, and **any
+number of them may be true at once**. A comparative edition that sets both `ashkenaz` and
+`teimani_baladi`, as above, gets both variants. Encode each variant as its own `tei:div` with
+a `tei:head` naming the custom, wrapped in a `j:conditional` on that rite's feature alone, so
+the variants evaluate independently of one another.
+
+Leaving `opensiddur:rite` unset is meaningful and is the right default for a printed volume:
+an undefined feature evaluates to undefined rather than to false, so every variant is kept
+together with the heading that says whose custom it is. This is unlike `opensiddur:override`,
+where undefined is equivalent to false.
+
+The feature set is open — a rite that is not listed below is still valid. Known rite names:
+`ashkenaz`, `sepharad`, `edot_hamizrach`, `teimani_baladi`, `teimani_shami`, `italiani`,
+`romaniote`, `nusach_ari`.
+
 The zman tefillah is also able to be calculated (though there may also be other settings required to determine how to calculate it):
 ```xml
 <tei:fs type="opensiddur:service-time">


### PR DESCRIPTION
## Summary

Documents `opensiddur:rite`, the feature structure used to select passages that differ by custom — most often the haftarah for a given parshah, but also some aliyah divisions.

The key points recorded in `schema/JLPTEI-3.md`:
- Each rite is its **own binary feature**, not a value of one enumerated feature, so a comparative edition can set several at once and keep every selected variant.
- Leaving `opensiddur:rite` unset is meaningful and is the right default for a printed volume: an undefined feature evaluates to undefined rather than false, so all variants are kept along with the `tei:head` naming whose custom each is. (Unlike `opensiddur:override`, where undefined behaves as false.)
- The feature set is open; the known rite names are listed but an unlisted one is still valid.

`doc/exporter-settings.example.yaml` gains a corresponding example block.

## Tests

Adds `TestRiteConditions` to `opensiddur/tests/exporter/test_conditional_integration.py`, covering all four documented behaviors: unset keeps every variant with its heading, a single rite selects only its variant, two rites true at once keep both, and an unlisted rite name works.

No compiler changes — this pins down and documents the intended use of the existing conditional machinery.

```
Ran 17 tests in 0.136s
OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)