### PR TITLE
Fix miqra_al_pi_hamasorah converter to cover all 24 books

### DIFF
--- a/opensiddur/importer/miqra_al_pi_hamasorah/convert_tsv.py
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/convert_tsv.py
@@ -103,13 +103,13 @@ TANAKH_INDEX: list[Index] = [
                 file_name="the_prophets",
                 transclusions=[
                     Book("יהושע", "Joshua", "joshua"),
-                    Book("שפטים", "Judges", "judges"),
+                    Book("שופטים", "Judges", "judges"),
                     Book("שמואל א", "I Samuel", "samuel_1"),
                     Book("שמואל ב", "II Samuel", "samuel_2"),
                     Book("מלכים א", "I Kings", "kings_1"),
                     Book("מלכים ב", "II Kings", "kings_2"),
-                    Book("ישעיה", "Isaiah", "isaiah"),
-                    Book("ירמיה", "Jeremiah", "jeremiah"),
+                    Book("ישעיהו", "Isaiah", "isaiah"),
+                    Book("ירמיהו", "Jeremiah", "jeremiah"),
                     Book("יחזקאל", "Ezekiel", "ezekiel"),
                     Index(
                         index_title_en="The Twelve",
@@ -121,7 +121,7 @@ TANAKH_INDEX: list[Index] = [
                             Book("הושע", "Hosea", "hosea"),
                             Book("יואל", "Joel", "joel"),
                             Book("עמוס", "Amos", "amos"),
-                            Book("עובדיה", "Obadiah", "obadiah"),
+                            Book("עבדיה", "Obadiah", "obadiah"),
                             Book("יונה", "Jonah", "jonah"),
                             Book("מיכה", "Micah", "micah"),
                             Book("נחום", "Nahum", "nahum"),
@@ -259,14 +259,39 @@ def _xml_escape(text: str) -> str:
     )
 
 
-_PAGE_KEY_RE = re.compile(r"^\s*(?:ספר\s+)?(?P<book>[^/]+)\s*/\s*(?P<chapter>[^/\s]+)\s*$")
+_PAGE_KEY_RE = re.compile(r"^\s*(?:(?:ספר|מגילת)\s+)?(?P<book>[^/]+)\s*/\s*(?P<rest>.+?)\s*$")
+
+# Some sheet tabs group several books under one outer "ספר X" label, with the
+# actual sub-book abbreviated and embedded alongside the chapter numeral in
+# the second field (e.g. "ספר שמואל/שמ""א א" -> sub-book שמ"א, chapter א).
+_SUBBOOK_ABBREVIATIONS = {
+    'שמ"א': "שמואל א",
+    'שמ"ב': "שמואל ב",
+    'מל"א': "מלכים א",
+    'מל"ב': "מלכים ב",
+    'דה"א': "דברי הימים א",
+    'דה"ב': "דברי הימים ב",
+}
 
 
-def _book_key_from_page_key(page_key: str) -> Optional[str]:
+def _split_page_key(page_key: str) -> Optional[tuple[str, str]]:
+    """Resolve a page key to (book_name_he, chapter_token), or None if unparseable."""
     m = _PAGE_KEY_RE.match(page_key or "")
     if not m:
         return None
-    return m.group("book").strip()
+    outer_book = m.group("book").strip()
+    rest = m.group("rest").strip()
+    parts = rest.split(None, 1)
+    if len(parts) == 2:
+        sub_label, chapter_token = parts
+        book = _SUBBOOK_ABBREVIATIONS.get(sub_label, sub_label)
+        return book, chapter_token
+    return outer_book, rest
+
+
+def _book_key_from_page_key(page_key: str) -> Optional[str]:
+    parsed = _split_page_key(page_key)
+    return parsed[0] if parsed else None
 
 
 _HEBREW_NUM_RE = re.compile(r"^[\u05d0-\u05ea\"׳״\s]+$")
@@ -349,10 +374,10 @@ def _valid_urn_segment(value: str) -> str:
 
 
 def _chapter_from_page_key(page_key: str) -> str:
-    m = _PAGE_KEY_RE.match(page_key or "")
-    if not m:
+    parsed = _split_page_key(page_key)
+    if not parsed:
         return ""
-    return _normalize_to_arabic_numerals(m.group("chapter").strip())
+    return _normalize_to_arabic_numerals(parsed[1])
 
 
 def _extract_m_pasuk(scaffold_wikitext: str) -> tuple[str, str]:

--- a/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_convert_tsv.py
+++ b/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_convert_tsv.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -5,9 +7,18 @@ import tempfile
 
 
 from opensiddur.importer.miqra_al_pi_hamasorah.convert_tsv import (
+    _book_key_from_page_key,
+    _chapter_from_page_key,
     _extract_chapter_verse_numbers,
+    _split_page_key,
     main,
 )
+
+
+def _tsv_rows(*rows: list[str]) -> str:
+    buf = io.StringIO()
+    csv.writer(buf, delimiter="\t").writerows(rows)
+    return buf.getvalue()
 
 
 class TestMiqraConvertTsv(unittest.TestCase):
@@ -141,6 +152,166 @@ class TestMiqraConvertTsv(unittest.TestCase):
             self.assertIn("urn:x-opensiddur:text:bible:exodus/15/1", xml)
             self.assertNotIn("צורת-השיר", xml)
             self.assertNotIn("השיר|", xml)
+
+
+    @patch("opensiddur.importer.miqra_al_pi_hamasorah.convert_tsv.validate")
+    def test_split_book_tab_writes_samuel_1(self, mock_validate):
+        # neviim_rishonim.tsv groups Samuel under one outer "ספר שמואל" label,
+        # with the sub-book abbreviation (שמ"א) embedded alongside the chapter.
+        mock_validate.return_value = (True, [])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            sourcetexts_root = tmp_path / "sources"
+            sheets_dir = sourcetexts_root / "miqra_al_pi_hamasorah" / "sheets"
+            sheets_dir.mkdir(parents=True, exist_ok=True)
+
+            (sheets_dir / "neviim_rishonim.tsv").write_text(
+                _tsv_rows(
+                    ["Page key", "Row id", "Nav", "Scaffold", "Text"],
+                    [
+                        'ספר שמואל/שמ"א א',
+                        "א",
+                        "",
+                        "{{מ:פסוק|שמואל א|1|1}}",
+                        "וַיְהִי אִישׁ אֶחָד",
+                    ],
+                ),
+                encoding="utf-8",
+            )
+
+            project_dir = tmp_path / "project"
+            rc = main(
+                [
+                    "--sourcetexts-root",
+                    str(sourcetexts_root),
+                    "--project-dir",
+                    str(project_dir),
+                    "--only-book",
+                    "samuel_1",
+                ]
+            )
+            self.assertEqual(rc, 0)
+
+            xml = (project_dir / "samuel_1.xml").read_text(encoding="utf-8")
+            self.assertIn("urn:x-opensiddur:text:bible:samuel_1/1/1", xml)
+            self.assertIn("וַיְהִי אִישׁ אֶחָד", xml)
+
+    @patch("opensiddur.importer.miqra_al_pi_hamasorah.convert_tsv.validate")
+    def test_twelve_tab_writes_hosea(self, mock_validate):
+        # neviim_acharonim.tsv groups the Twelve Minor Prophets under one outer
+        # "ספר תרי עשר" label, with the actual book name embedded alongside
+        # the chapter (e.g. "הושע א").
+        mock_validate.return_value = (True, [])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            sourcetexts_root = tmp_path / "sources"
+            sheets_dir = sourcetexts_root / "miqra_al_pi_hamasorah" / "sheets"
+            sheets_dir.mkdir(parents=True, exist_ok=True)
+
+            (sheets_dir / "neviim_acharonim.tsv").write_text(
+                _tsv_rows(
+                    ["Page key", "Row id", "Nav", "Scaffold", "Text"],
+                    [
+                        "ספר תרי עשר/הושע א",
+                        "א",
+                        "",
+                        "{{מ:פסוק|הושע|1|1}}",
+                        "דְּבַר יְהוָה",
+                    ],
+                ),
+                encoding="utf-8",
+            )
+
+            project_dir = tmp_path / "project"
+            rc = main(
+                [
+                    "--sourcetexts-root",
+                    str(sourcetexts_root),
+                    "--project-dir",
+                    str(project_dir),
+                    "--only-book",
+                    "hosea",
+                ]
+            )
+            self.assertEqual(rc, 0)
+
+            xml = (project_dir / "hosea.xml").read_text(encoding="utf-8")
+            self.assertIn("urn:x-opensiddur:text:bible:hosea/1/1", xml)
+            self.assertIn("דְּבַר יְהוָה", xml)
+
+    @patch("opensiddur.importer.miqra_al_pi_hamasorah.convert_tsv.validate")
+    def test_megillot_tab_writes_ruth(self, mock_validate):
+        # chamisha_megillot.tsv uses the "מגילת " prefix instead of "ספר ".
+        mock_validate.return_value = (True, [])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            sourcetexts_root = tmp_path / "sources"
+            sheets_dir = sourcetexts_root / "miqra_al_pi_hamasorah" / "sheets"
+            sheets_dir.mkdir(parents=True, exist_ok=True)
+
+            (sheets_dir / "chamisha_megillot.tsv").write_text(
+                _tsv_rows(
+                    ["Page key", "Row id", "Nav", "Scaffold", "Text"],
+                    [
+                        "מגילת רות/א",
+                        "א",
+                        "",
+                        "{{מ:פסוק|רות|1|1}}",
+                        "וַיְהִי בִּימֵי",
+                    ],
+                ),
+                encoding="utf-8",
+            )
+
+            project_dir = tmp_path / "project"
+            rc = main(
+                [
+                    "--sourcetexts-root",
+                    str(sourcetexts_root),
+                    "--project-dir",
+                    str(project_dir),
+                    "--only-book",
+                    "ruth",
+                ]
+            )
+            self.assertEqual(rc, 0)
+
+            xml = (project_dir / "ruth.xml").read_text(encoding="utf-8")
+            self.assertIn("urn:x-opensiddur:text:bible:ruth/1/1", xml)
+            self.assertIn("וַיְהִי בִּימֵי", xml)
+
+    def test_split_page_key_resolves_subbook_abbreviations(self):
+        self.assertEqual(
+            _split_page_key('ספר שמואל/שמ"א א'), ("שמואל א", "א")
+        )
+        self.assertEqual(
+            _split_page_key('ספר מלכים/מל"ב יג'), ("מלכים ב", "יג")
+        )
+        self.assertEqual(
+            _split_page_key('ספר דברי הימים/דה"א ג'), ("דברי הימים א", "ג")
+        )
+
+    def test_split_page_key_resolves_full_subbook_labels(self):
+        # The Twelve and Ezra/Nehemiah sub-labels already match TANAKH_INDEX
+        # names verbatim, so no abbreviation lookup is needed for them.
+        self.assertEqual(_split_page_key("ספר תרי עשר/הושע א"), ("הושע", "א"))
+        self.assertEqual(_split_page_key("ספר עזרא/נחמיה ה"), ("נחמיה", "ה"))
+        self.assertEqual(_split_page_key("ספר עזרא/עזרא ב"), ("עזרא", "ב"))
+
+    def test_split_page_key_strips_megillat_prefix(self):
+        self.assertEqual(_split_page_key("מגילת איכה/ג"), ("איכה", "ג"))
+
+    def test_split_page_key_ungrouped_book(self):
+        self.assertEqual(_split_page_key("ספר בראשית/א"), ("בראשית", "א"))
+
+    def test_book_and_chapter_from_page_key_wrappers(self):
+        self.assertEqual(_book_key_from_page_key('ספר שמואל/שמ"א א'), "שמואל א")
+        self.assertEqual(_chapter_from_page_key('ספר שמואל/שמ"א א'), "1")
+        self.assertEqual(_book_key_from_page_key(""), None)
+        self.assertEqual(_chapter_from_page_key(""), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- The page-key parser silently dropped rows from sheet tabs that group several books under one outer label (Samuel, Kings, Chronicles, the Twelve, Ezra/Nehemiah) because the chapter regex couldn't handle a sub-book label embedded alongside the chapter numeral.
- The `מגילת ` (Megillat) prefix used by the Five Scrolls tab was never stripped (only `ספר ` was).
- `TANAKH_INDEX`'s hardcoded Hebrew spellings for Judges/Isaiah/Jeremiah/Obadiah didn't match the source's spelling, so those books' rows never matched either.
- Together these accounted for the gap between 11/39 book files having real content and the full 39.

## Test plan
- [x] `uv run pytest` — 1129 passed, 0 regressions
- [x] Added unit coverage for split-book tabs (Samuel), the Twelve, Megillot prefix stripping, and the new `_split_page_key` helper directly
- [x] Regenerated all 39 books against the real source data (see companion `opensiddur-projects` PR) and confirmed chapter/verse counts match the standard Masoretic count for every book checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)