### PR TITLE
Fix Latin manuscript sigla rendering backwards in Hebrew MAM notes

### DIFF
--- a/opensiddur/exporter/tex/reledmac.xslt
+++ b/opensiddur/exporter/tex/reledmac.xslt
@@ -940,7 +940,14 @@
          ==================================================================== -->
 
     <xsl:template match="text()" mode="emit">
-        <xsl:value-of select="f:escape-tex(.)"/>
+        <xsl:choose>
+            <xsl:when test="f:is-hebrew-lang(f:in-scope-lang(.))">
+                <xsl:value-of select="f:emit-bidi-text(string(.))"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="f:escape-tex(.)"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <!-- Headings are centered with symmetric fill glue, which only exists on the first
@@ -1400,6 +1407,29 @@
         <xsl:variable name="t3" select="replace($t2, '~', '\\textasciitilde{}')"/>
         <xsl:variable name="t4" select="replace($t3, '\^', '\\textasciicircum{}')"/>
         <xsl:sequence select="$t4"/>
+    </xsl:function>
+
+    <!-- Sources like the MAM apparatus notes are Hebrew prose that embeds short Latin
+         tokens (manuscript sigla such as "EVR-II-B-8", "BHS"). \textdir TRT forces the
+         whole Hebrew note into strict RTL layout (note-content), which has no per-run
+         bidi detection, so an embedded Latin token renders with its characters
+         back-to-front unless explicitly switched back to LTR. Wrap each such token the
+         same way \vno/\chno/note-content already wrap other LTR content in RTL context,
+         leaving a hyphen that merely touches Hebrew (e.g. "פטרבורג-EVR-II-B-8") outside
+         the wrap so its direction still resolves normally. -->
+    <xsl:function name="f:emit-bidi-text" as="xs:string">
+        <xsl:param name="s" as="xs:string"/>
+        <xsl:variable name="parts" as="xs:string*">
+            <xsl:analyze-string select="$s" regex="[A-Za-z0-9]+([-'.][A-Za-z0-9]+)*">
+                <xsl:matching-substring>
+                    <xsl:sequence select="concat('{{\textdir TLT\selectlanguage{english}', f:escape-tex(.), '}}')"/>
+                </xsl:matching-substring>
+                <xsl:non-matching-substring>
+                    <xsl:sequence select="f:escape-tex(.)"/>
+                </xsl:non-matching-substring>
+            </xsl:analyze-string>
+        </xsl:variable>
+        <xsl:sequence select="string-join($parts, '')"/>
     </xsl:function>
 
     <xsl:function name="f:escape-url" as="xs:string">

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -557,6 +557,57 @@ class TestNotesMapping(unittest.TestCase):
         self.assertIn(r"{{\textdir TLT\selectlanguage{english} English note}}", out)
         self.assertIn(r"{{\textdir TLT\selectlanguage{english} Inline English instruction}}", out)
 
+    def test_hebrew_note_wraps_embedded_latin_siglum(self):
+        """MAM apparatus notes are Hebrew prose that embeds Latin manuscript
+        sigla, e.g. "פטרבורג-EVR-II-B-8". \\textdir TRT forces the whole note
+        into strict RTL, which has no per-run bidi detection, so an embedded
+        Latin token renders back-to-front unless it gets its own explicit LTR
+        override — same as digits already get in \\vno/\\chno."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace">
+          <tei:text><tei:body>
+            <tei:p>
+              <tei:milestone unit="verse" n="1"/>טקסט<tei:note xml:lang="he">פטרבורג-EVR-II-B-8 ומ""ג</tei:note>
+            </tei:p>
+          </tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml)
+        self.assertIn(r"{{\textdir TLT\selectlanguage{english}EVR-II-B-8}}", out)
+        # The hyphen joining the Hebrew word to the siglum stays outside the
+        # wrap; only the Latin/digit token itself is switched to LTR.
+        self.assertIn("פטרבורג-{{\\textdir TLT\\selectlanguage{english}EVR-II-B-8}}", out)
+
+    def test_pure_hebrew_note_has_no_spurious_latin_wrap(self):
+        """Hebrew abbreviation punctuation (ASCII gershayim, e.g. מ""ג) must
+        not be mistaken for a Latin run: it contains no [A-Za-z0-9], so it
+        should pass through unwrapped."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace">
+          <tei:text><tei:body>
+            <tei:p>
+              <tei:milestone unit="verse" n="1"/>טקסט<tei:note xml:lang="he">וכך מ""ג ודותן</tei:note>
+            </tei:p>
+          </tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml)
+        self.assertNotIn(r"\textdir TLT", out.split(r"\notenote{", 1)[1])
+
+    def test_english_context_latin_text_not_double_wrapped(self):
+        """Latin text already in an LTR (English) context must go through
+        plain escaping, not the Hebrew-context bidi wrapper — that would be
+        redundant with note-content's own English-note wrap."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en">
+          <tei:text><tei:body>
+            <tei:p>
+              <tei:milestone unit="verse" n="1"/>Manuscript EVR-II-B-8 is cited here.
+            </tei:p>
+          </tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml)
+        self.assertNotIn(r"\textdir TLT\selectlanguage{english}EVR-II-B-8", out)
+        self.assertIn("EVR-II-B-8", out)
+
 
 class TestInlineFormatting(unittest.TestCase):
     """Inline formatting elements that survived the compiler should map to


### PR DESCRIPTION
## Summary
- MAM apparatus notes are Hebrew prose (`xml:lang="he"`) that embed short Latin manuscript sigla, e.g. `פטרבורג-EVR-II-B-8`. Verified the imported/compiled project XML stores these tokens in correct logical order, so the reversal happens only at PDF-export time.
- `reledmac.xslt` forces the whole Hebrew note into strict RTL via `\textdir TRT`, which has no per-run bidi detection — the same class of bug already fixed elsewhere in this file for verse numbers, chapter numbers, and line numbers, but not for arbitrary embedded Latin substrings inside note prose.
- Adds `f:emit-bidi-text`, which finds Latin/digit tokens in Hebrew-context text nodes and wraps each in `{{\textdir TLT\selectlanguage{english}...}}`, reusing the file's existing LTR-wrap convention. A hyphen merely touching Hebrew (e.g. the `-` in `פטרבורג-EVR-II-B-8`) is left outside the wrap so it still resolves normally.

## Test plan
- [x] New unit tests in `test_reledmac_xslt.py`: embedded Latin siglum gets wrapped; pure-Hebrew abbreviation punctuation (ASCII gershayim, e.g. `מ""ג`) is *not* mistaken for Latin; Latin text already in an English context is not double-wrapped.
- [x] `uv run pytest opensiddur/tests/exporter/test_reledmac_xslt.py` — 69 passed
- [x] `uv run pytest` (full suite) — 1132 passed, 23 skipped (pre-existing), no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)