### PR TITLE
Fix single-verse transclusion ranges and language propagation in parallel transcludes

### DIFF
--- a/opensiddur/exporter/external_compiler.py
+++ b/opensiddur/exporter/external_compiler.py
@@ -349,7 +349,19 @@ class ExternalCompilerProcessor(CompilerProcessor):
                 transclude_el.get(f"{{{p_ns}}}file_name") or default_file,
             )
 
-        def make_rows(prim_flat, par_flat, prim_src, par_src):
+        def lang_of(transclude_el, default_lang):
+            """Language of a boundary transclude, falling back to the enclosing document.
+
+            Mirrors source_of(): a nested transclude may cross into a document in a
+            different language (e.g. an English translation transcluded into a Hebrew
+            humash), and each p:parallelItem must be stamped with the language of the
+            content it actually holds, not the language of the outermost stream.
+            """
+            if transclude_el is None:
+                return default_lang
+            return transclude_el.get(xml_lang) or default_lang
+
+        def make_rows(prim_flat, par_flat, prim_src, par_src, prim_lang, par_lang):
             prim_sub = ExternalCompilerProcessor._split_at_milestones(prim_flat, ns_map)
             par_sub = ExternalCompilerProcessor._split_at_milestones(par_flat, ns_map)
 
@@ -382,12 +394,12 @@ class ExternalCompilerProcessor(CompilerProcessor):
                     continue
                 rows.append(make_parallel(
                     column_order,
-                    make_item("primary", primary_lang, prim_src[0], prim_src[1], p_elems),
-                    make_item("parallel", parallel_lang, par_src[0], par_src[1], q_elems),
+                    make_item("primary", prim_lang, prim_src[0], prim_src[1], p_elems),
+                    make_item("parallel", par_lang, par_src[0], par_src[1], q_elems),
                 ))
             return rows
 
-        def assemble(prim_flat, par_flat, prim_src, par_src):
+        def assemble(prim_flat, par_flat, prim_src, par_src, prim_lang, par_lang):
             primary_segments, primary_transcludes = split_at_transcludes(prim_flat)
             parallel_segments, parallel_transcludes = split_at_transcludes(par_flat)
 
@@ -402,7 +414,7 @@ class ExternalCompilerProcessor(CompilerProcessor):
             output = []
             for i in range(max_segments):
                 output.extend(make_rows(
-                    primary_segments[i], parallel_segments[i], prim_src, par_src))
+                    primary_segments[i], parallel_segments[i], prim_src, par_src, prim_lang, par_lang))
 
                 if i < max_transcludes:
                     prim_t = primary_transcludes[i] if i < len(primary_transcludes) else None
@@ -421,10 +433,14 @@ class ExternalCompilerProcessor(CompilerProcessor):
                         # independent of the enclosing one rather than nested inside it.
                         # Items built from a transcluded document must be attributed to that
                         # document, not to the enclosing one: latex.py::get_file_references reads
-                        # these attributes to build the licence, credits and bibliography.
+                        # these attributes to build the licence, credits and bibliography, and
+                        # numbered-stream in reledmac.xslt reads @xml:lang to pick the stream's
+                        # typesetting direction, so a stale language here mislabels a translation
+                        # as the host document's language and gets it mirrored under RTL (#p856).
                         inner = assemble(
                             list(prim_t), list(par_t) if par_t is not None else [],
-                            source_of(prim_t, *prim_src), source_of(par_t, *par_src))
+                            source_of(prim_t, *prim_src), source_of(par_t, *par_src),
+                            lang_of(prim_t, prim_lang), lang_of(par_t, par_lang))
                         for child in inner:
                             combined.append(child)
 
@@ -434,7 +450,8 @@ class ExternalCompilerProcessor(CompilerProcessor):
 
         return assemble(
             primary, parallel,
-            (primary_project, primary_file), (parallel_project, parallel_file))
+            (primary_project, primary_file), (parallel_project, parallel_file),
+            primary_lang, parallel_lang)
 
     def _resolve_parallel_range(self, target: str, target_end: Optional[str], parallel_project: str):
         """Resolve a parallel URN to (project, file_name, from_start, to_end, include_tail).
@@ -736,19 +753,24 @@ class ExternalCompilerProcessor(CompilerProcessor):
         Update the processing context for the given element, after the element has been processed.
         """
         context = self.linear_data.processing_context[-1]
+
+        # A single-point range (start == end == deepest_common_ancestor) must still close here,
+        # since there is no deeper element for the end-element check below to ever run against.
+        is_end_element = (
+            not context['before_start']
+            and not context['after_end']
+            and element is self.end_element
+        )
+        if is_end_element:
+            context['after_end'] = True
+
         if element is self.deepest_common_ancestor:
             context['inside_deepest_common_ancestor'] = False
+            context["include_tail_after_end"] = self.include_tail_after_end if is_end_element else False
             return context
 
-
         # always reset the include_tail_after_end flag except for the one case where we are processing the end element
-        context["include_tail_after_end"] = False
-
-        if not context['before_start'] and not context['after_end']:
-            # between start and end
-            if element is self.end_element:
-                context['after_end'] = True
-                context["include_tail_after_end"] = self.include_tail_after_end
+        context["include_tail_after_end"] = self.include_tail_after_end if is_end_element else False
 
         context['element_path'] = None
         return context

--- a/opensiddur/tests/exporter/test_external_compiler.py
+++ b/opensiddur/tests/exporter/test_external_compiler.py
@@ -977,11 +977,12 @@ class TestExternalCompilerProcessor(unittest.TestCase):
         processor = ExternalCompilerProcessor(project, file_name, target_path, target_path)
         result = processor.process()
 
-        # Should return a list (may include content after the target due to implementation details)
+        # Regression (haftarah-length bug): a single-point range must not spill into
+        # whatever follows the target in the source document.
         self.assertIsInstance(result, list)
-        self.assertGreaterEqual(len(result), 1)
+        self.assertEqual(len(result), 1)
 
-        # First element should be the target div with all its children
+        # The element should be the target div with all its children
         self.assertEqual(result[0].tag, "{http://www.tei-c.org/ns/1.0}div")
         # xml:id should be rewritten with hash
         xml_id = result[0].get("{http://www.w3.org/XML/1998/namespace}id")
@@ -996,10 +997,48 @@ class TestExternalCompilerProcessor(unittest.TestCase):
         self.assertEqual(children[1].text, "Nested paragraph 2")
         self.assertIn("Nested tail 2", children[1].tail)
 
-        # Verify excluded content
-        result_str = etree.tostring(result[0], encoding='unicode')
+        # Verify excluded content, across the whole result (not just the first element)
+        result_str = "".join(etree.tostring(el, encoding='unicode') for el in result)
         self.assertNotIn("Before (excluded)", result_str)
         self.assertNotIn("After (excluded)", result_str)
+
+    def test_single_verse_milestone_range_does_not_spill_into_rest_of_document(self):
+        """Regression: a single-point (x-x) milestone range (e.g. joshua/6/27-6/27) must
+        stop at that milestone rather than running to the end of the source file, as it
+        did for the Ashkenaz/Sepharad Pesach I haftarah (Joshua 6:27)."""
+        xml_content = '''<tei:text xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="he">
+    <tei:div>
+        Text before verse 27
+        <tei:milestone type="verse" corresp="urn:x-opensiddur:text:bible:book/6/26"/>
+        Verse 26 text
+        <tei:milestone type="verse" corresp="urn:x-opensiddur:text:bible:book/6/27"/>
+        Verse 27 text
+        <tei:milestone type="verse" corresp="urn:x-opensiddur:text:bible:book/7/1"/>
+        Chapter 7 verse 1 text
+        <tei:milestone type="verse" corresp="urn:x-opensiddur:text:bible:book/24/33"/>
+        Last verse of the book
+    </tei:div>
+</tei:text>'''
+
+        project, file_name = self._create_test_file("book.xml", xml_content.encode('utf-8'))
+
+        root = etree.fromstring(xml_content.encode('utf-8'))
+        tree = root.getroottree()
+        milestone_elem = root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/6/27']")[0]
+        target_path = tree.getpath(milestone_elem)
+
+        # A single-point range: from_start and to_end are the same element.
+        processor = ExternalCompilerProcessor(project, file_name, target_path, target_path)
+        result = processor.process()
+
+        result_str = ''.join(etree.tostring(elem, encoding='unicode') for elem in result)
+
+        self.assertIn('corresp="urn:x-opensiddur:text:bible:book/6/27"', result_str)
+        self.assertNotIn("Verse 26 text", result_str)
+        self.assertNotIn("Chapter 7 verse 1 text", result_str)
+        self.assertNotIn("Last verse of the book", result_str)
+        self.assertNotIn('corresp="urn:x-opensiddur:text:bible:book/7/1"', result_str)
+        self.assertNotIn('corresp="urn:x-opensiddur:text:bible:book/24/33"', result_str)
 
     def test_hierarchy_crossing_end_is_descendant_of_start(self):
         """Test ExternalCompilerProcessor when end is a descendant of start."""

--- a/opensiddur/tests/exporter/test_parallel_compiler.py
+++ b/opensiddur/tests/exporter/test_parallel_compiler.py
@@ -101,10 +101,12 @@ class TestAssembleParallelStreams(unittest.TestCase):
         el.text = text
         return el
 
-    def _transclude(self, target="urn:test@orig", *children):
+    def _transclude(self, target="urn:test@orig", *children, lang=None):
         el = etree.Element(f"{{{P_NS}}}transclude", nsmap=self.ns)
         el.set("target", target)
         el.set("type", "external")
+        if lang:
+            el.set(f"{{{XML_NS}}}lang", lang)
         for child in (children or (self._div("inner"),)):
             el.append(child)
         return el
@@ -206,6 +208,45 @@ class TestAssembleParallelStreams(unittest.TestCase):
         assert_parallel_invariants(self, result)
         for par_el in result[0].iter(f"{{{P_NS}}}parallel"):
             self.assertEqual(len(list(par_el)), 2)
+
+    def test_nested_transclude_language_override_propagates(self):
+        """Regression (#p856): a nested transclude into a different-language document must
+        stamp its own p:parallelItem with that document's language, not the outer stream's.
+
+        The Ki Tisa haftarah (Hebrew humash) transcludes 1 Kings 8 from the jps1917 English
+        translation; the resulting p:parallelItem kept the outer xml:lang="he", so
+        reledmac.xslt wrapped the genuinely-English text in \\begin{hebrew}, and pdfTeX's
+        \\textdir primitive mirrored it (backwards English on the printed page).
+        """
+        prim_inner = self._transclude("urn:inner@orig", self._div("english text"), lang="en")
+        par_inner = self._transclude("urn:inner@trans", self._div("hebrew parallel"), lang="he")
+        prim_outer = self._transclude("urn:outer@orig", self._div("a"), prim_inner)
+        par_outer = self._transclude("urn:outer@trans", self._div("pa"), par_inner)
+
+        result = self._assemble([prim_outer], [par_outer])
+
+        outer = result[0]
+        inner_transclude = [c for c in outer if etree.QName(c).localname == "transclude"][0]
+        inner_parallel = list(inner_transclude)[0]
+        prim_item, par_item = list(inner_parallel)
+        self.assertEqual(prim_item.get(f"{{{XML_NS}}}lang"), "en")
+        self.assertEqual(par_item.get(f"{{{XML_NS}}}lang"), "he")
+
+    def test_nested_transclude_without_lang_override_inherits_outer_language(self):
+        """A nested transclude that doesn't declare its own xml:lang keeps the outer language."""
+        prim_inner = self._transclude("urn:inner@orig", self._div("deep"))
+        par_inner = self._transclude("urn:inner@trans", self._div("deep-par"))
+        prim_outer = self._transclude("urn:outer@orig", self._div("a"), prim_inner)
+        par_outer = self._transclude("urn:outer@trans", self._div("pa"), par_inner)
+
+        result = self._assemble([prim_outer], [par_outer])
+
+        outer = result[0]
+        inner_transclude = [c for c in outer if etree.QName(c).localname == "transclude"][0]
+        inner_parallel = list(inner_transclude)[0]
+        prim_item, par_item = list(inner_parallel)
+        self.assertEqual(prim_item.get(f"{{{XML_NS}}}lang"), "he")
+        self.assertEqual(par_item.get(f"{{{XML_NS}}}lang"), "en")
 
     def test_milestone_alignment_survives_inside_nested_transclude(self):
         def _ms(corresp):


### PR DESCRIPTION
## Summary
- A single-point `j:transclude` range (start == end, e.g. `joshua/6/27-6/27`) never set `after_end` in `_update_processing_context_after`, because the deepest-common-ancestor early return fired before the end-element check. This made the compiler copy every following sibling in the source document — the cause of the Ashkenaz/Sepharad Pesach I haftarah running all the way to the end of the Book of Joshua.
- `_assemble_parallel_streams` re-derived project/file attribution at each nested-transclude recursion depth via `source_of()`, but never refreshed the language the same way, so a `p:parallelItem` built from a nested transclude into a different-language document kept the outer stream's `xml:lang`. `reledmac.xslt` picks a stream's typesetting direction from that attribute, so English text transcluded into a Hebrew document got wrapped in `\begin{hebrew}` and mirrored by pdfTeX's RTL primitive (backwards English on printed pages, e.g. Haftarat Ki Tisa's 1 Kings 8 text on humash p856).

## Test plan
- [x] Added regression tests in `test_external_compiler.py` and `test_parallel_compiler.py`, confirmed each fails against the pre-fix code and passes with the fix
- [x] `uv run pytest` — full suite passes (1121 passed, 23 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)