### PR TITLE
Fix #50: same-page anchor links produce empty bible URNs

### DIFF
--- a/opensiddur/importer/jps1917/mediawiki_to_tei.xslt
+++ b/opensiddur/importer/jps1917/mediawiki_to_tei.xslt
@@ -363,14 +363,31 @@
 
 
     <xsl:template match="__link__">
-        <!-- parse out the book, chapter, and verse -->
-        <xsl:variable name="title" select="substring-after(@title, '/')"/>
-        <xsl:variable name="book" select="replace(lower-case(substring-before($title, '#')), ' ', '_')"/>
+        <!-- parse out the book, chapter, and verse. @title may name a page
+        (book/chapter:verse), be a same-page anchor with no page (#chapter:verse,
+        used for footnote cross-references within the book being converted), or
+        name a page with no anchor (a table-of-contents link). -->
+        <xsl:variable name="has-page" select="contains(@title, '/')"/>
+        <xsl:variable name="has-anchor" select="contains(@title, '#')"/>
+        <xsl:variable name="page-title" select="if ($has-page) then substring-after(@title, '/') else ()"/>
+        <xsl:variable name="anchor" select="if ($has-anchor) then substring-after(@title, '#') else ()"/>
+
+        <!-- a same-page anchor names no book, so fall back to the book being converted -->
+        <xsl:variable name="raw-book" select="
+            if (not($has-page)) then $book_name
+            else if ($has-anchor) then substring-before($page-title, '#')
+            else $page-title"/>
+        <xsl:variable name="book" select="replace(lower-case($raw-book), ' ', '_')"/>
         <xsl:variable name="book-1" select="replace($book, '^i_(.*)', '$1_1')"/>
         <xsl:variable name="book-2" select="replace($book-1, '^ii_(.*)', '$1_2')"/>
-        <xsl:variable name="chapter" select="substring-before(substring-after($title, '#'), ':')"/>
-        <xsl:variable name="verse" select="substring-after(substring-after($title, '#'), ':')"/>
-        <tei:ref target="urn:x-opensiddur:text:bible:{$book-2}/{$chapter}/{$verse}">
+
+        <xsl:variable name="target" select="
+            if ($has-anchor) then
+                concat('urn:x-opensiddur:text:bible:', $book-2, '/',
+                    substring-before($anchor, ':'), '/', substring-after($anchor, ':'))
+            else
+                concat('urn:x-opensiddur:text:bible:', $book-2)"/>
+        <tei:ref target="{$target}">
             <xsl:apply-templates select="node()"/>
         </tei:ref>
     </xsl:template>

--- a/opensiddur/tests/importer/jps1917/test_mediawiki_to_tei_xslt.py
+++ b/opensiddur/tests/importer/jps1917/test_mediawiki_to_tei_xslt.py
@@ -1,0 +1,87 @@
+"""Tests for the JPS 1917 MediaWiki → JLPTEI stylesheet
+(``opensiddur/importer/jps1917/mediawiki_to_tei.xslt``), focused on the
+``__link__`` template that resolves wikilinks to ``urn:x-opensiddur:text:bible:``
+targets.
+
+These run the transformation directly over hand-written intermediate XML, so
+they exercise the stylesheet without depending on real Wikisource pages.
+"""
+
+import unittest
+from pathlib import Path
+
+from lxml import etree
+
+from opensiddur.common.xslt import xslt_transform_string
+
+TEI_NS = "http://www.tei-c.org/ns/1.0"
+NS = {"tei": TEI_NS}
+
+MEDIAWIKI_TO_TEI_XSLT = (
+    Path(__file__).parents[3] / "importer" / "jps1917" / "mediawiki_to_tei.xslt"
+)
+
+
+def _transform(link_xml: str, book_name: str) -> etree._Element:
+    xml = f"<mediawikis>{link_xml}</mediawikis>"
+    outputs = xslt_transform_string(
+        MEDIAWIKI_TO_TEI_XSLT,
+        xml,
+        multiple_results=True,
+        xslt_params={"book_name": book_name, "is_section": False},
+    )
+    return etree.fromstring(f"<root xmlns:tei='{TEI_NS}'>{outputs['']}</root>")
+
+
+def _ref_target(link_xml: str, book_name: str = "genesis") -> str:
+    root = _transform(link_xml, book_name)
+    refs = root.findall(".//tei:ref", NS)
+    return refs[0].get("target")
+
+
+class TestLinkResolution(unittest.TestCase):
+    """Test resolution of __link__ wikilinks to bible URNs"""
+
+    def test_page_and_anchor(self):
+        """A link naming a page and a chapter:verse anchor resolves both."""
+        target = _ref_target(
+            '<__link__ title="Bible (Jewish Publication Society 1917)/Exodus#3:14">Exodus</__link__>'
+        )
+        self.assertEqual(target, "urn:x-opensiddur:text:bible:exodus/3/14")
+
+    def test_same_page_anchor_only(self):
+        """A same-page anchor (no page name) resolves against the book being
+        converted rather than producing an empty book segment. Regression
+        test for issue #50."""
+        target = _ref_target(
+            '<__link__ title="#19:20">verse 20</__link__>', book_name="genesis"
+        )
+        self.assertEqual(target, "urn:x-opensiddur:text:bible:genesis/19/20")
+
+    def test_same_page_anchor_roman_numeral_book(self):
+        """The book-name normalization (I/II -> _1/_2) is a no-op for an
+        already-normalized $book_name used on a same-page anchor."""
+        target = _ref_target(
+            '<__link__ title="#4:5">verse 5</__link__>', book_name="kings_1"
+        )
+        self.assertEqual(target, "urn:x-opensiddur:text:bible:kings_1/4/5")
+
+    def test_page_without_anchor(self):
+        """A link naming a page but no anchor (table-of-contents links)
+        degrades to a book-level URN instead of empty chapter/verse
+        segments."""
+        target = _ref_target(
+            '<__link__ title="Bible (Jewish Publication Society 1917)/Zephaniah">Zephaniah</__link__>'
+        )
+        self.assertEqual(target, "urn:x-opensiddur:text:bible:zephaniah")
+
+    def test_page_with_roman_numeral_book(self):
+        """Book normalization still applies for the page+anchor case."""
+        target = _ref_target(
+            '<__link__ title="Bible (Jewish Publication Society 1917)/I Kings#4:5">I Kings</__link__>'
+        )
+        self.assertEqual(target, "urn:x-opensiddur:text:bible:kings_1/4/5")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- The `__link__` template in `mediawiki_to_tei.xslt` assumed every wikilink named a page, splitting `@title` on `/` and `#`. Same-page anchors like `[[#19:20|verse 20]]` (footnote cross-references within the book being converted) carry `@title="#19:20"` with no page name, so book/chapter/verse all came out empty, producing `urn:x-opensiddur:text:bible://`.
- Resolves a same-page anchor's book against `$book_name` (the book being converted) instead of the parsed page title.
- Also fixes the noted milder gap: a page-only link with no anchor (table-of-contents links) now degrades to a book-level URN instead of emitting empty chapter/verse segments.

Fixes #50.

## Test plan
- [x] `uv run pytest opensiddur/tests/importer/jps1917/test_mediawiki_to_tei_xslt.py -v` — new tests covering page+anchor, anchor-only, page-only, and roman-numeral book normalization
- [x] `uv run pytest opensiddur/tests/importer/jps1917/` — no regressions (173 passed)
- [x] `uv run pytest` — full suite passes (1116 passed, 23 skipped)
- [x] Regenerated the 6 affected books in opensiddur-projects and confirmed `opensiddur.exporter.validate_urn_references jps1917 --index` now exits 0 with no unresolvable refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)