### PR TITLE
Fix #53: don't resolve transclusions/annotations before a range's start

### DIFF
--- a/opensiddur/exporter/external_compiler.py
+++ b/opensiddur/exporter/external_compiler.py
@@ -780,13 +780,20 @@ class ExternalCompilerProcessor(CompilerProcessor):
             self._update_processing_context_after(element)
             return result
 
-        transcluded = self._transclude(element)
-        if transcluded is not None:
-            return [transcluded]
+        # Before the range's start, a transclusion or annotation must not be resolved at
+        # all: resolving it here would leak content that RECURSE is meant to suppress
+        # entirely (see #53), and would raise on an unresolvable target that will never
+        # actually appear in the output.
+        if context["command"] != _ProcessingCommand.RECURSE:
+            transcluded = self._transclude(element)
+            if transcluded is not None:
+                return [transcluded]
 
-        annotations, annotation_command = self._annotate(element, root)
-        if annotation_command == _AnnotationCommand.REPLACE:
-            return [annotations[0]]
+            annotations, annotation_command = self._annotate(element, root)
+            if annotation_command == _AnnotationCommand.REPLACE:
+                return [annotations[0]]
+        else:
+            annotations, annotation_command = [], _AnnotationCommand.NONE
 
         if context["command"] == _ProcessingCommand.RECURSE:
             append_to = processed

--- a/opensiddur/tests/exporter/test_external_compiler.py
+++ b/opensiddur/tests/exporter/test_external_compiler.py
@@ -695,6 +695,130 @@ class TestExternalCompilerProcessor(unittest.TestCase):
         self.assertIn("Nested tail 1", full_result)
         self.assertIn("Nested tail 2", full_result)
 
+    def test_transclusion_before_start_is_not_emitted(self):
+        """Regression (#53): a j:transclude preceding the range's start must not be resolved or emitted."""
+        main_xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0"
+                                     xmlns:jlp="http://jewishliturgy.org/ns/jlptei/2"
+                                     xmlns:xml="http://www.w3.org/XML/1998/namespace">
+    <tei:div>Main document text
+        <jlp:transclude target="#pre-fragment" type="external"/> Tail after pre-transclude (excluded)
+        <tei:p xml:id="start">Start element</tei:p> Tail after start
+        <jlp:transclude target="#fragment-start"
+                        targetEnd="#fragment-end"
+                        type="external"/> Tail after transclusion
+        <tei:p xml:id="end">End element</tei:p>
+    </tei:div>
+</root>'''
+
+        external_xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace">
+    <tei:div>External document text
+        <tei:p xml:id="pre-fragment">PRE-START LEAKED CONTENT</tei:p>
+        <tei:p xml:id="fragment-start" type="fragment" n="1">Transcluded start</tei:p>
+        <tei:p xml:id="fragment-end" type="fragment" n="3">Transcluded end</tei:p>
+    </tei:div>
+</root>'''
+
+        project, file_name = self._create_test_file("main.xml", main_xml_content)
+
+        external_tree = etree.fromstring(external_xml_content)
+        linear_data = get_linear_data()
+        original_parse_xml = linear_data.xml_cache.parse_xml
+
+        def mock_parse_xml(*args, **kwargs):
+            if len(args) == 1 and hasattr(args[0], '__fspath__'):
+                mock_tree = MagicMock()
+                mock_tree.getroot.return_value = external_tree
+                return mock_tree
+            elif len(args) == 2 and args[0] == 'external_project':
+                mock_tree = MagicMock()
+                mock_tree.getroot.return_value = external_tree
+                return mock_tree
+            else:
+                return original_parse_xml(*args, **kwargs)
+
+        ext_tree_root = etree.fromstring(external_xml_content)
+        ext_tree_obj = ext_tree_root.getroottree()
+        xml_ns = 'http://www.w3.org/XML/1998/namespace'
+
+        def ext_path(xml_id: str) -> str:
+            elem = ext_tree_root.xpath(f"//*[@xml:id='{xml_id}']", namespaces={'xml': xml_ns})[0]
+            return ext_tree_obj.getpath(elem)
+
+        resolve_range_calls = []
+
+        def mock_resolve_range(urn_range):
+            resolve_range_calls.append(urn_range)
+            if urn_range == "#pre-fragment":
+                return [ResolvedUrn(urn=urn_range, project="external_project",
+                                     file_name="external.xml", element_path=ext_path("pre-fragment"))]
+            elif urn_range == "#fragment-start":
+                return [ResolvedUrn(urn=urn_range, project="external_project",
+                                     file_name="external.xml", element_path=ext_path("fragment-start"))]
+            elif urn_range == "#fragment-end":
+                return [ResolvedUrn(urn=urn_range, project="external_project",
+                                     file_name="external.xml", element_path=ext_path("fragment-end"))]
+            return []
+
+        def mock_prioritize_range(urns, priority_list, return_all=False):
+            if urns and len(urns) > 0:
+                return urns[0]
+            return None
+
+        def mock_get_path_from_urn(resolved_urn):
+            return Path(self.temp_dir.name) / "external_project" / "external.xml"
+
+        start_path = self._get_element_path(main_xml_content, "#start")
+        end_path = self._get_element_path(main_xml_content, "#end")
+
+        with patch.object(linear_data.xml_cache, 'parse_xml', side_effect=mock_parse_xml):
+            with patch('opensiddur.exporter.compiler.UrnResolver.resolve_range', side_effect=mock_resolve_range):
+                with patch('opensiddur.exporter.compiler.UrnResolver.prioritize_range', side_effect=mock_prioritize_range):
+                    with patch('opensiddur.exporter.compiler.UrnResolver.get_path_from_urn', side_effect=mock_get_path_from_urn):
+                        processor = ExternalCompilerProcessor(project, file_name, start_path, end_path)
+                        result = processor.process()
+
+        result_strs = [etree.tostring(elem, encoding='unicode') for elem in result]
+        full_result = ''.join(result_strs)
+
+        # The pre-start transclusion must not have leaked into the output...
+        self.assertNotIn("PRE-START LEAKED CONTENT", full_result)
+        # ...and must never have been resolved at all (not just resolved-then-discarded).
+        self.assertNotIn("#pre-fragment", resolve_range_calls)
+
+        # The in-range transclusion is still resolved normally (positive control).
+        self.assertIn("Transcluded start", full_result)
+        self.assertIn("Transcluded end", full_result)
+
+    def test_unresolvable_transclusion_before_start_is_ignored(self):
+        """Regression (#53): an unresolvable target on a pre-start transclusion must not raise."""
+        main_xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0"
+                                     xmlns:jlp="http://jewishliturgy.org/ns/jlptei/2"
+                                     xmlns:xml="http://www.w3.org/XML/1998/namespace">
+    <tei:div>Main document text
+        <jlp:transclude target="#does-not-exist" type="external"/> Tail after pre-transclude (excluded)
+        <tei:p xml:id="start">Start element</tei:p> Tail after start
+        <tei:p xml:id="end">End element</tei:p>
+    </tei:div>
+</root>'''
+
+        project, file_name = self._create_test_file("main.xml", main_xml_content)
+
+        def mock_resolve_range(urn_range):
+            # Unresolvable: no project defines this target.
+            return []
+
+        start_path = self._get_element_path(main_xml_content, "#start")
+        end_path = self._get_element_path(main_xml_content, "#end")
+
+        with patch('opensiddur.exporter.compiler.UrnResolver.resolve_range', side_effect=mock_resolve_range):
+            processor = ExternalCompilerProcessor(project, file_name, start_path, end_path)
+            result = processor.process()
+
+        result_strs = [etree.tostring(elem, encoding='unicode') for elem in result]
+        full_result = ''.join(result_strs)
+        self.assertIn("Start element", full_result)
+        self.assertIn("End element", full_result)
+
     def test_hierarchy_crossing_start_equals_end(self):
         """Test ExternalCompilerProcessor when start equals end (single element)."""
         xml_content = b'''<root xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace">


### PR DESCRIPTION
## Summary
- `ExternalCompilerProcessor._process_element` resolved `j:transclude`/annotations unconditionally, before checking `context['command']`, so a transclusion preceding a range's start leaked fully-resolved content into range-restricted output even though ordinary content before the start is correctly dropped.
- It also did wasted work (compiling a pre-start transclusion in full only to throw it away) and raised on an unresolvable target before the start, instead of ignoring it.
- Fix: gate transclusion/annotation resolution on `context["command"] != RECURSE`, which is exactly the "before start, not an ancestor" state that should emit nothing.
- The analogous gap in `_process_element_as_marker` (parallel/marker-mode transclusion) is left out of scope — narrower, unreached by any current project, and would need a larger state-tracking change; noted in a follow-up-worthy comment rather than bundled here.

Fixes #53.

## Test plan
- [x] Added `test_transclusion_before_start_is_not_emitted` and `test_unresolvable_transclusion_before_start_is_ignored` to `opensiddur/tests/exporter/test_external_compiler.py`; verified both fail against pre-fix code and pass with the fix.
- [x] `uv run pytest` — full suite: 1111 passed, 23 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)