### PR TITLE
Match parallel root documents by URN, not by file name

### DIFF
--- a/opensiddur/exporter/external_compiler.py
+++ b/opensiddur/exporter/external_compiler.py
@@ -1,5 +1,6 @@
 """External compiler processor for processing specific ranges of XML files."""
 
+import logging
 import re
 from contextlib import contextmanager
 from typing import Any, Optional
@@ -29,6 +30,8 @@ from opensiddur.exporter.marker_reconstruct import (
     doc_needs_marker_reconstruction,
     reconstruct_markered_document,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _attrs_structural_original(source: ElementBase) -> dict[str, str]:
@@ -499,6 +502,9 @@ class ExternalCompilerProcessor(CompilerProcessor):
 
             return p_project, p_file, p_start, p_end, p_tail
         except Exception:
+            logger.warning(
+                "parallel: could not resolve %s in project %s; that project contributes no "
+                "parallel column here", parallel_target, parallel_project, exc_info=True)
             return None
 
     def _transclude_parallel(self, element: ElementBase, transclude_range: ResolvedUrnRange, transclusion_type: str) -> Optional[ElementBase]:
@@ -555,6 +561,10 @@ class ExternalCompilerProcessor(CompilerProcessor):
                     parallel_file = p_file
                     break
                 except Exception:
+                    logger.warning(
+                        "parallel: compiling %s/%s as the parallel column for %s failed; "
+                        "trying the next configured parallel project",
+                        p_project, p_file, target, exc_info=True)
                     continue
 
         if parallel_result is None:
@@ -612,8 +622,83 @@ class ExternalCompilerProcessor(CompilerProcessor):
             self.linear_data.project_priority = saved_priority
             self.linear_data.instruction_priority = saved_instr
 
-    def _process_parallel_root(self) -> list[ElementBase]:
-        """Compile this file in parallel mode, replacing tei:body with p:parallel content."""
+    def _root_correspondence_urn(self) -> Optional[str]:
+        """The URN identifying this document as a whole, for parallel-column matching.
+
+        Prefers the @corresp of the body's first tei:div, which is what the reference
+        database indexes; falls back to the header's URN idno with any @project stripped.
+        Returns None if the document declares neither.
+        """
+        body_div = self.root_tree.find(
+            f"{{{TEI_NS}}}text/{{{TEI_NS}}}body/{{{TEI_NS}}}div")
+        if body_div is not None and body_div.get('corresp'):
+            return body_div.get('corresp')
+
+        idno = self.root_tree.find(
+            f"{{{TEI_NS}}}teiHeader//{{{TEI_NS}}}idno[@type='urn']")
+        if idno is not None and idno.text:
+            return re.sub(r'@[\w-]+$', '', idno.text.strip())
+
+        return None
+
+    def _select_root_parallel_project(self) -> Optional[tuple[str, str]]:
+        """Pick the project holding this document's counterpart, as (project, file_name).
+
+        Correspondence is decided by URN, not by file name: two documents pair up only when
+        the parallel project actually contains this document's URN. Matching on file name
+        alone pairs unrelated documents that happen to share a name -- every project has an
+        index.xml -- which silently commits the whole compilation to a bogus column pairing
+        and suppresses the per-transclusion parallels that would have been correct.
+
+        Returns None when this document has no counterpart, which is the normal case for a
+        project that holds no text of its own and only transcludes (its URNs are private to
+        it, while its transclusion *targets* are what the parallel project shares).
+        """
+        root_urn = self._root_correspondence_urn()
+        if root_urn is None:
+            logger.warning(
+                "parallel: %s/%s declares no URN, so no parallel counterpart can be "
+                "identified; falling back to per-transclusion parallels",
+                self.project, self.file_name)
+            return None
+
+        for proj in self.linear_data.parallel_projects:
+            # Never parallelize a project against itself.
+            if proj == self.project:
+                continue
+            try:
+                resolved = self._urn_resolver.resolve_range(
+                    self._build_parallel_urn(root_urn, proj))
+            except Exception:
+                logger.warning(
+                    "parallel: resolving %s in project %s failed", root_urn, proj,
+                    exc_info=True)
+                continue
+            if not resolved:
+                continue
+            match = resolved[0]
+            file_name = (match.start.file_name
+                         if isinstance(match, ResolvedUrnRange) else match.file_name)
+            return proj, file_name
+
+        logger.warning(
+            "parallel: %s (%s/%s) has no counterpart in any configured parallel project "
+            "(%s); falling back to per-transclusion parallels",
+            root_urn, self.project, self.file_name,
+            ", ".join(self.linear_data.parallel_projects) or "none")
+        return None
+
+    def _process_parallel_root(self) -> Optional[list[ElementBase]]:
+        """Compile this file in parallel mode, replacing tei:body with p:parallel content.
+
+        Returns None if no parallel project holds a counterpart of this document, signalling
+        the caller to compile normally so that each transclusion can pair itself instead.
+        """
+        selected = self._select_root_parallel_project()
+        if selected is None:
+            return None
+        parallel_project, parallel_file = selected
+
         with self._parallel_sub_compilation():
             primary_proc = ExternalCompilerProcessor(
                 self.project, self.file_name,
@@ -622,30 +707,24 @@ class ExternalCompilerProcessor(CompilerProcessor):
             primary_proc.marker_stack = []
             primary_result = primary_proc.process()
 
-            parallel_result = None
-            parallel_project = None
-            parallel_file = self.file_name
-            parallel_proc = None
-
-            for proj in self.linear_data.parallel_projects:
-                # Never parallelize a project against itself.
-                if proj == self.project:
-                    continue
-                try:
-                    with self._parallel_priority(proj):
-                        parallel_proc = ExternalCompilerProcessor(
-                            proj, self.file_name,
-                            linear_data=self.linear_data,
-                            reference_database=self._refdb)
-                        parallel_proc.marker_stack = []
-                        parallel_result = parallel_proc.process()
-                    parallel_project = proj
-                    break
-                except Exception:
-                    continue
+            try:
+                with self._parallel_priority(parallel_project):
+                    parallel_proc = ExternalCompilerProcessor(
+                        parallel_project, parallel_file,
+                        linear_data=self.linear_data,
+                        reference_database=self._refdb)
+                    parallel_proc.marker_stack = []
+                    parallel_result = parallel_proc.process()
+            except Exception:
+                logger.warning(
+                    "parallel: compiling %s/%s as the parallel column for %s/%s failed; "
+                    "falling back to per-transclusion parallels",
+                    parallel_project, parallel_file, self.project, self.file_name,
+                    exc_info=True)
+                parallel_result = None
 
         if parallel_result is None:
-            return primary_result
+            return None
 
         def _body_children(result):
             for el in result:
@@ -891,8 +970,14 @@ class ExternalCompilerProcessor(CompilerProcessor):
 
         if is_root and self.linear_data.parallel_projects and not self._in_parallel_compilation:
             processed = self._process_parallel_root()
-            _reconstruct_if_needed(processed)
-            return processed
+            if processed is not None:
+                _reconstruct_if_needed(processed)
+                return processed
+            # No counterpart document: fall through to the normal path, which leaves
+            # parallel_compilation_depth at 0 so that _transclude_parallel pairs each
+            # external transclusion individually. A project that only arranges transclusions
+            # (a humash built from Tanakh verses) has no document-level counterpart at all --
+            # its correspondence with the parallel project lives entirely in its targets.
 
         # set the root language to the language of the deepest common ancestor if present, else root
         self.root_language = self._get_in_scope_language(

--- a/opensiddur/tests/exporter/test_parallel_compiler.py
+++ b/opensiddur/tests/exporter/test_parallel_compiler.py
@@ -616,6 +616,22 @@ class TestParallelCompilationFlag(_ProcessorBase):
             proc.process()
             mock_root.assert_called_once()
 
+    def test_root_returning_none_falls_through_to_normal_compilation(self):
+        """No root counterpart must not abort parallel processing, only defer it.
+
+        Returning None leaves parallel_compilation_depth at 0 so that each transclusion
+        pairs itself; swallowing it here would drop the parallel column entirely.
+        """
+        self.linear_data.parallel_projects = ["some-proj"]
+        proc = self._make_processor(in_parallel_compilation=False)
+
+        with patch.object(proc, "_process_parallel_root", return_value=None) as mock_root:
+            result = proc.process()
+            mock_root.assert_called_once()
+
+        self.assertEqual(self.linear_data.parallel_compilation_depth, 0)
+        self.assertTrue(result, "compilation must still produce output")
+
     def test_structural_elements_always_get_markers_in_marker_mode(self):
         """In marker mode, all structural elements get start/end marker pairs."""
         proc = self._make_processor(in_parallel_compilation=True)

--- a/opensiddur/tests/exporter/test_parallel_e2e.py
+++ b/opensiddur/tests/exporter/test_parallel_e2e.py
@@ -88,6 +88,9 @@ class _E2EBase(unittest.TestCase):
     PRIMARY_PROJECT = "primary-proj"
     PARALLEL_PROJECT = "parallel-proj"
     PARALLEL_CORRESP = {
+        # The root document's own URN: both fixtures carry it on tei:body/tei:div/@corresp,
+        # so they genuinely correspond and root-level parallel applies to them.
+        "urn:x-test:section",
         "urn:x-test:section/1",
         "urn:x-test:section/2",
     }
@@ -496,6 +499,184 @@ class TestThreeWayTransclusionE2E(_E2EBase):
         self.assertNotIn("English verse", primary_text,
                          "translation must not leak into the primary column")
         self.assertIn("English verse", parallel_text)
+
+
+# ── Arrangement projects (a wrapper that holds no text of its own) ────────────
+
+class TestArrangementProjectRootE2E(_E2EBase):
+    """A wrapper project that only arranges transclusions has no document-level counterpart.
+
+    Regression: the root document used to be paired with whichever parallel project merely
+    contained a file of the same name. Every project has an index.xml, so an arrangement
+    project (a humash built by transcluding Tanakh verses) was paired with an unrelated
+    index, and that pairing suppressed the per-transclusion parallels that were the only
+    real correspondence. The result was a Hebrew source facing itself, with the translation
+    absent from the output entirely.
+    """
+
+    WRAPPER_URN = "urn:x-test:arrangement"
+    ENGLISH_PROJECT = "english-proj"
+
+    _UNRELATED_INDEX_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0"
+         xmlns:j="http://jewishliturgy.org/ns/jlptei/2"
+         xml:lang="he">
+  <tei:teiHeader>
+    <tei:fileDesc>
+      <tei:titleStmt><tei:title>Whole Collection</tei:title></tei:titleStmt>
+      <tei:publicationStmt>
+        <tei:distributor><tei:ref target="http://e.org">e</tei:ref></tei:distributor>
+        <tei:availability status="free">
+          <tei:licence target="http://creativecommons.org/publicdomain/zero/1.0/">CC0</tei:licence>
+        </tei:availability>
+      </tei:publicationStmt>
+      <tei:sourceDesc><tei:bibl xml:id="usrc"><tei:title>U</tei:title></tei:bibl></tei:sourceDesc>
+    </tei:fileDesc>
+  </tei:teiHeader>
+  <tei:text xml:lang="he">
+    <tei:body>
+      <tei:div corresp="urn:x-test:collection">
+        <tei:p>Front matter of the whole collection.</tei:p>
+      </tei:div>
+    </tei:body>
+  </tei:text>
+</tei:TEI>"""
+
+    _WRAPPER_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0"
+         xmlns:j="http://jewishliturgy.org/ns/jlptei/2"
+         xml:lang="he">
+  <tei:teiHeader>
+    <tei:fileDesc>
+      <tei:titleStmt><tei:title>Arrangement</tei:title></tei:titleStmt>
+      <tei:publicationStmt>
+        <tei:distributor><tei:ref target="http://e.org">e</tei:ref></tei:distributor>
+        <tei:availability status="free">
+          <tei:licence target="http://creativecommons.org/publicdomain/zero/1.0/">CC0</tei:licence>
+        </tei:availability>
+      </tei:publicationStmt>
+      <tei:sourceDesc><tei:bibl xml:id="wsrc"><tei:title>W</tei:title></tei:bibl></tei:sourceDesc>
+    </tei:fileDesc>
+  </tei:teiHeader>
+  <tei:text xml:lang="he">
+    <tei:body>
+      <tei:div corresp="urn:x-test:arrangement">
+        <tei:head>Arrangement</tei:head>
+        <j:transclude type="external" target="urn:x-test:section/1"/>
+      </tei:div>
+    </tei:body>
+  </tei:text>
+</tei:TEI>"""
+
+    def setUp(self):
+        super().setUp()
+        base = Path(self.temp_dir.name)
+        (base / self.ENGLISH_PROJECT).mkdir()
+
+        # The wrapper is the compilation root and holds no text of its own.
+        (base / self.PRIMARY_PROJECT / "index.xml").write_bytes(self._WRAPPER_XML)
+        # The Hebrew project plays MAM's role: it supplies the transcluded verses *and*
+        # owns an index.xml that has nothing to do with the wrapper. That file-name
+        # collision is what used to be mistaken for a correspondence.
+        (base / self.PARALLEL_PROJECT / "index.xml").write_bytes(self._UNRELATED_INDEX_XML)
+        (base / self.PARALLEL_PROJECT / "verses.xml").write_bytes(_PRIMARY_XML)
+        # The English project plays jps1917's role: the translation, listed second.
+        (base / self.ENGLISH_PROJECT / "verses.xml").write_bytes(_PARALLEL_XML)
+
+        # Hebrew first, exactly as the real settings list MAM before jps1917.
+        self.linear_data.parallel_projects = [self.PARALLEL_PROJECT, self.ENGLISH_PROJECT]
+        self.linear_data.project_priority = [
+            self.PRIMARY_PROJECT, self.PARALLEL_PROJECT, self.ENGLISH_PROJECT]
+
+    def _milestone_path(self, xml_bytes, n):
+        tree_root = etree.fromstring(xml_bytes)
+        milestone = tree_root.xpath(
+            f"//tei:milestone[@n='{n}']",
+            namespaces={"tei": TEI_NS})[0]
+        return tree_root.getroottree().getpath(milestone)
+
+    def _mock_resolve_range(self, urn):
+        base_urn, _, hint = urn.partition("@")
+        # The wrapper's own URN is private to the arrangement project: no parallel
+        # project contains it, so no root-level pairing is possible.
+        if base_urn == self.WRAPPER_URN:
+            return []
+        if base_urn == "urn:x-test:collection":
+            return [ResolvedUrn(
+                urn=base_urn, project=self.PARALLEL_PROJECT, file_name="index.xml",
+                element_path="/tei:TEI")]
+        if base_urn == "urn:x-test:section/1":
+            if hint == self.ENGLISH_PROJECT:
+                project, xml_bytes = self.ENGLISH_PROJECT, _PARALLEL_XML
+            else:
+                project, xml_bytes = self.PARALLEL_PROJECT, _PRIMARY_XML
+            path = self._milestone_path(xml_bytes, "1")
+            return [ResolvedUrn(
+                urn=base_urn, project=project, file_name="verses.xml",
+                element_path=path, end_element_path=path, end_includes_tail=True)]
+        return []
+
+    def _compile_wrapper(self):
+        proc = ExternalCompilerProcessor(
+            self.PRIMARY_PROJECT, "index.xml", linear_data=self.linear_data)
+        with patch.object(UrnResolver, "resolve_range", side_effect=self._mock_resolve_range):
+            with patch.object(UrnResolver, "prioritize_range",
+                              side_effect=lambda urns, priority, return_all=False: (
+                                  urns[0] if urns else None)):
+                return proc.process()
+
+    def _compiled_root(self):
+        result = self._compile_wrapper()
+        result_xml = "".join(etree.tostring(el, encoding="unicode") for el in result)
+        return etree.fromstring(f"<root>{result_xml}</root>")
+
+    def test_no_root_parallel_is_selected(self):
+        """The wrapper's URN resolves in no parallel project, so root pairing is declined."""
+        proc = ExternalCompilerProcessor(
+            self.PRIMARY_PROJECT, "index.xml", linear_data=self.linear_data)
+        with patch.object(UrnResolver, "resolve_range", side_effect=self._mock_resolve_range):
+            self.assertIsNone(proc._select_root_parallel_project())
+
+    def test_same_file_name_does_not_make_a_counterpart(self):
+        """The Hebrew project's index.xml exists but is a different document, so it loses.
+
+        Both files are named index.xml; only their URNs distinguish them.
+        """
+        proc = ExternalCompilerProcessor(
+            self.PRIMARY_PROJECT, "index.xml", linear_data=self.linear_data)
+        self.assertEqual(proc._root_correspondence_urn(), self.WRAPPER_URN)
+        with patch.object(UrnResolver, "resolve_range", side_effect=self._mock_resolve_range):
+            self.assertIsNone(proc._process_parallel_root())
+
+    def test_translation_reaches_the_output(self):
+        """The whole point: English must be present, via the per-transclusion parallel."""
+        root = self._compiled_root()
+
+        parallel_text = " ".join(
+            "".join(item.itertext())
+            for item in root.findall(f".//{{{P_NS}}}parallelItem[@role='parallel']"))
+        self.assertIn("English verse 1", parallel_text)
+
+    def test_columns_are_not_the_same_source(self):
+        """No row may draw both of its columns from the same project."""
+        parallels = self._compiled_root().findall(f".//{{{P_NS}}}parallel")
+        self.assertGreater(len(parallels), 0, "expected per-transclusion parallels")
+
+        for par in parallels:
+            primary = par.find(f"{{{P_NS}}}parallelItem[@role='primary']")
+            parallel = par.find(f"{{{P_NS}}}parallelItem[@role='parallel']")
+            self.assertNotEqual(
+                primary.get(f"{{{P_NS}}}project"),
+                parallel.get(f"{{{P_NS}}}project"),
+                "a parallel row must not have the same source in both columns")
+
+    def test_columns_carry_distinct_languages(self):
+        root = self._compiled_root()
+        for par in root.findall(f".//{{{P_NS}}}parallel"):
+            primary = par.find(f"{{{P_NS}}}parallelItem[@role='primary']")
+            parallel = par.find(f"{{{P_NS}}}parallelItem[@role='parallel']")
+            self.assertEqual(primary.get(f"{{{XML_NS}}}lang"), "he")
+            self.assertEqual(parallel.get(f"{{{XML_NS}}}lang"), "en")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Compiling the humash with `settings-parallel.yaml` produced **no English at all** — both columns were Miqra al pi ha-Masorah. In the previous output, every `p:parallelItem[@role="parallel"]` was `p:project="miqra_al_pi_hamasorah"` and the string `jps1917` appeared zero times.

## Root cause

`_process_parallel_root` selected the parallel column by **file-name identity across projects**:

```python
for proj in self.linear_data.parallel_projects:
    if proj == self.project:      # only guards literal self-parallel
        continue
    ...ExternalCompilerProcessor(proj, self.file_name, ...)   # same file name, other project
    break
```

Compilation starts at `humash/index.xml`, so `miqra_al_pi_hamasorah/index.xml` won the filename match and `break`'d — jps1917 was never tried. The two documents are unrelated: `corresp="urn:x-opensiddur:text:bible:humash"` (60 transclusions of parshiyot and haftarot) against `corresp="urn:x-opensiddur:text:bible:index"` (3 transclusions: law/prophets/writings). They collided only because every project has an `index.xml`.

That pairing removed the translation twice over:

1. The humash holds no text of its own — its primary stream resolves down to MAM under `priority.transclusion`, so the result was **MAM facing itself**.
2. Both root sub-compilations run inside `_parallel_sub_compilation()`, which suppressed `_transclude_parallel` at **every depth below the root** — the machinery that already pairs MAM against jps1917 correctly.

Reordering `parallel.projects` would not have fixed it: `jps1917/index.xml` (`corresp="…:bible:tanakh"`, 3 transclusions) would then win the same filename match against humash's 60 and zip into misaligned garbage.

### Why the URN namespaces make this the right fix

| pair | shared URNs |
|---|---|
| `miqra_al_pi_hamasorah` ∩ `jps1917` | **23,228** |
| `humash` ∩ `miqra_al_pi_hamasorah` | **0** |
| `humash` ∩ `jps1917` | **0** |

MAM and JPS both use `urn:x-opensiddur:text:bible:{book}/{chapter}/{verse}` and both stamp it on `tei:milestone[@unit="verse"]/@corresp`, so the transclusion targets *and* the row-alignment keys read by `_split_at_milestones` match. humash occupies a separate arrangement namespace (`bible:parsha/…`, `bible:reading/…`) with aliyah/parsha milestones, never verses.

**Only humash's transclusion *references* need to be shared, not humash's own identifiers.** An arrangement project isn't required to have a counterpart document anywhere — it only has to point, at its leaves, into a namespace the parallel project also populates. The old code demanded a document-level pairing and settled for a filename coincidence to fake one.

## Fix

- Gate root pairing on **URN correspondence** — new `_root_correspondence_urn()` (body div `@corresp`, falling back to the header URN `idno`) and `_select_root_parallel_project()`, reusing the existing `_build_parallel_urn` and `UrnResolver.resolve_range`.
- `_process_parallel_root` now returns `Optional[...]`; `None` means no counterpart, and `process()` **falls through to the normal path**, which leaves `parallel_compilation_depth` at 0 so each transclusion pairs itself.
- Added a module logger and warnings at the four sites that were silently swallowing parallel-resolution failures, so a missing column is visible in the build log instead of absent without explanation.

No change to `settings-parallel.yaml`. Leaving `miqra_al_pi_hamasorah` in `parallel.projects` is harmless — at verse level MAM is the *primary*, so the self-guard skips it — and keeps the fix honest: the code, not config ordering, is what makes the English appear.

## Verification

Full humash recompiled with the real `settings-parallel.yaml`:

| | before | after |
|---|---|---|
| rows with the same project in both columns | 322+ | **0** |
| rows sourcing `jps1917` | 0 | 19,645 |
| column language pairs | — | **19,672 × (he, en)** |

Text is genuinely aligned — `בְּרֵאשִׁית…` ↔ "In the beginning God created the heaven and the earth." The build log emits exactly one warning, naming the URN and the projects tried.

**Tests: 1145 passed, 21 skipped.** The 5 new `TestArrangementProjectRootE2E` tests reproduce the bug faithfully — each was verified to **fail** against the unfixed compiler with the reported symptoms (`'parallel-proj' == 'parallel-proj'`, `'he' != 'en'`, English absent). The first draft of that fixture passed unfixed, so it was rebuilt as a three-project setup where the colliding `index.xml` is an unrelated document that is *also* the transclusion source — MAM's actual role.

One existing fixture changed: `test_parallel_e2e.py`'s two documents already share `corresp="urn:x-test:section"`, so they genuinely correspond; that URN was added to the mocked `PARALLEL_CORRESP` set so the mock answers the new root gate.

## Noticed, not addressed

- **27 rows source Hebrew from `wlc` rather than MAM** — Exodus 20 verses, where MAM's dual-cantillation encoding leaves those URNs unmapped, so the declared `wlc` fallback supplies them. Correct per the priority list, and English still appears. Possibly related to `fix/miqra-book-coverage`.
- **`jps1917/genesis.xml` carries 50 `unit="chapter"` and 12 `unit="parsha"` milestones MAM lacks** (verse counts 1533 vs 1534), so a range crossing a chapter boundary can emit a JPS-only row with an empty Hebrew column. Pre-existing cosmetic misalignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)