### PR TITLE
Fix Sukkot Chol HaMoed maftir labels leaking raw source keys

### DIFF
--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -83,6 +83,12 @@ ALIYAH_TITLES = {
 
 WEEKDAY_TITLES = {"1": "כֹּהֵן", "2": "לֵוִי", "3": "יִשְׂרָאֵל"}
 
+# Sukkot's Chol HaMoed Shabbat maftir varies by which intermediate day it falls on
+# ("maftir_day1".."maftir_day5"). Latin/digits here would be reversed when set in the
+# surrounding right-to-left text, same as TRIENNIAL_YEARS below, so days are spelled out
+# as Hebrew letters rather than left as the raw source label.
+MAFTIR_DAY_LETTERS = {1: "א׳", 2: "ב׳", 3: "ג׳", 4: "ד׳", 5: "ה׳"}
+
 
 def _escape(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
@@ -156,6 +162,9 @@ def _milestone_title(span: ReadingSpan) -> str:
     if span.unit == UNIT_WEEKDAY:
         return WEEKDAY_TITLES.get(label, label)
     if span.unit == UNIT_MAFTIR:
+        if label.startswith("maftir_day"):
+            day = int(label[len("maftir_day"):])
+            return f"{ALIYAH_TITLES['maftir']} לְיוֹם {MAFTIR_DAY_LETTERS[day]}"
         return ALIYAH_TITLES["maftir"]
     if span.unit in (UNIT_PARSHA, UNIT_PARSHA_COMBINED):
         return SLUG_TO_HEBREW.get(label, label)

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -197,10 +197,19 @@ def festival_readings(sourcetexts_root: Path | None = None) -> dict[str, dict]:
         aliyot_spans: list[ReadingSpan] = []
         for label, value in entry.get("fullkriyah", {}).items():
             book = BOOK_NUMBER_TO_SLUG[value["k"]]
-            unit = UNIT_MAFTIR if label == "M" else UNIT_ALIYAH
+            # Most festivals have one maftir, keyed "M". Sukkot's Chol HaMoed Shabbat has a
+            # different maftir per weekday of the intermediate days, keyed "M-day1".."M-day5".
+            is_maftir = label == "M" or label.startswith("M-day")
+            unit = UNIT_MAFTIR if is_maftir else UNIT_ALIYAH
+            if label == "M":
+                normalized_label = "maftir"
+            elif is_maftir:
+                normalized_label = f"maftir_{label[len('M-'):]}"
+            else:
+                normalized_label = label
             aliyot_spans.append(ReadingSpan(
                 unit=unit,
-                label="maftir" if label == "M" else label,
+                label=normalized_label,
                 start=parse_hebcal_ref(book, value["b"]),
                 end=parse_hebcal_ref(book, value["e"]),
                 numbering=NUMBERING_COMMON,

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -16,6 +16,7 @@ from opensiddur.importer.humash.readings import Passage
 from opensiddur.importer.humash.refs import (
     UNIT_ALIYAH,
     UNIT_ALIYAH_COMBINED,
+    UNIT_MAFTIR,
     ReadingSpan,
     VerseRef,
     triennial_unit,
@@ -301,3 +302,29 @@ class TestBookFile(unittest.TestCase):
             [target.rsplit("/", 1)[1] for target in targets],
             ["vayikra", PAIR, "emor"],
         )
+
+
+class TestMaftirMilestoneTitle(unittest.TestCase):
+    """Regression: Sukkot Chol HaMoed's per-day maftir labels ("maftir_day1", etc., after
+    readings.festival_readings normalizes them) used to have no entry in ALIYAH_TITLES and
+    so fell back to the raw label, which is Latin text with no place inside a Hebrew RTL
+    milestone (it prints mirrored, as `readings.py`'s TRIENNIAL_YEARS comment warns).
+    """
+
+    def test_ordinary_maftir_is_unchanged(self):
+        span = _span(UNIT_MAFTIR, "maftir", (1, 1), (1, 1))
+        self.assertEqual(build._milestone_title(span), "מַפְטִיר")
+
+    def test_a_days_maftir_gets_a_hebrew_day_qualified_title(self):
+        span = _span(UNIT_MAFTIR, "maftir_day1", (1, 1), (1, 1))
+        title = build._milestone_title(span)
+        self.assertNotIn("day", title.lower())
+        self.assertNotIn("1", title)
+        self.assertIn("מַפְטִיר", title)
+
+    def test_each_day_gets_a_distinct_title(self):
+        titles = {
+            build._milestone_title(_span(UNIT_MAFTIR, f"maftir_day{day}", (1, 1), (1, 1)))
+            for day in (1, 2, 3, 4, 5)
+        }
+        self.assertEqual(len(titles), 5)

--- a/opensiddur/tests/importer/humash/test_readings.py
+++ b/opensiddur/tests/importer/humash/test_readings.py
@@ -13,10 +13,12 @@ import unittest
 from pathlib import Path
 
 from opensiddur.importer.humash.readings import (
+    festival_readings,
     triennial,
     triennial_haftarot,
     triennial_patterns,
 )
+from opensiddur.importer.humash.refs import UNIT_ALIYAH, UNIT_MAFTIR
 
 
 def _aliyot(chapter: int) -> dict[str, list[str]]:
@@ -202,3 +204,67 @@ class TestTriennialHaftarot(unittest.TestCase):
     def test_an_occasion_that_is_not_a_parshah_is_dropped(self):
         self.assertNotIn("tisha_bav", self.haftarot)
         self.assertEqual(sorted(self.haftarot), ["bereshit", "noach", "tazria"])
+
+
+HOLIDAY_READINGS_FIXTURE = {
+    # Ordinary festival: one maftir, keyed "M".
+    "Pesach I": {
+        "fullkriyah": {
+            "1": {"k": 2, "b": "12:21", "e": "12:28"},
+            "M": {"k": 4, "b": "28:16", "e": "28:25"},
+        },
+    },
+    # Sukkot's Chol HaMoed Shabbat: the maftir varies by which intermediate day it is,
+    # keyed "M-day1".."M-day5" rather than a plain "M" (real hebcal shape).
+    "Sukkot Shabbat Chol ha-Moed": {
+        "fullkriyah": {
+            "1": {"k": 2, "b": "33:12", "e": "33:16"},
+            "M-day1": {"k": 4, "b": "29:17", "e": "29:22"},
+            "M-day2": {"k": 4, "b": "29:20", "e": "29:25"},
+            "M-day5": {"k": 4, "b": "29:29", "e": "29:34"},
+        },
+    },
+}
+
+
+class TestFestivalReadingsMaftir(unittest.TestCase):
+    """Regression: Sukkot Chol HaMoed's per-day maftir keys ("M-day1"..) used to fall
+    through to UNIT_ALIYAH with the raw, untranslated key kept as the label, which then
+    surfaced as backwards-looking raw English ("M-day1") inside an all-Hebrew RTL milestone.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "holiday-readings.json").write_text(
+            json.dumps(HOLIDAY_READINGS_FIXTURE), encoding="utf-8"
+        )
+        self.festivals = festival_readings(self.root)
+
+    def _span(self, occasion: str, label: str):
+        spans = self.festivals[occasion]["aliyot"]
+        matches = [span for span in spans if span.label == label]
+        self.assertEqual(len(matches), 1, f"expected exactly one span labeled {label!r}")
+        return matches[0]
+
+    def test_ordinary_single_maftir_is_normalized_to_maftir(self):
+        span = self._span("pesach_i", "maftir")
+        self.assertEqual(span.unit, UNIT_MAFTIR)
+
+    def test_sukkot_chol_hamoed_day_maftirs_are_recognized_as_maftir(self):
+        for day in (1, 2, 5):
+            span = self._span("sukkot_shabbat_chol_ha_moed", f"maftir_day{day}")
+            self.assertEqual(span.unit, UNIT_MAFTIR)
+
+    def test_sukkot_chol_hamoed_day_maftirs_are_not_left_as_raw_source_keys(self):
+        labels = {span.label for span in self.festivals["sukkot_shabbat_chol_ha_moed"]["aliyot"]}
+        self.assertNotIn("M-day1", labels)
+        self.assertNotIn("M-day2", labels)
+        self.assertNotIn("M-day5", labels)
+
+    def test_sukkot_chol_hamoed_non_maftir_aliyah_is_unaffected(self):
+        span = self._span("sukkot_shabbat_chol_ha_moed", "1")
+        self.assertEqual(span.unit, UNIT_ALIYAH)


### PR DESCRIPTION
## Summary
- hebcal's `holiday-readings.json` keys Sukkot Shabbat Chol ha-Moed's maftir per weekday (`M-day1`..`M-day5`) instead of the plain `M` every other festival uses. `readings.py`'s `festival_readings()` only exact-matched `"M"`, so these fell into the aliyah branch with `unit=UNIT_ALIYAH` and kept the raw `"M-day1"` string as their label.
- `build.py`'s `_milestone_title` then had no `ALIYAH_TITLES` entry for that label and returned it unchanged, so the milestone's `n=` attribute ended up as untranslated Latin text sitting inside all-Hebrew RTL content — the same failure mode the existing `TRIENNIAL_YEARS` comment already documents for cycle-year digits, just not yet applied here.
- Normalizes `"M-day<N>"` to `unit=UNIT_MAFTIR` with label `"maftir_day<N>"`, and gives `_milestone_title` a Hebrew day-qualified title (`מַפְטִיר לְיוֹם <letter>`) for it.

## Test plan
- [x] Added regression tests in `test_readings.py` and `test_build.py`, confirmed each fails against the pre-fix code and passes with the fix
- [x] `uv run pytest` — full suite passes (1211 passed, 23 skipped)
- [x] Regenerate `reading_sukkot_shabbat_chol_ha_moed.xml` via the importer and visually confirm the maftir milestones are Hebrew, not `M-day1`..`M-day5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)