### PR TITLE
Give the bible URN space one canonical verse division

### DIFF
--- a/opensiddur/common/versification.py
+++ b/opensiddur/common/versification.py
@@ -1,0 +1,279 @@
+"""Canonical verse numbering for the ``urn:x-opensiddur:text:bible:`` URN space.
+
+A verse URN is the only join key between projects: the parallel compiler pairs two
+documents' text by exact ``@corresp`` equality, and the reference database resolves
+transclusion ranges by it. That only works if ``exodus/20/13`` denotes the same stretch of
+text in every project, which is not true of the editions' own numbering.
+
+**The canonical division.** A canonical verse boundary is any point that is a verse boundary
+under *either* ta'am elyon or ta'am tachton. In the Decalogue the two cantillations divide
+differently -- ta'am tachton merges the four short commandments into one verse and splits
+אנכי from לא יהיה לך, ta'am elyon does the reverse -- so their union is finer than either.
+That union is what the Leningrad Codex numbers, giving Exodus 20 = 26 verses and
+Deuteronomy 5 = 33. Every edition's own division is a coarsening of it, so an edition verse
+is always a whole number of consecutive canonical verses.
+
+Outside the Decalogue the editions still disagree in a handful of places, for reasons that
+have nothing to do with cantillation. Those are recorded in :data:`DIVERGENCES` below.
+
+**What this module is not.** It does not map the Decalogue. MAM ships both cantillation
+strands, so its importer derives the canonical boundaries from its own source rather than
+from a table here (see ``importer/miqra_al_pi_hamasorah``); a table would be a second,
+divergent statement of the same fact. The Decalogue entries here exist only so that
+references *stated* in an edition's numbering -- hebcal aliyah boundaries, a cross-reference
+in a translation -- can be resolved to canonical.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterator, NamedTuple
+
+# Verse numbering conventions, and the project that follows each.
+NUMBERING_MASORAH = "masorah"       # Miqra al pi ha-Masorah
+NUMBERING_LENINGRAD = "leningrad"   # Westminster Leningrad Codex -- the canonical numbering
+NUMBERING_COMMON = "common"         # common printed editions, which hebcal and jps1917 follow
+
+NUMBERINGS = (NUMBERING_MASORAH, NUMBERING_LENINGRAD, NUMBERING_COMMON)
+
+#: The numbering the canonical URN space uses. ``wlc`` needs no mapping at all.
+CANONICAL_NUMBERING = NUMBERING_LENINGRAD
+
+NUMBERING_PROJECT = {
+    NUMBERING_MASORAH: "miqra_al_pi_hamasorah",
+    NUMBERING_LENINGRAD: "wlc",
+    NUMBERING_COMMON: "jps1917",
+}
+
+PROJECT_NUMBERING = {project: numbering for numbering, project in NUMBERING_PROJECT.items()}
+
+
+class VerseRef(NamedTuple):
+    """A chapter and verse within a book."""
+
+    chapter: int
+    verse: int
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.chapter}:{self.verse}"
+
+
+class UnknownVerse(KeyError):
+    """Raised when a verse does not exist in the requested numbering."""
+
+
+@dataclass(frozen=True)
+class ChapterVersification:
+    """How one edition numbers one chapter, relative to the canonical division.
+
+    The four fields cover the four kinds of divergence actually present in the sources.
+    They compose: the spans are built by walking the canonical verses of the chapter in
+    order, so an edition may both merge and omit within one chapter.
+
+    Attributes:
+        canonical_verses: canonical verse count of this chapter.
+        merges: canonical spans ``(first, last)`` that the edition reads as a single verse.
+            The Decalogue case.
+        omits: canonical verses the edition does not contain at all. A witness difference
+            rather than a numbering one -- Joshua 21:36-37 are absent from MAM.
+        absorbs_next_chapter: canonical verses taken from the *start of the next chapter*
+            and numbered as the tail of this one. The edition's chapter is longer than the
+            canonical one and the next chapter is renumbered throughout.
+        merges_previous_chapter_tail: canonical verses at the *end of the previous chapter*
+            that this edition reads as part of its own verse 1. Numbers 26:1 in MAM, which
+            carries canonical 25:19 ahead of canonical 26:1 with a mid-verse parashah break.
+    """
+
+    canonical_verses: int
+    merges: tuple[tuple[int, int], ...] = ()
+    omits: tuple[int, ...] = ()
+    absorbs_next_chapter: int = 0
+    merges_previous_chapter_tail: int = 0
+
+    def __post_init__(self) -> None:
+        seen: set[int] = set()
+        for first, last in self.merges:
+            if last < first:
+                raise ValueError(f"merge span {first}-{last} is reversed")
+            span = set(range(first, last + 1))
+            if span & seen:
+                raise ValueError(f"merge span {first}-{last} overlaps another")
+            seen |= span
+        if set(self.omits) & seen:
+            raise ValueError("a canonical verse cannot be both merged and omitted")
+
+
+# Chapters an edition numbers differently from the canonical division.
+#
+# Derived from the raw sources rather than the generated projects: the MAM importer had a
+# known shortfall in Numbers 10 that is absent from MAM itself, and encoding that here would
+# bake an importer defect into the URN space. Verified by aligning MAM's TSV against the WLC
+# XML verse by verse; every other chapter of the Tanakh agrees.
+DIVERGENCES: dict[tuple[str, str, int], ChapterVersification] = {
+    # --- The Decalogue: ta'am elyon vs ta'am tachton -------------------------------------
+    # MAM numbers by ta'am tachton, which merges אנכי with לא יהיה לך and reads the four
+    # short commandments as one verse.
+    (NUMBERING_MASORAH, "exodus", 20): ChapterVersification(26, merges=((2, 3), (13, 16))),
+    (NUMBERING_MASORAH, "deuteronomy", 5): ChapterVersification(33, merges=((6, 7), (17, 20))),
+    # The common printed editions split אנכי but still merge the four short commandments.
+    (NUMBERING_COMMON, "exodus", 20): ChapterVersification(26, merges=((13, 16),)),
+    (NUMBERING_COMMON, "deuteronomy", 5): ChapterVersification(33, merges=((17, 20),)),
+
+    # --- Divergences unrelated to cantillation -------------------------------------------
+    # MAM reads canonical 25:19 ("ויהי אחרי המגפה") as the head of its own 26:1, separated
+    # from canonical 26:1 by a parashah break in the middle of the verse.
+    (NUMBERING_MASORAH, "numbers", 25): ChapterVersification(19, omits=(19,)),
+    (NUMBERING_MASORAH, "numbers", 26): ChapterVersification(65, merges_previous_chapter_tail=1),
+    # Joshua 21:36-37 are absent from MAM, so its numbering runs two short from verse 36 on.
+    (NUMBERING_MASORAH, "joshua", 21): ChapterVersification(45, omits=(36, 37)),
+    # MAM ends Jeremiah 30 and 1 Samuel 23 one verse later than the Leningrad Codex, which
+    # renumbers the whole of the following chapter.
+    (NUMBERING_MASORAH, "jeremiah", 30): ChapterVersification(24, absorbs_next_chapter=1),
+    (NUMBERING_MASORAH, "samuel_1", 23): ChapterVersification(28, absorbs_next_chapter=1),
+}
+
+#: Canonical verse counts for the divergent chapters, so callers can validate a chapter
+#: without reconstructing the spans. Chapters absent here are numbered identically by every
+#: edition, and their canonical count is whatever the sources say.
+CANONICAL_VERSE_COUNTS: dict[tuple[str, int], int] = {
+    (book, chapter): spec.canonical_verses
+    for (_numbering, book, chapter), spec in DIVERGENCES.items()
+}
+
+
+def divergent_chapters(numbering: str | None = None) -> set[tuple[str, int]]:
+    """The ``(book, chapter)`` pairs some edition numbers differently from canonical."""
+    return {
+        (book, chapter)
+        for (numbering_key, book, chapter) in DIVERGENCES
+        if numbering is None or numbering_key == numbering
+    }
+
+
+@lru_cache(maxsize=None)
+def _spans(numbering: str, book: str, chapter: int) -> tuple[tuple[VerseRef, VerseRef], ...]:
+    """The canonical span of every verse of ``chapter`` in ``numbering``, in edition order.
+
+    Index ``n - 1`` holds the ``(first, last)`` canonical refs covered by the edition's
+    verse ``n``. Both ends are inclusive, and are equal for the ordinary one-to-one case.
+    """
+    spec = DIVERGENCES.get((numbering, book, chapter))
+    if spec is None:
+        raise UnknownVerse(f"{book} {chapter} is not divergent in {numbering!r}")
+
+    merge_start = {first: last for first, last in spec.merges}
+    omitted = set(spec.omits)
+    spans: list[tuple[VerseRef, VerseRef]] = []
+
+    # A verse borrowed from the tail of the previous chapter heads this chapter's verse 1.
+    lead_in: list[VerseRef] = []
+    if spec.merges_previous_chapter_tail:
+        previous = _canonical_verse_count(book, chapter - 1)
+        borrowed = spec.merges_previous_chapter_tail
+        lead_in = [VerseRef(chapter - 1, previous - borrowed + n + 1) for n in range(borrowed)]
+
+    canonical = 1
+    while canonical <= spec.canonical_verses:
+        if canonical in omitted:
+            canonical += 1
+            continue
+        last = merge_start.get(canonical, canonical)
+        start_ref, end_ref = VerseRef(chapter, canonical), VerseRef(chapter, last)
+        if lead_in and not spans:
+            start_ref = lead_in[0]
+        spans.append((start_ref, end_ref))
+        canonical = last + 1
+
+    for n in range(spec.absorbs_next_chapter):
+        spans.append((VerseRef(chapter + 1, n + 1), VerseRef(chapter + 1, n + 1)))
+
+    return tuple(spans)
+
+
+def _canonical_verse_count(book: str, chapter: int) -> int:
+    count = CANONICAL_VERSE_COUNTS.get((book, chapter))
+    if count is None:
+        raise UnknownVerse(
+            f"no canonical verse count recorded for {book} {chapter}; it is only needed for "
+            "chapters adjacent to a divergent one"
+        )
+    return count
+
+
+def _borrowed_by_previous_chapter(numbering: str, book: str, chapter: int) -> int:
+    """How many of this chapter's leading canonical verses the previous chapter absorbed."""
+    previous = DIVERGENCES.get((numbering, book, chapter - 1))
+    return previous.absorbs_next_chapter if previous else 0
+
+
+def to_canonical(numbering: str, book: str, chapter: int, verse: int) -> tuple[VerseRef, VerseRef]:
+    """Map a verse stated in ``numbering`` to the canonical verses it covers.
+
+    Returns the inclusive ``(first, last)`` canonical refs. They are equal unless the
+    edition merges several canonical verses into one, as it does in the Decalogue.
+
+    Raises:
+        UnknownVerse: if the verse does not exist in that numbering.
+    """
+    if numbering == CANONICAL_NUMBERING:
+        return VerseRef(chapter, verse), VerseRef(chapter, verse)
+    if verse < 1:
+        raise UnknownVerse(f"{book} {chapter}:{verse} is not a verse")
+
+    if (numbering, book, chapter) in DIVERGENCES:
+        spans = _spans(numbering, book, chapter)
+        if verse > len(spans):
+            raise UnknownVerse(f"{book} {chapter}:{verse} does not exist in {numbering!r}")
+        return spans[verse - 1]
+
+    # A chapter whose predecessor absorbed its opening verses is renumbered throughout even
+    # though the chapter itself has no entry of its own.
+    offset = _borrowed_by_previous_chapter(numbering, book, chapter)
+    shifted = VerseRef(chapter, verse + offset)
+    return shifted, shifted
+
+
+def from_canonical(numbering: str, book: str, chapter: int, verse: int) -> VerseRef:
+    """Map a canonical verse to the verse that contains it in ``numbering``.
+
+    Raises:
+        UnknownVerse: if the edition omits the verse entirely.
+    """
+    if numbering == CANONICAL_NUMBERING:
+        return VerseRef(chapter, verse)
+
+    # The verse may be numbered as the tail of the previous chapter (Jeremiah 31:1, which MAM
+    # reads as 30:25), within this chapter, or as the head of the next (Numbers 25:19, which
+    # MAM reads as the first half of 26:1).
+    for candidate_chapter in (chapter - 1, chapter, chapter + 1):
+        if (numbering, book, candidate_chapter) not in DIVERGENCES:
+            continue
+        for index, (first, last) in enumerate(_spans(numbering, book, candidate_chapter), start=1):
+            if first <= VerseRef(chapter, verse) <= last:
+                return VerseRef(candidate_chapter, index)
+
+    offset = _borrowed_by_previous_chapter(numbering, book, chapter)
+    if offset:
+        if verse <= offset:
+            raise UnknownVerse(
+                f"canonical {book} {chapter}:{verse} is numbered in the previous chapter"
+            )
+        return VerseRef(chapter, verse - offset)
+
+    if (numbering, book, chapter) in DIVERGENCES:
+        raise UnknownVerse(f"{book} {chapter}:{verse} is absent from {numbering!r}")
+    return VerseRef(chapter, verse)
+
+
+def edition_verse_count(numbering: str, book: str, chapter: int, canonical_verses: int) -> int:
+    """How many verses ``numbering`` reads in a chapter of ``canonical_verses`` verses."""
+    if (numbering, book, chapter) in DIVERGENCES:
+        return len(_spans(numbering, book, chapter))
+    return canonical_verses - _borrowed_by_previous_chapter(numbering, book, chapter)
+
+
+def iter_canonical(numbering: str, book: str, chapter: int) -> Iterator[tuple[int, VerseRef, VerseRef]]:
+    """Yield ``(edition_verse, first_canonical, last_canonical)`` for a divergent chapter."""
+    for index, (first, last) in enumerate(_spans(numbering, book, chapter), start=1):
+        yield index, first, last

--- a/opensiddur/exporter/refdb.py
+++ b/opensiddur/exporter/refdb.py
@@ -13,6 +13,14 @@ from opensiddur.common.constants import PROJECT_DIRECTORY, INDEX_DB_DIRECTORY
 
 INDEX_DB_FILE = INDEX_DB_DIRECTORY / "reference.db"
 
+#: URNs under this prefix identify a stretch of text, so they must be unique within a
+#: project. Other URN types (condition, notes) are names and are meant to be shared.
+TEXT_URN_PREFIX = "urn:x-opensiddur:text:"
+
+
+class DuplicateUrnError(ValueError):
+    """A text URN is mapped to more than one place within a single project."""
+
 
 def find_end_of_mapping(element: ElementBase) -> tuple[str, bool]:
     """Find the end element path and tail-inclusion flag for a URN mapping.
@@ -244,11 +252,15 @@ class ReferenceDatabase:
 
     def add_urn_mapping(self, project: str, file_name: str, element: ElementBase):
         """Add or update a URN mapping.
-        
+
         Args:
             project: The project/directory name
             file_name: The file name containing the element
             element: The element that has the URN mapping
+
+        Raises:
+            DuplicateUrnError: if the same URN is already mapped to a different place in the
+                same project.
         """
         cursor = self.conn.cursor()
         urn = element.get('corresp')
@@ -258,11 +270,36 @@ class ReferenceDatabase:
         end_element_path, end_includes_tail = find_end_of_mapping(element)
         element_tag = element.tag
         element_type = element.get('type')
+
+        # A text URN names one stretch of text, so a second, different mapping for it within
+        # one project is a data error rather than an update. Letting the conflict resolve
+        # silently is how MAM's repeated Decalogue milestones went unnoticed: the row kept
+        # the first element_path and every later segment became unreachable by URN.
+        #
+        # Only text URNs are identities. A condition URN is a feature name and is meant to
+        # repeat — one setting selects the ta'am elyon reading everywhere it occurs — and a
+        # note URN names a kind of note shared across books, so neither is checked.
+        existing = cursor.execute(
+            'SELECT file_name, element_path FROM urn_mappings WHERE urn = ? AND project = ?',
+            (urn, project),
+        ).fetchone() if urn.startswith(TEXT_URN_PREFIX) else None
+        if existing is not None and (
+            existing['file_name'] != file_name or existing['element_path'] != element_path
+        ):
+            raise DuplicateUrnError(
+                f"{urn} is mapped twice in project {project!r}: "
+                f"{existing['file_name']}:{existing['element_path']} and "
+                f"{file_name}:{element_path}"
+            )
+
         cursor.execute('''
             INSERT INTO urn_mappings (urn, project, file_name, element_path, element_tag, element_type, end_element_path, end_includes_tail)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(urn, project) DO UPDATE SET
                 file_name = excluded.file_name,
+                element_path = excluded.element_path,
+                end_element_path = excluded.end_element_path,
+                end_includes_tail = excluded.end_includes_tail,
                 updated_at = CURRENT_TIMESTAMP
         ''', (urn, project, file_name, element_path, element_tag, element_type, end_element_path, end_includes_tail))
         self.conn.commit()

--- a/opensiddur/exporter/validate_versification.py
+++ b/opensiddur/exporter/validate_versification.py
@@ -1,0 +1,265 @@
+"""Check that the Tanakh projects agree about what each verse URN denotes.
+
+A verse URN is the only join key between projects: the parallel compiler pairs text by exact
+``@corresp`` equality and the reference database resolves transclusion ranges by it. Nothing
+in the schema enforces that two projects mean the same thing by ``exodus/20/13``, and when
+they disagree nothing fails -- the compiler simply pairs the wrong verses and a range stops
+early. This validator is what notices.
+
+Two checks:
+
+* **Duplicates.** A URN naming two places within one project. The reference database keeps
+  one of them and every other segment becomes unreachable.
+* **Coverage.** The verse URNs each project exposes for a chapter they share. A project that
+  is missing verses another has will silently drop text from a parallel compile or a range.
+
+Verses genuinely absent from a witness are not errors, and are listed in
+:data:`KNOWN_ABSENCES`. Chapters where a project's verse *count* is still under
+investigation are listed in :data:`UNRESOLVED_CHAPTERS`, so they are reported separately
+from new regressions rather than drowning them out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Optional
+
+from lxml import etree
+
+from opensiddur.common.constants import PROJECT_DIRECTORY
+
+VERSE_URN = re.compile(
+    r"^urn:x-opensiddur:text:bible:(?P<book>[a-z_0-9]+)/(?P<chapter>\d+)/(?P<verse>\d+)$"
+)
+
+#: Projects whose verse URNs must agree, and the numbering each edition follows.
+TANAKH_PROJECTS = ("wlc", "miqra_al_pi_hamasorah", "jps1917")
+
+#: Verses a witness genuinely does not contain. Not a numbering difference: the text is
+#: absent from the edition altogether, so it has no URN there and never should.
+KNOWN_ABSENCES: dict[str, set[tuple[str, int, int]]] = {
+    # Joshua 21:36-37 are absent from Miqra al pi ha-Masorah.
+    "miqra_al_pi_hamasorah": {("joshua", 21, 36), ("joshua", 21, 37)},
+}
+
+#: Chapters where a project's verse division is known to differ and has not yet been
+#: reconciled with the canonical numbering. These predate the canonical URN space and are
+#: reported as unresolved rather than as regressions. Each needs the edition's own text
+#: aligned against the canonical division before it can be encoded or fixed; zechariah 4
+#: and 14 in particular look transposed rather than genuinely divergent.
+UNRESOLVED_CHAPTERS: set[tuple[str, str, int]] = {
+    ("jps1917", "ezra", 2),
+    ("jps1917", "ezra", 4),
+    ("jps1917", "isaiah", 9),
+    ("jps1917", "kings_2", 18),
+    ("jps1917", "leviticus", 14),
+    ("jps1917", "nehemiah", 7),
+    ("jps1917", "psalms", 30),
+    ("jps1917", "zechariah", 4),
+    ("jps1917", "zechariah", 8),
+    ("jps1917", "zechariah", 14),
+}
+
+
+@dataclass(frozen=True)
+class DuplicateVerseUrn:
+    project: str
+    urn: str
+    occurrences: int
+
+    def __str__(self) -> str:
+        return f"{self.project}: {self.urn} appears {self.occurrences} times"
+
+
+@dataclass(frozen=True)
+class MissingVerseUrn:
+    project: str
+    book: str
+    chapter: int
+    verses: tuple[int, ...]
+    present_in: tuple[str, ...]
+
+    def __str__(self) -> str:
+        listed = ", ".join(str(v) for v in self.verses)
+        others = ", ".join(self.present_in)
+        return (
+            f"{self.project}: {self.book} {self.chapter} is missing verse(s) {listed}, "
+            f"present in {others}"
+        )
+
+
+@dataclass(frozen=True)
+class ExtraVerseUrn:
+    """A verse no other project has. Almost always a verse attributed to the wrong chapter."""
+
+    project: str
+    book: str
+    chapter: int
+    verses: tuple[int, ...]
+
+    def __str__(self) -> str:
+        listed = ", ".join(str(v) for v in self.verses)
+        return (
+            f"{self.project}: {self.book} {self.chapter} has verse(s) {listed}, "
+            "which no other project has"
+        )
+
+
+@dataclass
+class VersificationReport:
+    duplicates: list[DuplicateVerseUrn] = field(default_factory=list)
+    missing: list[MissingVerseUrn] = field(default_factory=list)
+    extra: list[ExtraVerseUrn] = field(default_factory=list)
+    unresolved: list[MissingVerseUrn | ExtraVerseUrn] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing beyond the known, documented divergences was found."""
+        return not self.duplicates and not self.missing and not self.extra
+
+
+def _verse_urns(path: Path) -> list[tuple[str, int, int]]:
+    """Every verse URN in one file, in document order, duplicates included."""
+    tree = etree.parse(str(path))
+    found = []
+    for element in tree.getroot().xpath("//*[@corresp]"):
+        match = VERSE_URN.match(element.get("corresp", ""))
+        if match:
+            found.append(
+                (match["book"], int(match["chapter"]), int(match["verse"]))
+            )
+    return found
+
+
+def collect_verse_urns(
+    project: str, *, project_directory: Path = PROJECT_DIRECTORY
+) -> collections.Counter:
+    """Count every verse URN a project exposes."""
+    project_path = Path(project_directory) / project
+    if not project_path.is_dir():
+        raise ValueError(f"Project directory does not exist: {project_path}")
+    counts: collections.Counter = collections.Counter()
+    for xml_file in sorted(project_path.glob("*.xml")):
+        counts.update(_verse_urns(xml_file))
+    return counts
+
+
+def validate_versification(
+    projects: Iterable[str] = TANAKH_PROJECTS,
+    *,
+    project_directory: Path = PROJECT_DIRECTORY,
+) -> VersificationReport:
+    """Compare the verse URNs the given projects expose."""
+    projects = tuple(projects)
+    report = VersificationReport()
+    per_project = {}
+
+    for project in projects:
+        counts = collect_verse_urns(project, project_directory=project_directory)
+        per_project[project] = set(counts)
+        for ref, occurrences in sorted(counts.items()):
+            if occurrences > 1:
+                book, chapter, verse = ref
+                report.duplicates.append(
+                    DuplicateVerseUrn(
+                        project=project,
+                        urn=f"urn:x-opensiddur:text:bible:{book}/{chapter}/{verse}",
+                        occurrences=occurrences,
+                    )
+                )
+
+    # Compare only chapters a project actually covers: a project that has not imported a
+    # book at all is incomplete, which is a different thing from disagreeing about it.
+    chapters_of = {
+        project: {(book, chapter) for book, chapter, _ in refs}
+        for project, refs in per_project.items()
+    }
+
+    verses_of: dict[str, dict[tuple[str, int], set[int]]] = {}
+    for project, refs in per_project.items():
+        by_chapter: dict[tuple[str, int], set[int]] = collections.defaultdict(set)
+        for book, chapter, verse in refs:
+            by_chapter[(book, chapter)].add(verse)
+        verses_of[project] = by_chapter
+
+    for project in projects:
+        absences = KNOWN_ABSENCES.get(project, set())
+        for book, chapter in sorted(chapters_of[project]):
+            others = [
+                other
+                for other in projects
+                if other != project and (book, chapter) in chapters_of[other]
+            ]
+            if not others:
+                continue
+            mine = verses_of[project][(book, chapter)]
+            elsewhere = [verses_of[other][(book, chapter)] for other in others]
+
+            # A verse only this project has is its own invention — in practice a verse
+            # attributed to the wrong chapter — not something the others are missing.
+            # Reporting it against them would blame two projects for one project's defect.
+            extra = sorted(v for v in mine if not any(v in other for other in elsewhere))
+            missing = sorted(
+                v
+                for v in set().union(*elsewhere) - mine
+                if (book, chapter, v) not in absences
+                and all(v in other for other in elsewhere)
+            )
+
+            unresolved = (project, book, chapter) in UNRESOLVED_CHAPTERS
+            if extra:
+                finding = ExtraVerseUrn(project, book, chapter, tuple(extra))
+                (report.unresolved if unresolved else report.extra).append(finding)
+            if missing:
+                finding = MissingVerseUrn(
+                    project, book, chapter, tuple(missing), tuple(others)
+                )
+                (report.unresolved if unresolved else report.missing).append(finding)
+
+    return report
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--project-directory", type=Path, default=PROJECT_DIRECTORY,
+        help="Directory holding the projects.",
+    )
+    parser.add_argument(
+        "--project", action="append", dest="projects",
+        help="Project to check; repeatable. Defaults to the Tanakh projects.",
+    )
+    args = parser.parse_args(argv)
+
+    report = validate_versification(
+        args.projects or TANAKH_PROJECTS, project_directory=args.project_directory
+    )
+
+    for duplicate in report.duplicates:
+        print(f"DUPLICATE  {duplicate}")
+    for missing in report.missing:
+        print(f"MISSING    {missing}")
+    for extra in report.extra:
+        print(f"EXTRA      {extra}")
+    for unresolved in report.unresolved:
+        print(f"unresolved {unresolved}")
+
+    if report.ok:
+        print(
+            f"OK: verse URNs agree across projects "
+            f"({len(report.unresolved)} known unresolved chapter(s))"
+        )
+        return 0
+    print(
+        f"FAILED: {len(report.duplicates)} duplicate, {len(report.missing)} missing and "
+        f"{len(report.extra)} extra verse(s)"
+    )
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/opensiddur/importer/jps1917/canonical_verses.py
+++ b/opensiddur/importer/jps1917/canonical_verses.py
@@ -1,0 +1,113 @@
+"""Split JPS 1917's verses onto the canonical verse division.
+
+JPS follows the common printed numbering, which reads the four short commandments of the
+Decalogue as a single verse -- Exodus 20:13 and Deuteronomy 5:17. Canonically those are four
+verses each, so a JPS verse milestone there would carry a URN that denotes four times as
+much text as the same URN does in WLC, and the parallel compiler would pair it against only
+the first of them.
+
+JPS sets the four commandments as separate paragraphs, so the canonical boundaries are
+already in the source; this pass promotes the paragraph breaks inside a merged verse to
+verse boundaries. How many canonical verses a JPS verse covers comes from
+:mod:`opensiddur.common.versification`, and the paragraph breaks found here must supply
+exactly that many.
+"""
+
+from __future__ import annotations
+
+from lxml import etree
+
+from opensiddur.common.versification import (
+    NUMBERING_COMMON,
+    UnknownVerse,
+    to_canonical,
+)
+
+
+class CanonicalVerseError(ValueError):
+    """The paragraph breaks in the source disagree with the versification table."""
+
+
+def _following_boundaries(verse: etree._Element) -> list[etree._Element]:
+    """The ``p`` breaks inside this verse that have text after them.
+
+    A break is a verse boundary only when more of the verse follows it. The break that
+    closes the verse -- the one with nothing but the next verse marker after it -- is a
+    paragraph boundary and nothing more, so it is excluded.
+    """
+    candidates: list[etree._Element] = []
+    for node in verse.itersiblings():
+        if node.tag == "verse":
+            break
+        if node.tag == "p":
+            candidates.append(node)
+    return [p for p in candidates if _content_follows(p)]
+
+
+def _content_follows(node: etree._Element) -> bool:
+    """True when text follows ``node`` before the next paragraph break or verse marker."""
+    if (node.tail or "").strip():
+        return True
+    for sibling in node.itersiblings():
+        if sibling.tag in ("p", "verse"):
+            return False
+        if "".join(sibling.itertext()).strip() or (sibling.tail or "").strip():
+            return True
+    return False
+
+
+def annotate_canonical_verses(intermediate_xml: str, book: str) -> str:
+    """Renumber ``verse`` markers onto canonical numbering, splitting merged verses.
+
+    Every ``verse`` element ends up with ``@verse`` in canonical numbering and
+    ``@editionVerse`` in JPS's own, so the importer can mint one canonical URN per verse and
+    still show JPS's numbering.
+
+    Args:
+        intermediate_xml: the mediawiki intermediate document.
+        book: the book's opensiddur slug, e.g. ``"exodus"``.
+
+    Raises:
+        CanonicalVerseError: when a verse covers several canonical verses but the source
+            does not offer the right number of paragraph breaks to split it at.
+    """
+    root = etree.fromstring(intermediate_xml.encode("utf-8"))
+
+    for verse in list(root.iter("verse")):
+        chapter_raw, verse_raw = verse.get("chapter", ""), verse.get("verse", "")
+        if not chapter_raw.isdigit() or not verse_raw.isdigit():
+            continue
+        chapter, edition_verse = int(chapter_raw), int(verse_raw)
+
+        try:
+            first, last = to_canonical(NUMBERING_COMMON, book, chapter, edition_verse)
+        except UnknownVerse as exc:
+            raise CanonicalVerseError(
+                f"{book} {chapter}:{edition_verse} is in the source but not in the "
+                f"versification table for {NUMBERING_COMMON!r}"
+            ) from exc
+
+        verse.set("editionVerse", str(edition_verse))
+        verse.set("verse", str(first.verse))
+        verse.set("chapter", str(first.chapter))
+        if first.verse == last.verse:
+            continue
+
+        wanted = last.verse - first.verse
+        boundaries = _following_boundaries(verse)
+        if len(boundaries) != wanted:
+            raise CanonicalVerseError(
+                f"{book} {chapter}:{edition_verse} covers {wanted + 1} canonical verses but "
+                f"the source offers {len(boundaries)} paragraph breaks inside it"
+            )
+        for offset, boundary in enumerate(boundaries, start=1):
+            marker = etree.Element("verse")
+            marker.set("chapter", str(first.chapter))
+            marker.set("verse", str(first.verse + offset))
+            # The continuation carries no edition number: it is the same JPS verse, so a
+            # renderer showing JPS's numbering must not print a new one here.
+            marker.tail = boundary.tail
+            boundary.tail = None
+            boundary.addnext(marker)
+
+    return etree.tostring(root, encoding="unicode")

--- a/opensiddur/importer/jps1917/convert_wikisource.py
+++ b/opensiddur/importer/jps1917/convert_wikisource.py
@@ -12,6 +12,7 @@ from opensiddur.importer.util.pages import (
     get_credits,
     get_page,
 )
+from opensiddur.importer.jps1917.canonical_verses import annotate_canonical_verses
 from opensiddur.importer.jps1917.mediawiki_processor import create_processor
 from opensiddur.importer.util.parshiyot import skeleton_map_json
 from opensiddur.importer.util.prettify import prettify_xml
@@ -583,6 +584,9 @@ def process_mediawiki(
     <mediawikis>{content}</mediawikis>
     </tei:{wrapper_element}>
     """
+    book_name = kwargs.get("book_name")
+    if book_name:
+        pre_xml = annotate_canonical_verses(pre_xml, book_name)
     # Path("temp").mkdir(parents=True, exist_ok=True)
     # with open(f"temp/{kwargs.get("book_name", "temp")}.temp.xml", "w") as f:
     #     f.write(pre_xml)

--- a/opensiddur/importer/jps1917/mediawiki_to_tei.xslt
+++ b/opensiddur/importer/jps1917/mediawiki_to_tei.xslt
@@ -434,13 +434,17 @@
             <!-- add an initial paragraph break -->
             <p/>
         </xsl:if>
-        <xsl:if test="$chapter">
+        <!-- A chapter is opened either by its dropinitial or by an explicit verse 1 marker,
+             never by both: the verse template emits the chapter milestone alongside verse 1,
+             so emitting one here as well would give the chapter two identical corresp
+             values, and the reference database and the parallel compiler each keep only the
+             first of those. Where a verse 1 marker follows, it opens the chapter and this
+             dropinitial is decoration. -->
+        <xsl:if test="$chapter and not(following-sibling::verse[@chapter=$chapter][@verse='1'])">
             <tei:milestone unit="chapter" n="{$chapter}"
                 corresp="urn:x-opensiddur:text:bible:{$book_name}/{$chapter}"/>
-            <xsl:if test="not(following-sibling::verse[@chapter=$chapter][@verse='1'])">
-                <tei:milestone unit="verse" n="1"
-                    corresp="urn:x-opensiddur:text:bible:{$book_name}/{$chapter}/1"/>
-            </xsl:if>
+            <tei:milestone unit="verse" n="1"
+                corresp="urn:x-opensiddur:text:bible:{$book_name}/{$chapter}/1"/>
         </xsl:if>
 
     </xsl:template>
@@ -457,6 +461,14 @@
                 <!-- add an initial paragraph break -->
                 <p/>
             </xsl:if>
+        </xsl:if>
+        <!-- @verse is the canonical number and drives the URN; @editionVerse is JPS's own,
+             emitted only where the two differ. It carries no @corresp, so the reference
+             database and the parallel compiler — which look only at @corresp — ignore it,
+             while a renderer can still show JPS's numbering. A verse continued from a
+             merged one has no @editionVerse at all: it is the same JPS verse. -->
+        <xsl:if test="@editionVerse and @editionVerse != @verse">
+            <tei:milestone unit="edition-verse" n="{@editionVerse}"/>
         </xsl:if>
         <tei:milestone unit="verse" n="{@verse}"
             corresp="urn:x-opensiddur:text:bible:{$book_name}/{@chapter}/{@verse}"/>

--- a/opensiddur/importer/miqra_al_pi_hamasorah/canonical_verses.py
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/canonical_verses.py
@@ -1,0 +1,228 @@
+"""Split MAM's verses into canonical verses.
+
+MAM numbers by ta'am tachton, which in the Decalogue merges the four short commandments
+into one verse and reads אנכי together with לא יהיה לך. The canonical URN space numbers the
+union of the two cantillations' boundaries, so several canonical verses can fall inside one
+MAM verse, and a project that emitted one milestone per MAM verse would give those canonical
+verses no URN of their own -- or, as the importer previously did, give them all the *same*
+URN, which the reference database and the parallel compiler both silently collapse.
+
+MAM ships both cantillation strands (``{{מ:כפול|כפול=…|א=…|ב=…}}``), so the interior
+boundaries are derivable from MAM's own source: wherever the ta'am elyon strand ends a verse
+but MAM's own does not, a canonical verse ends. Where a merge is not cantillation-driven --
+Numbers 26:1, which carries canonical 25:19 ahead of it -- the boundary is a parashah break
+in the middle of the verse instead.
+
+How many canonical verses a MAM verse covers is not inferred from the source; it comes from
+:mod:`opensiddur.common.versification`, and the boundaries found here must agree with it.
+A mismatch means the source and the table disagree about the text, which is an error worth
+stopping for rather than papering over.
+"""
+
+from __future__ import annotations
+
+from lxml import etree
+
+from opensiddur.common.versification import (
+    CANONICAL_VERSE_COUNTS,
+    NUMBERING_MASORAH,
+    UnknownVerse,
+    to_canonical,
+)
+
+MIQRA_NS = "urn:x-opensiddur:miqra:intermediate"
+Q = f"{{{MIQRA_NS}}}"
+
+#: U+05C3 HEBREW PUNCTUATION SOF PASUQ -- the end-of-verse mark.
+SOF_PASUQ = "׃"
+
+#: The ta'am elyon strand. ``א`` is ta'am tachton, which is the reading MAM's own verse
+#: division follows; see the strand labels documented in the source's ``templates.tsv``.
+ELYON_STRAND = "ב"
+
+
+class CanonicalVerseError(ValueError):
+    """The boundaries found in the source disagree with the versification table."""
+
+
+def _text_of(element: etree._Element) -> str:
+    return "".join(element.itertext())
+
+
+def _ends_verse(dual_accent: etree._Element, role: str) -> bool:
+    """True when ``role``'s reading of this span ends a verse."""
+    strand = dual_accent.find(f'{Q}strand[@role="{role}"]')
+    if strand is None:
+        return False
+    return _text_of(strand).rstrip().endswith(SOF_PASUQ)
+
+
+def _has_content_after(children: list[etree._Element], index: int) -> bool:
+    """True when real text follows ``children[index]`` within the same verse."""
+    rest = [children[index].tail or ""]
+    for later in children[index + 1:]:
+        rest.append(_text_of(later))
+        rest.append(later.tail or "")
+    return bool("".join(rest).strip())
+
+
+def _elyon_boundaries(text: etree._Element) -> list[int]:
+    """Indices of top-level children after which the ta'am elyon reading ends a verse."""
+    children = list(text)
+    return [
+        index
+        for index, child in enumerate(children)
+        if child.tag == f"{Q}dual-accent"
+        and _ends_verse(child, ELYON_STRAND)
+        and _has_content_after(children, index)
+    ]
+
+
+def _mid_verse_parashah_boundaries(text: etree._Element) -> list[int]:
+    """Indices of top-level children after which a parashah break falls mid-verse.
+
+    Used only where a merge is not cantillation-driven -- Numbers 26:1, whose two canonical
+    halves are separated by a parashah break rather than by a difference in cantillation.
+
+    The source carries a break three ways, all of which reach the body: bare, wrapped in a
+    ``{{נוסח}}`` because another witness places it differently, or inside a ``{{מ:כפול}}``
+    whose strands hold nothing but the break.
+    """
+    children = list(text)
+    boundaries = []
+    for index, child in enumerate(children):
+        if child.tag == f"{Q}parashah":
+            has_break = True
+        elif child.tag == f"{Q}variant":
+            has_break = child.find(f"{Q}display/{Q}parashah") is not None
+        elif child.tag == f"{Q}dual-accent":
+            has_break = child.find(f".//{Q}parashah") is not None and not _text_of(child).strip()
+        else:
+            has_break = False
+        if has_break and _has_content_after(children, index):
+            boundaries.append(index)
+    return boundaries
+
+
+def _split_text(
+    text: etree._Element, boundaries: list[int]
+) -> list[tuple[str | None, list[etree._Element]]]:
+    """Partition the children of ``miqra:text`` after each boundary index.
+
+    Returns ``(leading_text, elements)`` per segment. The tail of a boundary element is the
+    text that follows the verse-final word, so it opens the *next* segment rather than
+    closing the one that ends at the boundary.
+    """
+    children = list(text)
+    segments: list[tuple[str | None, list[etree._Element]]] = []
+    leading = text.text
+    start = 0
+    for boundary in boundaries:
+        segments.append((leading, children[start:boundary + 1]))
+        leading = children[boundary].tail
+        children[boundary].tail = None
+        start = boundary + 1
+    segments.append((leading, children[start:]))
+    return segments
+
+
+def _new_row(template: etree._Element, *, verse: int, edition_verse: int, first: bool) -> etree._Element:
+    row = etree.Element(f"{Q}row", nsmap=template.nsmap)
+    for name, value in template.attrib.items():
+        row.set(name, value)
+    row.set("verse", str(verse))
+    row.set("editionVerse", str(edition_verse))
+    row.set("editionVerseStart", "true" if first else "false")
+    return row
+
+
+def annotate_canonical_verses(intermediate_xml: str, book: str) -> str:
+    """Renumber and split ``miqra:row`` elements onto the canonical verse division.
+
+    Every emitted row carries ``@verse`` in canonical numbering and ``@editionVerse`` in
+    MAM's own, so the importer can mint one canonical URN per row and still display MAM's
+    numbering. Rows for chapters both editions number alike pass through with only
+    ``@editionVerse`` added.
+
+    Args:
+        intermediate_xml: the ``miqra:book`` document.
+        book: the book's opensiddur slug, e.g. ``"exodus"``.
+
+    Raises:
+        CanonicalVerseError: if a MAM verse is recorded as covering several canonical verses
+            but the source offers the wrong number of boundaries to split it at.
+    """
+    root = etree.fromstring(intermediate_xml.encode("utf-8"))
+
+    for row in list(root.findall(f"{Q}row")):
+        chapter_raw, verse_raw = row.get("chapter", ""), row.get("verse", "")
+        if not chapter_raw.isdigit() or not verse_raw.isdigit():
+            continue
+        chapter, edition_verse = int(chapter_raw), int(verse_raw)
+
+        try:
+            # A merged verse may cross a chapter boundary (Numbers 26:1), so each canonical
+            # verse carries its own chapter rather than inheriting the row's.
+            canonical_refs = _canonical_refs(book, chapter, edition_verse)
+        except UnknownVerse as exc:
+            raise CanonicalVerseError(
+                f"{book} {chapter}:{edition_verse} is in the source but not in the "
+                f"versification table for {NUMBERING_MASORAH!r}"
+            ) from exc
+        expected_segments = len(canonical_refs)
+
+        row.set("editionVerse", str(edition_verse))
+        if expected_segments == 1:
+            (canonical_chapter, canonical_verse), = canonical_refs
+            row.set("chapter", str(canonical_chapter))
+            row.set("verse", str(canonical_verse))
+            row.set("editionVerseStart", "true")
+            continue
+
+        text = row.find(f"{Q}text")
+        boundaries = _elyon_boundaries(text) if text is not None else []
+        if len(boundaries) != expected_segments - 1:
+            boundaries = _mid_verse_parashah_boundaries(text) if text is not None else []
+        if len(boundaries) != expected_segments - 1:
+            raise CanonicalVerseError(
+                f"{book} {chapter}:{edition_verse} covers {expected_segments} canonical "
+                f"verses but the source offers {len(boundaries)} interior boundaries; the "
+                "versification table and the source disagree"
+            )
+
+        segments = _split_text(text, boundaries)
+        anchor = row
+        for index, ((leading, elements), (canonical_chapter, canonical_verse)) in enumerate(
+            zip(segments, canonical_refs)
+        ):
+            new_row = _new_row(
+                row, verse=canonical_verse, edition_verse=edition_verse, first=index == 0
+            )
+            new_row.set("chapter", str(canonical_chapter))
+            if index == 0:
+                # Row-level navigation and scaffold anchor at the head of the MAM verse.
+                for name in ("nav", "scaffold"):
+                    part = row.find(f"{Q}{name}")
+                    if part is not None:
+                        new_row.append(part)
+            new_text = etree.SubElement(new_row, f"{Q}text")
+            new_text.text = leading
+            for child in elements:
+                new_text.append(child)
+            anchor.addnext(new_row)
+            anchor = new_row
+        root.remove(row)
+
+    return etree.tostring(root, encoding="unicode")
+
+
+def _canonical_refs(book: str, chapter: int, edition_verse: int) -> list[tuple[int, int]]:
+    """Every ``(chapter, verse)`` the MAM verse covers, in order."""
+    first, last = to_canonical(NUMBERING_MASORAH, book, chapter, edition_verse)
+    if first.chapter == last.chapter:
+        return [(first.chapter, verse) for verse in range(first.verse, last.verse + 1)]
+    # A merge across a chapter boundary: the tail of the previous chapter, then this one.
+    previous_total = CANONICAL_VERSE_COUNTS[(book, first.chapter)]
+    refs = [(first.chapter, verse) for verse in range(first.verse, previous_total + 1)]
+    refs += [(last.chapter, verse) for verse in range(1, last.verse + 1)]
+    return refs

--- a/opensiddur/importer/miqra_al_pi_hamasorah/convert_tsv.py
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/convert_tsv.py
@@ -19,6 +19,7 @@ from opensiddur.importer.util.pages import (
 )
 from opensiddur.importer.util.prettify import prettify_xml
 from opensiddur.importer.util.validation import validate
+from opensiddur.importer.miqra_al_pi_hamasorah.canonical_verses import annotate_canonical_verses
 from opensiddur.importer.miqra_al_pi_hamasorah.miqra_wikitext import (
     wikitext_to_intermediate_xml,
 )
@@ -511,6 +512,7 @@ def book_file(book: Book, *, sourcetexts_root: Path | None, project_dir: Path | 
         raise FileNotFoundError(f"Missing Miqra sheets directory: {sheets_dir} (run download first)")
 
     intermediate = miqra_rows_to_intermediate(book, sheets_dir)
+    intermediate = annotate_canonical_verses(intermediate, book.file_name)
     xml_dict = intermediate_to_tei(intermediate)
     header_xml = header(book.book_name_he, book.book_name_en, qualifier=f":{book.file_name}")
     tei_content = tei_file(header_xml, **xml_dict)

--- a/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
@@ -100,6 +100,8 @@
          context item is a member of the group, not the row. -->
     <xsl:variable name="chapter" select="string(@chapter)"/>
     <xsl:variable name="verse" select="string(@verse)"/>
+    <xsl:variable name="editionVerse" select="string(@editionVerse)"/>
+    <xsl:variable name="editionVerseStart" select="string(@editionVerseStart)"/>
     <xsl:variable name="fileName" select="string(ancestor::miqra:book/@fileName)"/>
     <!-- The rest of the column C/D notes annotate the row — a break another witness has
          but MAM does not, a seder marker, a free {{מ:הערה}} — rather than a point in the
@@ -118,19 +120,37 @@
     </xsl:variable>
     <xsl:choose>
       <xsl:when test="$text-nodes[self::miqra:parashah]">
+        <!-- A parashah break in the middle of a verse splits the verse across paragraphs, but
+             the verse is still one verse: only the first group that carries content opens it,
+             and the rest continue it. Emitting a milestone per group is what previously gave
+             MAM's לא תחמד two identical corresp values. -->
+        <xsl:variable name="group-has-content" as="xs:boolean*">
+          <xsl:for-each-group select="$text-nodes" group-starting-with="miqra:parashah">
+            <xsl:sequence select="
+              exists(current-group()[not(self::miqra:parashah)][not(self::miqra:note)])"/>
+          </xsl:for-each-group>
+        </xsl:variable>
+        <xsl:variable name="first-group" select="index-of($group-has-content, true())[1]"/>
         <xsl:for-each-group select="$text-nodes" group-starting-with="miqra:parashah">
+          <xsl:variable name="position" select="position()"/>
           <xsl:apply-templates select="current-group()[self::miqra:parashah]" mode="flatten"/>
           <xsl:variable name="content"
                         select="current-group()[not(self::miqra:parashah)][not(self::miqra:note)]"/>
           <xsl:if test="exists($content)">
-            <miqra:verse chapter="{$chapter}" verse="{$verse}" fileName="{$fileName}">
+            <miqra:verse chapter="{$chapter}" verse="{$verse}" fileName="{$fileName}"
+                         editionVerse="{$editionVerse}"
+                         editionVerseStart="{$editionVerseStart}"
+                         opensVerse="{if ($position = $first-group) then 'true' else 'false'}">
               <xsl:copy-of select="$content"/>
             </miqra:verse>
           </xsl:if>
         </xsl:for-each-group>
       </xsl:when>
       <xsl:otherwise>
-        <miqra:verse chapter="{$chapter}" verse="{$verse}" fileName="{$fileName}">
+        <miqra:verse chapter="{$chapter}" verse="{$verse}" fileName="{$fileName}"
+                     editionVerse="{$editionVerse}"
+                     editionVerseStart="{$editionVerseStart}"
+                     opensVerse="true">
           <xsl:copy-of select="$text-nodes[not(self::miqra:note)]"/>
         </miqra:verse>
       </xsl:otherwise>
@@ -174,21 +194,35 @@
     <xsl:copy-of select="."/>
   </xsl:template>
 
-  <!-- Verse milestone + text (no tei:ab wrapper). -->
+  <!-- Verse milestones + text (no tei:ab wrapper).
+
+       Two units are emitted. @unit='verse' carries the canonical URN and is the join key for
+       alignment and transclusion; there is exactly one per canonical verse. @unit='edition-verse'
+       carries MAM's own number and no @corresp, so the reference database and the parallel
+       compiler — which both look only at @corresp — ignore it, while a renderer can still show
+       MAM's numbering. The two coincide everywhere except the chapters the editions divide
+       differently, where one MAM verse opens several canonical ones. -->
   <xsl:template match="miqra:verse" mode="block">
     <xsl:variable name="chapter" select="normalize-space(@chapter)"/>
     <xsl:variable name="verse" select="normalize-space(@verse)"/>
+    <xsl:variable name="editionVerse" select="normalize-space(@editionVerse)"/>
     <xsl:if test="miqra:has-verse-ref($chapter, $verse)">
-      <tei:milestone unit="verse" n="{$verse}">
-        <xsl:attribute name="corresp">
-          <xsl:text>urn:x-opensiddur:text:bible:</xsl:text>
-          <xsl:value-of select="@fileName"/>
-          <xsl:text>/</xsl:text>
-          <xsl:value-of select="$chapter"/>
-          <xsl:text>/</xsl:text>
-          <xsl:value-of select="$verse"/>
-        </xsl:attribute>
-      </tei:milestone>
+      <xsl:if test="@editionVerseStart = 'true' and @opensVerse = 'true'
+                    and $editionVerse != '' and $editionVerse != $verse">
+        <tei:milestone unit="edition-verse" n="{$editionVerse}"/>
+      </xsl:if>
+      <xsl:if test="@opensVerse = 'true'">
+        <tei:milestone unit="verse" n="{$verse}">
+          <xsl:attribute name="corresp">
+            <xsl:text>urn:x-opensiddur:text:bible:</xsl:text>
+            <xsl:value-of select="@fileName"/>
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="$chapter"/>
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="$verse"/>
+          </xsl:attribute>
+        </tei:milestone>
+      </xsl:if>
     </xsl:if>
     <xsl:apply-templates select="node()" mode="inline"/>
   </xsl:template>

--- a/opensiddur/tests/common/test_versification.py
+++ b/opensiddur/tests/common/test_versification.py
@@ -1,0 +1,270 @@
+"""Tests for canonical verse numbering.
+
+The expected values are the alignments verified against the raw sources -- MAM's TSV against
+the WLC XML, verse by verse -- not against the generated projects, which is where the
+mapping came from in the first place.
+"""
+
+import unittest
+
+from opensiddur.common.versification import (
+    CANONICAL_NUMBERING,
+    NUMBERING_COMMON,
+    NUMBERING_LENINGRAD,
+    NUMBERING_MASORAH,
+    ChapterVersification,
+    UnknownVerse,
+    VerseRef,
+    divergent_chapters,
+    edition_verse_count,
+    from_canonical,
+    to_canonical,
+)
+
+
+class TestCanonicalNumberingIsIdentity(unittest.TestCase):
+    """The Leningrad numbering *is* the canonical one, so it never needs mapping."""
+
+    def test_to_canonical_is_identity(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_LENINGRAD, "exodus", 20, 13),
+            (VerseRef(20, 13), VerseRef(20, 13)),
+        )
+
+    def test_from_canonical_is_identity(self):
+        self.assertEqual(from_canonical(CANONICAL_NUMBERING, "exodus", 20, 13), VerseRef(20, 13))
+
+    def test_undivergent_chapter_round_trips(self):
+        for numbering in (NUMBERING_MASORAH, NUMBERING_COMMON):
+            with self.subTest(numbering=numbering):
+                self.assertEqual(
+                    to_canonical(numbering, "genesis", 1, 5),
+                    (VerseRef(1, 5), VerseRef(1, 5)),
+                )
+                self.assertEqual(from_canonical(numbering, "genesis", 1, 5), VerseRef(1, 5))
+
+
+class TestDecalogue(unittest.TestCase):
+    """Exodus 20 has 26 canonical verses; MAM reads 22 of them and JPS 23."""
+
+    def test_masorah_merges_anokhi_with_lo_yihyeh(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "exodus", 20, 2),
+            (VerseRef(20, 2), VerseRef(20, 3)),
+        )
+
+    def test_masorah_merges_the_four_short_commandments(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "exodus", 20, 12),
+            (VerseRef(20, 13), VerseRef(20, 16)),
+        )
+
+    def test_masorah_tail_of_chapter_is_offset_by_four(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "exodus", 20, 22),
+            (VerseRef(20, 26), VerseRef(20, 26)),
+        )
+
+    def test_common_splits_anokhi_but_merges_the_four(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_COMMON, "exodus", 20, 2),
+            (VerseRef(20, 2), VerseRef(20, 2)),
+        )
+        self.assertEqual(
+            to_canonical(NUMBERING_COMMON, "exodus", 20, 13),
+            (VerseRef(20, 13), VerseRef(20, 16)),
+        )
+        self.assertEqual(
+            to_canonical(NUMBERING_COMMON, "exodus", 20, 23),
+            (VerseRef(20, 26), VerseRef(20, 26)),
+        )
+
+    def test_every_canonical_verse_maps_back_into_each_edition(self):
+        for numbering, expected_count in (
+            (NUMBERING_MASORAH, 22),
+            (NUMBERING_COMMON, 23),
+        ):
+            with self.subTest(numbering=numbering):
+                mapped = {
+                    from_canonical(numbering, "exodus", 20, verse) for verse in range(1, 27)
+                }
+                self.assertEqual(len(mapped), expected_count)
+
+    def test_all_four_short_commandments_map_to_one_masorah_verse(self):
+        for canonical in (13, 14, 15, 16):
+            with self.subTest(canonical=canonical):
+                self.assertEqual(
+                    from_canonical(NUMBERING_MASORAH, "exodus", 20, canonical),
+                    VerseRef(20, 12),
+                )
+
+    def test_deuteronomy_five_follows_the_same_pattern(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "deuteronomy", 5, 6),
+            (VerseRef(5, 6), VerseRef(5, 7)),
+        )
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "deuteronomy", 5, 16),
+            (VerseRef(5, 17), VerseRef(5, 20)),
+        )
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "deuteronomy", 5, 29),
+            (VerseRef(5, 33), VerseRef(5, 33)),
+        )
+        self.assertEqual(
+            to_canonical(NUMBERING_COMMON, "deuteronomy", 5, 30),
+            (VerseRef(5, 33), VerseRef(5, 33)),
+        )
+
+    def test_verse_counts(self):
+        cases = [
+            (NUMBERING_MASORAH, "exodus", 20, 26, 22),
+            (NUMBERING_COMMON, "exodus", 20, 26, 23),
+            (NUMBERING_MASORAH, "deuteronomy", 5, 33, 29),
+            (NUMBERING_COMMON, "deuteronomy", 5, 33, 30),
+        ]
+        for numbering, book, chapter, canonical, expected in cases:
+            with self.subTest(numbering=numbering, book=book):
+                self.assertEqual(
+                    edition_verse_count(numbering, book, chapter, canonical), expected
+                )
+
+
+class TestChapterBoundaryShift(unittest.TestCase):
+    """MAM ends Jeremiah 30 and 1 Samuel 23 one verse later than the Leningrad Codex."""
+
+    def test_absorbed_verse_belongs_to_the_previous_chapter(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "jeremiah", 30, 25),
+            (VerseRef(31, 1), VerseRef(31, 1)),
+        )
+        self.assertEqual(from_canonical(NUMBERING_MASORAH, "jeremiah", 31, 1), VerseRef(30, 25))
+
+    def test_following_chapter_is_renumbered_throughout(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "jeremiah", 31, 1),
+            (VerseRef(31, 2), VerseRef(31, 2)),
+        )
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "jeremiah", 31, 39),
+            (VerseRef(31, 40), VerseRef(31, 40)),
+        )
+        self.assertEqual(from_canonical(NUMBERING_MASORAH, "jeremiah", 31, 40), VerseRef(31, 39))
+
+    def test_samuel(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "samuel_1", 23, 29),
+            (VerseRef(24, 1), VerseRef(24, 1)),
+        )
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "samuel_1", 24, 22),
+            (VerseRef(24, 23), VerseRef(24, 23)),
+        )
+
+    def test_chapter_lengths(self):
+        self.assertEqual(edition_verse_count(NUMBERING_MASORAH, "jeremiah", 30, 24), 25)
+        self.assertEqual(edition_verse_count(NUMBERING_MASORAH, "jeremiah", 31, 40), 39)
+        self.assertEqual(edition_verse_count(NUMBERING_MASORAH, "samuel_1", 23, 28), 29)
+        self.assertEqual(edition_verse_count(NUMBERING_MASORAH, "samuel_1", 24, 23), 22)
+
+
+class TestCrossChapterMerge(unittest.TestCase):
+    """MAM reads canonical Numbers 25:19 as the head of its own 26:1."""
+
+    def test_the_merged_verse_spans_two_chapters(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "numbers", 26, 1),
+            (VerseRef(25, 19), VerseRef(26, 1)),
+        )
+
+    def test_both_halves_map_back_to_the_same_verse(self):
+        self.assertEqual(from_canonical(NUMBERING_MASORAH, "numbers", 25, 19), VerseRef(26, 1))
+        self.assertEqual(from_canonical(NUMBERING_MASORAH, "numbers", 26, 1), VerseRef(26, 1))
+
+    def test_the_shortened_chapter_stops_early(self):
+        self.assertEqual(edition_verse_count(NUMBERING_MASORAH, "numbers", 25, 19), 18)
+        with self.assertRaises(UnknownVerse):
+            to_canonical(NUMBERING_MASORAH, "numbers", 25, 19)
+
+    def test_the_rest_of_the_chapter_is_unshifted(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "numbers", 26, 2),
+            (VerseRef(26, 2), VerseRef(26, 2)),
+        )
+        self.assertEqual(edition_verse_count(NUMBERING_MASORAH, "numbers", 26, 65), 65)
+
+
+class TestOmittedVerses(unittest.TestCase):
+    """Joshua 21:36-37 are absent from MAM entirely."""
+
+    def test_omitted_verses_have_no_edition_counterpart(self):
+        for canonical in (36, 37):
+            with self.subTest(canonical=canonical):
+                with self.assertRaises(UnknownVerse):
+                    from_canonical(NUMBERING_MASORAH, "joshua", 21, canonical)
+
+    def test_numbering_resumes_two_short(self):
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "joshua", 21, 35),
+            (VerseRef(21, 35), VerseRef(21, 35)),
+        )
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "joshua", 21, 36),
+            (VerseRef(21, 38), VerseRef(21, 38)),
+        )
+        self.assertEqual(
+            to_canonical(NUMBERING_MASORAH, "joshua", 21, 43),
+            (VerseRef(21, 45), VerseRef(21, 45)),
+        )
+        self.assertEqual(edition_verse_count(NUMBERING_MASORAH, "joshua", 21, 45), 43)
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_every_edition_verse_of_every_divergent_chapter_round_trips(self):
+        for numbering in (NUMBERING_MASORAH, NUMBERING_COMMON):
+            for book, chapter in divergent_chapters(numbering):
+                canonical_total = max(
+                    to_canonical(numbering, book, chapter, verse)[1].verse
+                    for verse in range(1, 200)
+                    if _exists(numbering, book, chapter, verse)
+                )
+                self.assertGreater(canonical_total, 0)
+                for verse in range(1, 200):
+                    if not _exists(numbering, book, chapter, verse):
+                        break
+                    first, last = to_canonical(numbering, book, chapter, verse)
+                    with self.subTest(numbering=numbering, ref=f"{book} {chapter}:{verse}"):
+                        self.assertEqual(
+                            from_canonical(numbering, book, first.chapter, first.verse),
+                            VerseRef(chapter, verse),
+                        )
+                        self.assertEqual(
+                            from_canonical(numbering, book, last.chapter, last.verse),
+                            VerseRef(chapter, verse),
+                        )
+
+
+def _exists(numbering: str, book: str, chapter: int, verse: int) -> bool:
+    try:
+        to_canonical(numbering, book, chapter, verse)
+    except UnknownVerse:
+        return False
+    return True
+
+
+class TestChapterVersificationValidation(unittest.TestCase):
+    def test_overlapping_merges_are_rejected(self):
+        with self.assertRaises(ValueError):
+            ChapterVersification(26, merges=((2, 4), (3, 5)))
+
+    def test_reversed_merge_is_rejected(self):
+        with self.assertRaises(ValueError):
+            ChapterVersification(26, merges=((5, 2),))
+
+    def test_a_verse_cannot_be_merged_and_omitted(self):
+        with self.assertRaises(ValueError):
+            ChapterVersification(26, merges=((2, 3),), omits=(3,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/exporter/test_refdb.py
+++ b/opensiddur/tests/exporter/test_refdb.py
@@ -7,7 +7,13 @@ import time
 import os
 from lxml import etree
 from lxml.etree import ElementBase
-from opensiddur.exporter.refdb import ReferenceDatabase, UrnMapping, Reference, find_end_of_mapping
+from opensiddur.exporter.refdb import (
+    DuplicateUrnError,
+    ReferenceDatabase,
+    UrnMapping,
+    Reference,
+    find_end_of_mapping,
+)
 
 
 class TestReferenceDatabaseBasics(unittest.TestCase):
@@ -52,43 +58,63 @@ class TestReferenceDatabaseBasics(unittest.TestCase):
         """Test adding a URN mapping."""
         project = "test_project"
         file_name = "doc1.xml"
-        elem = self._create_element_with_corresp("urn:x-opensiddur:test:doc1", "chapter")
+        elem = self._create_element_with_corresp("urn:x-opensiddur:text:doc1", "chapter")
         
         self.db.add_urn_mapping(project, file_name, elem)
         
         # Verify it was added
         cursor = self.db.conn.cursor()
-        cursor.execute('SELECT * FROM urn_mappings WHERE urn = ?', ("urn:x-opensiddur:test:doc1",))
+        cursor.execute('SELECT * FROM urn_mappings WHERE urn = ?', ("urn:x-opensiddur:text:doc1",))
         row = cursor.fetchone()
         
         self.assertIsNotNone(row)
-        self.assertEqual(row['urn'], "urn:x-opensiddur:test:doc1")
+        self.assertEqual(row['urn'], "urn:x-opensiddur:text:doc1")
         self.assertEqual(row['project'], project)
         self.assertEqual(row['file_name'], file_name)
 
-    def test_add_urn_mapping_update(self):
-        """Test updating an existing URN mapping."""
+    def test_reindexing_the_same_element_is_idempotent(self):
+        """Re-indexing a project must not fail on mappings it already holds."""
         project = "test_project"
-        
-        # Add initial mapping
-        elem1 = self._create_element_with_corresp("urn:x-opensiddur:test:doc1", "chapter")
-        self.db.add_urn_mapping(project, "file1.xml", elem1)
-        
-        # Update with new file name
-        elem2 = self._create_element_with_corresp("urn:x-opensiddur:test:doc1", "chapter")
-        self.db.add_urn_mapping(project, "file2.xml", elem2)
-        
-        # Verify it was updated
+        elem = self._create_element_with_corresp("urn:x-opensiddur:text:doc1", "chapter")
+
+        self.db.add_urn_mapping(project, "file1.xml", elem)
+        self.db.add_urn_mapping(project, "file1.xml", elem)
+
         cursor = self.db.conn.cursor()
-        cursor.execute('SELECT file_name FROM urn_mappings WHERE urn = ? AND project = ?', 
-                      ("urn:x-opensiddur:test:doc1", project))
-        row = cursor.fetchone()
-        self.assertEqual(row['file_name'], "file2.xml")
+        cursor.execute('SELECT COUNT(*) AS n FROM urn_mappings WHERE urn = ? AND project = ?',
+                      ("urn:x-opensiddur:text:doc1", project))
+        self.assertEqual(cursor.fetchone()['n'], 1)
+
+    def test_the_same_urn_twice_in_one_project_is_an_error(self):
+        """A URN names one stretch of text, so a second mapping for it is a data error.
+
+        Resolving the conflict silently is how MAM's repeated Decalogue milestones went
+        unnoticed: the row kept the first location and the rest became unreachable by URN.
+        """
+        project = "test_project"
+        elem1 = self._create_element_with_corresp("urn:x-opensiddur:text:doc1", "chapter")
+        self.db.add_urn_mapping(project, "file1.xml", elem1)
+
+        elem2 = self._create_element_with_corresp("urn:x-opensiddur:text:doc1", "chapter")
+        with self.assertRaises(DuplicateUrnError) as caught:
+            self.db.add_urn_mapping(project, "file2.xml", elem2)
+        self.assertIn("urn:x-opensiddur:text:doc1", str(caught.exception))
+
+    def test_a_second_location_in_the_same_file_is_an_error(self):
+        root = etree.Element("{http://www.tei-c.org/ns/1.0}TEI")
+        first = etree.SubElement(root, "{http://www.tei-c.org/ns/1.0}div")
+        first.set("corresp", "urn:x-opensiddur:text:doc1")
+        second = etree.SubElement(root, "{http://www.tei-c.org/ns/1.0}div")
+        second.set("corresp", "urn:x-opensiddur:text:doc1")
+
+        self.db.add_urn_mapping("test_project", "file1.xml", first)
+        with self.assertRaises(DuplicateUrnError):
+            self.db.add_urn_mapping("test_project", "file1.xml", second)
 
     def test_add_urn_mapping_multiple_projects(self):
         """Test that same URN can exist in multiple projects."""
-        elem1 = self._create_element_with_corresp("urn:x-opensiddur:test:doc1", "chapter")
-        elem2 = self._create_element_with_corresp("urn:x-opensiddur:test:doc1", "chapter")
+        elem1 = self._create_element_with_corresp("urn:x-opensiddur:text:doc1", "chapter")
+        elem2 = self._create_element_with_corresp("urn:x-opensiddur:text:doc1", "chapter")
         
         self.db.add_urn_mapping("project1", "file1.xml", elem1)
         self.db.add_urn_mapping("project2", "file2.xml", elem2)
@@ -96,7 +122,7 @@ class TestReferenceDatabaseBasics(unittest.TestCase):
         # Verify both exist
         cursor = self.db.conn.cursor()
         cursor.execute('SELECT project, file_name FROM urn_mappings WHERE urn = ? ORDER BY project', 
-                      ("urn:x-opensiddur:test:doc1",))
+                      ("urn:x-opensiddur:text:doc1",))
         rows = cursor.fetchall()
         
         self.assertEqual(len(rows), 2)
@@ -128,8 +154,8 @@ class TestReferenceDatabaseGetUrnMappings(unittest.TestCase):
     def _setup_test_data(self):
         """Set up test data after helper method is defined."""
         # Add test data
-        elem1 = self._create_element_with_corresp("urn:x-opensiddur:test:doc1", "chapter")
-        elem2 = self._create_element_with_corresp("urn:x-opensiddur:test:doc1", "chapter")
+        elem1 = self._create_element_with_corresp("urn:x-opensiddur:text:doc1", "chapter")
+        elem2 = self._create_element_with_corresp("urn:x-opensiddur:text:doc1", "chapter")
         elem3 = self._create_element_with_corresp("urn:x-opensiddur:test:doc2", "chapter")
         self.db.add_urn_mapping("wlc", "doc1.xml", elem1)
         self.db.add_urn_mapping("jps1917", "doc1.xml", elem2)
@@ -143,11 +169,11 @@ class TestReferenceDatabaseGetUrnMappings(unittest.TestCase):
         
     def test_get_urn_mappings_with_urn(self):
         """Test getting URN mappings filtered by URN."""
-        results = self.db.get_urn_mappings(urn="urn:x-opensiddur:test:doc1")
+        results = self.db.get_urn_mappings(urn="urn:x-opensiddur:text:doc1")
         
         self.assertEqual(len(results), 2)
         for result in results:
-            self.assertEqual(result.urn, "urn:x-opensiddur:test:doc1")
+            self.assertEqual(result.urn, "urn:x-opensiddur:text:doc1")
         
     def test_get_urn_mappings_with_project(self):
         """Test getting URN mappings filtered by project."""
@@ -159,10 +185,10 @@ class TestReferenceDatabaseGetUrnMappings(unittest.TestCase):
             
     def test_get_urn_mappings_with_urn_and_project(self):
         """Test getting URN mappings filtered by both URN and project."""
-        results = self.db.get_urn_mappings(urn="urn:x-opensiddur:test:doc1", project="wlc")
+        results = self.db.get_urn_mappings(urn="urn:x-opensiddur:text:doc1", project="wlc")
         
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].urn, "urn:x-opensiddur:test:doc1")
+        self.assertEqual(results[0].urn, "urn:x-opensiddur:text:doc1")
         self.assertEqual(results[0].project, "wlc")
 
 
@@ -190,7 +216,7 @@ class TestReferenceDatabaseGetByProject(unittest.TestCase):
     def _setup_test_data(self):
         """Set up test data after helper method is defined."""
         # Add test data
-        elem1 = self._create_element_with_corresp("urn:x-opensiddur:test:doc1", "chapter")
+        elem1 = self._create_element_with_corresp("urn:x-opensiddur:text:doc1", "chapter")
         elem2 = self._create_element_with_corresp("urn:x-opensiddur:test:doc2", "chapter")
         elem3 = self._create_element_with_corresp("urn:x-opensiddur:test:doc3", "chapter")
         self.db.add_urn_mapping("wlc", "doc1.xml", elem1)
@@ -203,7 +229,7 @@ class TestReferenceDatabaseGetByProject(unittest.TestCase):
         
         self.assertEqual(len(results), 2)
         urns = {r.urn for r in results}
-        self.assertEqual(urns, {"urn:x-opensiddur:test:doc1", "urn:x-opensiddur:test:doc2"})
+        self.assertEqual(urns, {"urn:x-opensiddur:text:doc1", "urn:x-opensiddur:test:doc2"})
         
         # All should be in wlc project
         for result in results:
@@ -245,8 +271,8 @@ class TestReferenceDatabaseGetByProject(unittest.TestCase):
     def test_get_files_by_project_no_duplicates(self):
         """Test that files list contains no duplicates."""
         # Add multiple URNs to same file
-        self.db.add_urn_mapping("wlc", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:test:doc1/new", "chapter"))
-        self.db.add_urn_mapping("wlc", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:test:doc1/another", "chapter"))
+        self.db.add_urn_mapping("wlc", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:text:doc1/new", "chapter"))
+        self.db.add_urn_mapping("wlc", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:text:doc1/another", "chapter"))
         
         files = self.db.get_files_by_project("wlc")
         
@@ -321,9 +347,9 @@ class TestReferenceDatabaseIndexing(unittest.TestCase):
     def test_index_file(self):
         """Test indexing a single XML file."""
         urns = [
-            "urn:x-opensiddur:test:doc1",
-            "urn:x-opensiddur:test:doc1/1",
-            "urn:x-opensiddur:test:doc1/1/1",
+            "urn:x-opensiddur:text:doc1",
+            "urn:x-opensiddur:text:doc1/1",
+            "urn:x-opensiddur:text:doc1/1/1",
         ]
         xml_path = self._create_test_xml("doc1.xml", urns)
         
@@ -341,7 +367,7 @@ class TestReferenceDatabaseIndexing(unittest.TestCase):
     def test_index_file_ignores_non_opensiddur_urns(self):
         """Test that indexing ignores URNs not starting with urn:x-opensiddur:."""
         urns = [
-            "urn:x-opensiddur:test:doc1",
+            "urn:x-opensiddur:text:doc1",
             "urn:other:test:doc2",  # Should be ignored
             "http://example.com",   # Should be ignored
         ]
@@ -354,7 +380,7 @@ class TestReferenceDatabaseIndexing(unittest.TestCase):
     def test_index_urns(self):
         """Test indexing all XML files in a project directory."""
         # Create multiple XML files
-        self._create_test_xml("doc1.xml", ["urn:x-opensiddur:test:doc1"])
+        self._create_test_xml("doc1.xml", ["urn:x-opensiddur:text:doc1"])
         self._create_test_xml("doc2.xml", ["urn:x-opensiddur:test:doc2"])
         self._create_test_xml("doc3.xml", ["urn:x-opensiddur:test:doc3"])
         
@@ -414,8 +440,8 @@ class TestReferenceDatabaseRemoval(unittest.TestCase):
     def _setup_test_data(self):
         """Set up test data after helper method is defined."""
         # Add test data
-        self.db.add_urn_mapping("wlc", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:test:doc1/1", "chapter"))
-        self.db.add_urn_mapping("wlc", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:test:doc1/2", "chapter"))
+        self.db.add_urn_mapping("wlc", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:text:doc1/1", "chapter"))
+        self.db.add_urn_mapping("wlc", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:text:doc1/2", "chapter"))
         self.db.add_urn_mapping("wlc", "doc2.xml", self._create_element_with_corresp("urn:x-opensiddur:test:doc2/1", "chapter"))
         self.db.add_urn_mapping("jps1917", "doc3.xml", self._create_element_with_corresp("urn:x-opensiddur:test:doc3/1", "chapter"))
         self.db.add_urn_mapping("jps1917", "doc4.xml", self._create_element_with_corresp("urn:x-opensiddur:test:doc4/1", "chapter"))
@@ -428,7 +454,7 @@ class TestReferenceDatabaseRemoval(unittest.TestCase):
         self.assertEqual(removed_count, 2)
         
         # Verify doc1.xml URNs are gone
-        results = self.db.get_urn_mappings(urn="urn:x-opensiddur:test:doc1/1")
+        results = self.db.get_urn_mappings(urn="urn:x-opensiddur:text:doc1/1")
         self.assertEqual(results, [])
         
         # Verify other files still exist
@@ -445,7 +471,7 @@ class TestReferenceDatabaseRemoval(unittest.TestCase):
     def test_remove_file_only_affects_specified_project(self):
         """Test that removing a file only affects the specified project."""
         # Add same file name in different project
-        self.db.add_urn_mapping("jps1917", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:test:doc1/1", "chapter"))
+        self.db.add_urn_mapping("jps1917", "doc1.xml", self._create_element_with_corresp("urn:x-opensiddur:text:doc1/1", "chapter"))
         
         # Remove from wlc only
         removed_count = self.db.remove_file("doc1.xml", "wlc")
@@ -453,7 +479,7 @@ class TestReferenceDatabaseRemoval(unittest.TestCase):
         self.assertEqual(removed_count, 2)
         
         # Verify jps1917 version still exists
-        results = self.db.get_urn_mappings(urn="urn:x-opensiddur:test:doc1/1", project="jps1917")
+        results = self.db.get_urn_mappings(urn="urn:x-opensiddur:text:doc1/1", project="jps1917")
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].project, "jps1917")
 
@@ -726,7 +752,7 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
     def test_add_reference_with_urn_target(self):
         """Test adding a reference with URN target."""
         elem = self._create_element_with_target(
-            target="urn:x-opensiddur:test:doc1",
+            target="urn:x-opensiddur:text:doc1",
             element_type="transclude",
             corresp="urn:x-opensiddur:ref:1"
         )
@@ -736,11 +762,11 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
         # Verify it was added
         cursor = self.db.conn.cursor()
         cursor.execute('SELECT * FROM element_references WHERE target_start = ?', 
-                      ("urn:x-opensiddur:test:doc1",))
+                      ("urn:x-opensiddur:text:doc1",))
         row = cursor.fetchone()
         
         self.assertIsNotNone(row)
-        self.assertEqual(row['target_start'], "urn:x-opensiddur:test:doc1")
+        self.assertEqual(row['target_start'], "urn:x-opensiddur:text:doc1")
         self.assertEqual(row['element_type'], "transclude")
         self.assertEqual(row['corresponding_urn'], "urn:x-opensiddur:ref:1")
         self.assertFalse(row['target_is_id'])
@@ -768,8 +794,8 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
     def test_add_reference_with_target_range(self):
         """Test adding a reference with targetEnd."""
         elem = self._create_element_with_target(
-            target="urn:x-opensiddur:test:doc1/1",
-            target_end="urn:x-opensiddur:test:doc1/5",
+            target="urn:x-opensiddur:text:doc1/1",
+            target_end="urn:x-opensiddur:text:doc1/5",
             element_type="range"
         )
         
@@ -778,16 +804,16 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
         # Verify range was stored
         cursor = self.db.conn.cursor()
         cursor.execute('SELECT * FROM element_references WHERE target_start = ?', 
-                      ("urn:x-opensiddur:test:doc1/1",))
+                      ("urn:x-opensiddur:text:doc1/1",))
         row = cursor.fetchone()
         
         self.assertIsNotNone(row)
-        self.assertEqual(row['target_end'], "urn:x-opensiddur:test:doc1/5")
+        self.assertEqual(row['target_end'], "urn:x-opensiddur:text:doc1/5")
 
     def test_add_reference_with_multiple_targets(self):
         """Test adding a reference with space-separated targets."""
         elem = self._create_element_with_target(
-            target="urn:x-opensiddur:test:doc1 urn:x-opensiddur:test:doc2",
+            target="urn:x-opensiddur:text:doc1 urn:x-opensiddur:test:doc2",
             element_type="multi"
         )
         
@@ -801,18 +827,18 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
         
         self.assertEqual(len(rows), 2)
         targets = {row['target_start'] for row in rows}
-        self.assertEqual(targets, {"urn:x-opensiddur:test:doc1", "urn:x-opensiddur:test:doc2"})
+        self.assertEqual(targets, {"urn:x-opensiddur:text:doc1", "urn:x-opensiddur:test:doc2"})
 
     def test_add_reference_stores_element_path(self):
         """Test that element path is correctly stored."""
-        elem = self._create_element_with_target(target="urn:x-opensiddur:test:doc1")
+        elem = self._create_element_with_target(target="urn:x-opensiddur:text:doc1")
         
         self.db.add_reference("test_project", "test.xml", elem)
         
         # Verify element path was stored
         cursor = self.db.conn.cursor()
         cursor.execute('SELECT element_path FROM element_references WHERE target_start = ?', 
-                      ("urn:x-opensiddur:test:doc1",))
+                      ("urn:x-opensiddur:text:doc1",))
         row = cursor.fetchone()
         
         self.assertIsNotNone(row)
@@ -861,7 +887,7 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
 
     def test_get_references_by_project(self):
         """Test retrieving all references for a project."""
-        elem1 = self._create_element_with_target(target="urn:x-opensiddur:test:doc1")
+        elem1 = self._create_element_with_target(target="urn:x-opensiddur:text:doc1")
         elem2 = self._create_element_with_target(target="urn:x-opensiddur:test:doc2")
         elem3 = self._create_element_with_target(target="urn:x-opensiddur:test:doc3")
         
@@ -883,7 +909,7 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
         
         # Element with corresp (URN)
         div = etree.SubElement(root, "{http://www.tei-c.org/ns/1.0}div")
-        div.set("corresp", "urn:x-opensiddur:test:doc1")
+        div.set("corresp", "urn:x-opensiddur:text:doc1")
         
         # Element with target (reference)
         ptr = etree.SubElement(root, "{http://www.tei-c.org/ns/1.0}ptr")
@@ -911,7 +937,7 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
 
     def test_remove_file_removes_references(self):
         """Test that removing a file also removes its references."""
-        elem = self._create_element_with_target(target="urn:x-opensiddur:test:doc1")
+        elem = self._create_element_with_target(target="urn:x-opensiddur:text:doc1")
         self.db.add_reference("proj1", "file1.xml", elem)
         
         # Also add a URN mapping
@@ -929,7 +955,7 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
 
     def test_remove_project_removes_references(self):
         """Test that removing a project also removes its references."""
-        elem = self._create_element_with_target(target="urn:x-opensiddur:test:doc1")
+        elem = self._create_element_with_target(target="urn:x-opensiddur:text:doc1")
         self.db.add_reference("proj1", "file1.xml", elem)
         self.db.add_urn_mapping("proj1", "file1.xml", self._create_element_with_corresp("urn:x-opensiddur:test:urn1", "chapter"))
         
@@ -1036,11 +1062,11 @@ class TestReferenceDatabaseContextManager(unittest.TestCase):
                 # Create element with corresp attribute
                 root = etree.Element("{http://www.tei-c.org/ns/1.0}TEI")
                 elem = etree.SubElement(root, "{http://www.tei-c.org/ns/1.0}div")
-                elem.set("corresp", "urn:x-opensiddur:test:doc1")
+                elem.set("corresp", "urn:x-opensiddur:text:doc1")
                 elem.set("type", "chapter")
                 
                 db.add_urn_mapping("test", "doc1.xml", elem)
-                results = db.get_urn_mappings(urn="urn:x-opensiddur:test:doc1")
+                results = db.get_urn_mappings(urn="urn:x-opensiddur:text:doc1")
                 self.assertEqual(len(results), 1)
             
             # Connection should be closed after context

--- a/opensiddur/tests/exporter/test_validate_versification.py
+++ b/opensiddur/tests/exporter/test_validate_versification.py
@@ -1,0 +1,145 @@
+"""Tests for the cross-project versification validator.
+
+Each test builds a miniature project tree in a temporary directory, so nothing here depends
+on the real Tanakh projects.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from opensiddur.exporter.validate_versification import (
+    collect_verse_urns,
+    validate_versification,
+)
+
+TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="he">
+  <tei:text><tei:body><tei:div type="book">{milestones}</tei:div></tei:body></tei:text>
+</tei:TEI>
+"""
+
+
+def milestone(book: str, chapter: int, verse: int) -> str:
+    return (
+        f'<tei:milestone unit="verse" n="{verse}" '
+        f'corresp="urn:x-opensiddur:text:bible:{book}/{chapter}/{verse}"/>'
+    )
+
+
+class VersificationTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def write_project(self, project: str, book: str, verses, *, chapter: int = 20):
+        directory = self.root / project
+        directory.mkdir(parents=True, exist_ok=True)
+        body = "".join(milestone(book, chapter, verse) for verse in verses)
+        (directory / f"{book}.xml").write_text(TEMPLATE.format(milestones=body), encoding="utf-8")
+
+
+class TestAgreement(VersificationTestCase):
+    def test_projects_that_agree_report_nothing(self):
+        for project in ("wlc", "miqra_al_pi_hamasorah", "jps1917"):
+            self.write_project(project, "exodus", range(1, 27))
+        report = validate_versification(project_directory=self.root)
+        self.assertTrue(report.ok)
+        self.assertEqual(report.duplicates, [])
+        self.assertEqual(report.missing, [])
+
+    def test_a_book_only_one_project_has_is_not_a_disagreement(self):
+        self.write_project("wlc", "exodus", range(1, 27))
+        self.write_project("miqra_al_pi_hamasorah", "genesis", range(1, 32), chapter=1)
+        self.write_project("jps1917", "genesis", range(1, 32), chapter=1)
+        report = validate_versification(project_directory=self.root)
+        self.assertTrue(report.ok)
+
+
+class TestDuplicates(VersificationTestCase):
+    def test_a_repeated_urn_is_reported(self):
+        self.write_project("wlc", "exodus", [1, 2, 2, 3])
+        self.write_project("miqra_al_pi_hamasorah", "exodus", [1, 2, 3])
+        self.write_project("jps1917", "exodus", [1, 2, 3])
+        report = validate_versification(project_directory=self.root)
+        self.assertFalse(report.ok)
+        self.assertEqual(len(report.duplicates), 1)
+        duplicate = report.duplicates[0]
+        self.assertEqual(duplicate.project, "wlc")
+        self.assertEqual(duplicate.occurrences, 2)
+        self.assertIn("exodus/20/2", duplicate.urn)
+
+
+class TestCoverage(VersificationTestCase):
+    def test_a_project_short_of_the_others_is_reported(self):
+        # The Decalogue failure mode: one edition stops four verses early.
+        self.write_project("wlc", "exodus", range(1, 27))
+        self.write_project("jps1917", "exodus", range(1, 27))
+        self.write_project("miqra_al_pi_hamasorah", "exodus", range(1, 23))
+        report = validate_versification(project_directory=self.root)
+        self.assertFalse(report.ok)
+        self.assertEqual(len(report.missing), 1)
+        missing = report.missing[0]
+        self.assertEqual(missing.project, "miqra_al_pi_hamasorah")
+        self.assertEqual(missing.verses, (23, 24, 25, 26))
+
+    def test_a_documented_absence_is_not_a_failure(self):
+        # Joshua 21:36-37 are genuinely absent from MAM.
+        verses = [v for v in range(1, 46) if v not in (36, 37)]
+        self.write_project("miqra_al_pi_hamasorah", "joshua", verses, chapter=21)
+        self.write_project("wlc", "joshua", range(1, 46), chapter=21)
+        self.write_project("jps1917", "joshua", range(1, 46), chapter=21)
+        report = validate_versification(project_directory=self.root)
+        self.assertTrue(report.ok, msg=str(report.missing))
+
+    def test_an_undocumented_gap_in_the_same_chapter_still_fails(self):
+        verses = [v for v in range(1, 46) if v not in (36, 37, 40)]
+        self.write_project("miqra_al_pi_hamasorah", "joshua", verses, chapter=21)
+        self.write_project("wlc", "joshua", range(1, 46), chapter=21)
+        self.write_project("jps1917", "joshua", range(1, 46), chapter=21)
+        report = validate_versification(project_directory=self.root)
+        self.assertFalse(report.ok)
+        self.assertEqual(report.missing[0].verses, (40,))
+
+    def test_a_verse_only_one_project_has_is_that_project_s_defect(self):
+        """Zechariah 4's failure mode: verses attributed to the wrong chapter.
+
+        Reporting it as the other two projects "missing" verse 15 would blame two correct
+        projects for one project's error, so it is reported against the outlier instead.
+        """
+        # haggai 1 stands in for zechariah 4, which is on the documented unresolved list and
+        # so would be reported there rather than as a live finding.
+        self.write_project("jps1917", "haggai", range(1, 22), chapter=1)
+        self.write_project("wlc", "haggai", range(1, 15), chapter=1)
+        self.write_project("miqra_al_pi_hamasorah", "haggai", range(1, 15), chapter=1)
+        report = validate_versification(project_directory=self.root)
+        self.assertFalse(report.ok)
+        self.assertEqual(report.missing, [])
+        self.assertEqual(len(report.extra), 1)
+        self.assertEqual(report.extra[0].project, "jps1917")
+        self.assertEqual(report.extra[0].verses, tuple(range(15, 22)))
+
+
+class TestCollectVerseUrns(VersificationTestCase):
+    def test_only_verse_urns_are_collected(self):
+        directory = self.root / "wlc"
+        directory.mkdir(parents=True)
+        body = (
+            milestone("exodus", 20, 1)
+            + '<tei:milestone unit="chapter" corresp="urn:x-opensiddur:text:bible:exodus/20"/>'
+            + '<tei:seg corresp="urn:x-opensiddur:condition:bible:taam-elyon"/>'
+        )
+        (directory / "exodus.xml").write_text(TEMPLATE.format(milestones=body), encoding="utf-8")
+        self.assertEqual(
+            collect_verse_urns("wlc", project_directory=self.root),
+            {("exodus", 20, 1): 1},
+        )
+
+    def test_a_missing_project_is_an_error(self):
+        with self.assertRaises(ValueError):
+            collect_verse_urns("nope", project_directory=self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/importer/jps1917/test_canonical_verses.py
+++ b/opensiddur/tests/importer/jps1917/test_canonical_verses.py
@@ -1,0 +1,115 @@
+"""Tests for splitting JPS 1917's merged Decalogue verses onto canonical verses.
+
+The fixtures are synthetic mediawiki intermediate documents, not JPS pages, so a change to
+the source text cannot turn these into failures.
+"""
+
+import unittest
+
+from lxml import etree
+
+from opensiddur.importer.jps1917.canonical_verses import (
+    CanonicalVerseError,
+    annotate_canonical_verses,
+)
+
+
+def document(body: str) -> str:
+    return f"<tei:body xmlns:tei='http://www.tei-c.org/ns/1.0'><mediawikis>{body}</mediawikis></tei:body>"
+
+
+def verse(chapter: int, number: int, text: str) -> str:
+    return f'<verse chapter="{chapter}" verse="{number}"></verse>{text}'
+
+
+def verses_of(annotated: str) -> list[tuple[int, int, str | None, str]]:
+    root = etree.fromstring(annotated.encode("utf-8"))
+    return [
+        (
+            int(v.get("chapter")),
+            int(v.get("verse")),
+            v.get("editionVerse"),
+            (v.tail or "").strip(),
+        )
+        for v in root.iter("verse")
+    ]
+
+
+class TestUndivergentChapters(unittest.TestCase):
+    def test_numbering_passes_through(self):
+        annotated = verses_of(annotate_canonical_verses(
+            document(verse(1, 1, "In the beginning")), "genesis"))
+        self.assertEqual(annotated, [(1, 1, "1", "In the beginning")])
+
+
+class TestMergedDecalogueVerse(unittest.TestCase):
+    """JPS reads the four short commandments as one verse; canonically they are 13-16."""
+
+    FOUR = (
+        verse(20, 13, "Thou shalt not murder.")
+        + "<p/>Thou shalt not commit adultery."
+        + "<p/>Thou shalt not steal."
+        + "<p/>Thou shalt not bear false witness."
+        + "<p/>"
+        + verse(20, 14, "Thou shalt not covet.")
+    )
+
+    def test_one_verse_becomes_four(self):
+        annotated = verses_of(annotate_canonical_verses(document(self.FOUR), "exodus"))
+        self.assertEqual([v for _, v, _, _ in annotated], [13, 14, 15, 16, 17])
+
+    def test_each_canonical_verse_keeps_its_own_text(self):
+        annotated = verses_of(annotate_canonical_verses(document(self.FOUR), "exodus"))
+        self.assertEqual(
+            [text for _, _, _, text in annotated],
+            [
+                "Thou shalt not murder.",
+                "Thou shalt not commit adultery.",
+                "Thou shalt not steal.",
+                "Thou shalt not bear false witness.",
+                "Thou shalt not covet.",
+            ],
+        )
+
+    def test_only_the_opening_verse_carries_the_edition_number(self):
+        annotated = verses_of(annotate_canonical_verses(document(self.FOUR), "exodus"))
+        self.assertEqual([edition for _, _, edition, _ in annotated], ["13", None, None, None, "14"])
+
+    def test_the_closing_paragraph_break_is_not_a_verse_boundary(self):
+        # There are four breaks inside the run but only three of them have text after them.
+        annotated = verses_of(annotate_canonical_verses(document(self.FOUR), "exodus"))
+        self.assertEqual(len(annotated), 5)
+
+    def test_the_rest_of_the_chapter_is_renumbered(self):
+        annotated = verses_of(annotate_canonical_verses(
+            document(verse(20, 23, "Neither shalt thou go up by steps")), "exodus"))
+        self.assertEqual(annotated, [(20, 26, "23", "Neither shalt thou go up by steps")])
+
+    def test_deuteronomy_five_follows_the_same_pattern(self):
+        body = (
+            verse(5, 17, "Thou shalt not murder.")
+            + "<p/>Neither shalt thou commit adultery."
+            + "<p/>Neither shalt thou steal."
+            + "<p/>Neither shalt thou bear false witness."
+            + "<p/>"
+            + verse(5, 18, "Neither shalt thou covet.")
+        )
+        annotated = verses_of(annotate_canonical_verses(document(body), "deuteronomy"))
+        self.assertEqual([v for _, v, _, _ in annotated], [17, 18, 19, 20, 21])
+
+
+class TestSourceAndTableMustAgree(unittest.TestCase):
+    def test_too_few_paragraph_breaks_is_an_error(self):
+        body = verse(20, 13, "Thou shalt not murder.") + "<p/>Thou shalt not commit adultery."
+        with self.assertRaises(CanonicalVerseError) as caught:
+            annotate_canonical_verses(document(body), "exodus")
+        self.assertIn("paragraph breaks", str(caught.exception))
+
+    def test_non_numeric_markers_are_left_alone(self):
+        annotated = annotate_canonical_verses(document("<verse/>"), "genesis")
+        root = etree.fromstring(annotated.encode("utf-8"))
+        self.assertEqual(len(list(root.iter("verse"))), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_canonical_verses.py
+++ b/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_canonical_verses.py
@@ -1,0 +1,195 @@
+"""Tests for splitting MAM's verses onto the canonical verse division.
+
+The fixtures are synthetic: a miniature ``miqra:book`` carrying just enough structure to
+exercise each case. They deliberately do not read MAM's TSV, so a change to the source
+cannot turn these into failures.
+"""
+
+import unittest
+
+from lxml import etree
+
+from opensiddur.importer.miqra_al_pi_hamasorah.canonical_verses import (
+    CanonicalVerseError,
+    annotate_canonical_verses,
+)
+
+MIQRA_NS = "urn:x-opensiddur:miqra:intermediate"
+Q = f"{{{MIQRA_NS}}}"
+
+
+def dual_accent(tachton: str, elyon: str) -> str:
+    """A span carried with both cantillations, as ``{{מ:כפול}}`` parses to."""
+    return (
+        "<miqra:dual-accent>"
+        f"<miqra:merged>{tachton}</miqra:merged>"
+        f'<miqra:strand role="א">{tachton}</miqra:strand>'
+        f'<miqra:strand role="ב">{elyon}</miqra:strand>'
+        "</miqra:dual-accent>"
+    )
+
+
+def book(*rows: str, file_name: str = "exodus") -> str:
+    joined = "\n".join(rows)
+    return (
+        f'<miqra:book xmlns:miqra="{MIQRA_NS}" '
+        f'xmlns:mw="urn:x-opensiddur:mw:intermediate" fileName="{file_name}">'
+        f"{joined}</miqra:book>"
+    )
+
+
+def row(chapter: int, verse: int, text: str) -> str:
+    return (
+        f'<miqra:row source="torah" pageKey="p" rowId="r" '
+        f'chapter="{chapter}" verse="{verse}">'
+        f"<miqra:nav/><miqra:scaffold/><miqra:text>{text}</miqra:text>"
+        f"</miqra:row>"
+    )
+
+
+def rows_of(annotated: str) -> list[dict]:
+    root = etree.fromstring(annotated.encode("utf-8"))
+    return [
+        {
+            "chapter": int(r.get("chapter")),
+            "verse": int(r.get("verse")),
+            "edition_verse": int(r.get("editionVerse")),
+            "first": r.get("editionVerseStart") == "true",
+            "text": "".join(r.find(f"{Q}text").itertext()),
+        }
+        for r in root.findall(f"{Q}row")
+    ]
+
+
+class TestUndivergentChapters(unittest.TestCase):
+    def test_rows_pass_through_with_their_own_numbering(self):
+        annotated = rows_of(annotate_canonical_verses(
+            book(row(1, 1, "בְּרֵאשִׁית׃"), row(1, 2, "וְהָאָרֶץ׃"), file_name="genesis"),
+            "genesis",
+        ))
+        self.assertEqual([(r["chapter"], r["verse"]) for r in annotated], [(1, 1), (1, 2)])
+        self.assertTrue(all(r["first"] for r in annotated))
+
+    def test_edition_verse_is_recorded_even_when_it_matches(self):
+        annotated = rows_of(annotate_canonical_verses(
+            book(row(1, 1, "בְּרֵאשִׁית׃"), file_name="genesis"), "genesis"))
+        self.assertEqual(annotated[0]["edition_verse"], 1)
+
+
+class TestDecalogueSplit(unittest.TestCase):
+    """MAM's Exodus 20:12 is the four short commandments; canonically they are 13-16."""
+
+    def build(self):
+        # The elyon strand ends each commandment; MAM's own (tachton) reading runs them on.
+        text = (
+            dual_accent("לֹא תִרְצָח", "לֹא תִּרְצָֽח׃")
+            + dual_accent("לֹא תִנְאָף", "לֹא תִּנְאָֽף׃")
+            + dual_accent("לֹא תִגְנֹב", "לֹא תִּגְנֹֽב׃")
+            + "לֹא תַעֲנֶה׃"
+        )
+        return rows_of(annotate_canonical_verses(book(row(20, 12, text)), "exodus"))
+
+    def test_one_edition_verse_becomes_four_canonical_verses(self):
+        self.assertEqual([r["verse"] for r in self.build()], [13, 14, 15, 16])
+
+    def test_every_segment_records_the_same_edition_verse(self):
+        self.assertEqual({r["edition_verse"] for r in self.build()}, {12})
+
+    def test_only_the_first_segment_opens_the_edition_verse(self):
+        self.assertEqual([r["first"] for r in self.build()], [True, False, False, False])
+
+    def test_the_text_is_partitioned_not_duplicated(self):
+        segments = self.build()
+        self.assertIn("תִרְצָח", segments[0]["text"])
+        self.assertNotIn("תִנְאָף", segments[0]["text"])
+        self.assertIn("תַעֲנֶה", segments[3]["text"])
+
+    def test_anokhi_and_lo_yihyeh_split_into_two(self):
+        text = dual_accent("אָנֹכִי", "אָנֹכִֽי׃") + "לֹא יִהְיֶה לְךָ׃"
+        annotated = rows_of(annotate_canonical_verses(book(row(20, 2, text)), "exodus"))
+        self.assertEqual([r["verse"] for r in annotated], [2, 3])
+
+    def test_the_rest_of_the_chapter_is_renumbered(self):
+        annotated = rows_of(annotate_canonical_verses(book(row(20, 22, "וְלֹא תַעֲלֶה׃")), "exodus"))
+        self.assertEqual(annotated[0]["verse"], 26)
+        self.assertEqual(annotated[0]["edition_verse"], 22)
+
+
+class TestMidVerseParashahIsNotAVerseBoundary(unittest.TestCase):
+    """MAM's Exodus 20:13 is one canonical verse (17) despite a break inside it."""
+
+    def test_a_break_inside_a_verse_does_not_split_it(self):
+        text = (
+            "לֹא תַחְמֹד בֵּית רֵעֶךָ"
+            + '<miqra:parashah type="close" midVerse="true"/>'
+            + "לֹא תַחְמֹד אֵשֶׁת רֵעֶךָ׃"
+        )
+        annotated = rows_of(annotate_canonical_verses(book(row(20, 13, text)), "exodus"))
+        self.assertEqual(len(annotated), 1)
+        self.assertEqual(annotated[0]["verse"], 17)
+
+
+class TestCrossChapterMerge(unittest.TestCase):
+    """MAM's Numbers 26:1 carries canonical 25:19 ahead of canonical 26:1."""
+
+    def test_split_at_a_mid_verse_parashah_wrapped_in_a_variant(self):
+        text = (
+            "וַיְהִי אַחֲרֵי הַמַּגֵּפָה"
+            + "<miqra:variant><miqra:display>"
+            + '<miqra:parashah type="open" midVerse="true"/>'
+            + "</miqra:display></miqra:variant>"
+            + "וַיֹּאמֶר יְהוָה אֶל מֹשֶׁה׃"
+        )
+        annotated = rows_of(annotate_canonical_verses(
+            book(row(26, 1, text), file_name="numbers"), "numbers"))
+        self.assertEqual(
+            [(r["chapter"], r["verse"]) for r in annotated], [(25, 19), (26, 1)]
+        )
+        self.assertEqual([r["first"] for r in annotated], [True, False])
+
+
+class TestChapterBoundaryShift(unittest.TestCase):
+    """MAM's Jeremiah 30:25 is canonical 31:1, and 31 is renumbered throughout."""
+
+    def test_absorbed_verse_moves_to_the_next_chapter(self):
+        annotated = rows_of(annotate_canonical_verses(
+            book(row(30, 25, "בָּעֵת הַהִיא׃"), file_name="jeremiah"), "jeremiah"))
+        self.assertEqual((annotated[0]["chapter"], annotated[0]["verse"]), (31, 1))
+
+    def test_following_chapter_is_shifted(self):
+        annotated = rows_of(annotate_canonical_verses(
+            book(row(31, 1, "כֹּה אָמַר יְהוָה׃"), file_name="jeremiah"), "jeremiah"))
+        self.assertEqual((annotated[0]["chapter"], annotated[0]["verse"]), (31, 2))
+
+
+class TestOmittedVerses(unittest.TestCase):
+    """Joshua 21:36-37 are absent from MAM, so its 21:36 is canonical 21:38."""
+
+    def test_numbering_resumes_past_the_omission(self):
+        annotated = rows_of(annotate_canonical_verses(
+            book(row(21, 36, "וּמִמַּטֵּה גָד׃"), file_name="joshua"), "joshua"))
+        self.assertEqual(annotated[0]["verse"], 38)
+
+
+class TestSourceAndTableMustAgree(unittest.TestCase):
+    def test_missing_boundaries_are_an_error(self):
+        # Recorded as four canonical verses, but the source offers no interior boundary.
+        with self.assertRaises(CanonicalVerseError) as caught:
+            annotate_canonical_verses(book(row(20, 12, "לֹא תִרְצָח׃")), "exodus")
+        self.assertIn("interior boundaries", str(caught.exception))
+
+    def test_a_verse_outside_the_table_is_an_error(self):
+        with self.assertRaises(CanonicalVerseError):
+            annotate_canonical_verses(book(row(25, 19, "וַיְהִי׃"), file_name="numbers"), "numbers")
+
+    def test_non_numeric_rows_are_left_alone(self):
+        annotated = annotate_canonical_verses(
+            book('<miqra:row chapter="" verse=""><miqra:text/></miqra:row>', file_name="genesis"),
+            "genesis",
+        )
+        root = etree.fromstring(annotated.encode("utf-8"))
+        self.assertEqual(len(root.findall(f"{Q}row")), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
+++ b/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
@@ -154,22 +154,26 @@ class TestDualAccent(unittest.TestCase):
 
 
 class TestMidVerseParashah(unittest.TestCase):
-    """A parashah break inside a verse splits its paragraph. The verse must keep both
-    its text and its milestone on each side of the break."""
+    """A parashah break inside a verse splits its paragraph but not the verse. The text
+    carries on across the break under a single milestone."""
 
     def test_verse_survives_a_mid_text_break(self):
         body, _ = _transform(
             _row("13", 'AAA<miqra:parashah type="close-inline" midVerse="true"/>BBB'),
             _row("14", "CCC"),
         )
-        self.assertEqual("AAA BBB", _verse_text(body, "20", "13"))
+        self.assertEqual("AAABBB", _verse_text(body, "20", "13"))
         milestones = [
             m.get("corresp")
             for m in body.findall(f".//{{{TEI_NS}}}milestone")
             if m.get("unit") == "verse"
         ]
-        # The milestone repeats so the verse's corresp scope resumes after the break.
-        self.assertEqual(2, milestones.count("urn:x-opensiddur:text:bible:exodus/20/13"))
+        # Exactly one milestone per verse. Repeating it in the second paragraph would give
+        # the verse two identical corresp values, and both the reference database and the
+        # parallel compiler keep only the first of those and silently drop the rest. The
+        # verse's scope runs to the next verse milestone regardless of paragraph boundaries,
+        # so a single milestone still covers the text after the break.
+        self.assertEqual(1, milestones.count("urn:x-opensiddur:text:bible:exodus/20/13"))
         self.assertIn("urn:x-opensiddur:text:bible:exodus/20/14", milestones)
 
     def test_plain_verse_is_unaffected(self):

--- a/opensiddur/tests/importer/wlc/test_transform_book.py
+++ b/opensiddur/tests/importer/wlc/test_transform_book.py
@@ -332,6 +332,51 @@ class TestTransformBookXSLT(unittest.TestCase):
             self.assertIn('corresp="urn:x-opensiddur:text:bible:genesis/1/1"', result)
             # Note: sof pasuq (׃) is commented out in the current XSLT
     
+    def test_verse_numbering_is_canonical(self):
+        """WLC's numbering *is* the canonical URN numbering, so it passes through untouched.
+
+        The canonical division is the union of the ta'am elyon and ta'am tachton verse
+        boundaries, which is what the Leningrad Codex numbers. WLC therefore needs no
+        remapping and no edition-verse milestones, unlike MAM and JPS, whose own divisions
+        are coarser in the Decalogue. Fixture verse numbers are deliberately spaced apart so
+        a stray offset would show up rather than coincide with the input.
+        """
+        input_xml = '''<?xml version="1.0" encoding="UTF-8"?>
+<Tanach>
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title level="a" type="main">Exodus</title>
+            </titleStmt>
+            <publicationStmt/>
+            <sourceDesc/>
+        </fileDesc>
+    </teiHeader>
+    <tanach>
+        <book>
+            <names><name>Exodus</name></names>
+            <c n="20">
+                <v n="13"><w>לֹא</w><w>תִּרְצָח</w></v>
+                <v n="14"><w>לֹא</w><w>תִּנְאָף</w></v>
+                <v n="26"><w>וְלֹא</w><w>תַעֲלֶה</w></v>
+            </c>
+        </book>
+    </tanach>
+</Tanach>'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xslt') as f:
+            f.write(self.xslt_content)
+            f.flush()
+
+            result = xslt_transform_string(Path(f.name), input_xml)
+
+        for verse in ("13", "14", "26"):
+            with self.subTest(verse=verse):
+                self.assertIn(
+                    f'corresp="urn:x-opensiddur:text:bible:exodus/20/{verse}"', result
+                )
+        self.assertNotIn('unit="edition-verse"', result)
+
     def test_word_elements_have_spaces(self):
         """Test that w (word) elements are separated by spaces"""
         input_xml = '''<?xml version="1.0" encoding="UTF-8"?>

--- a/opensiddur/tests/schema/test_jlptei_odd.py
+++ b/opensiddur/tests/schema/test_jlptei_odd.py
@@ -59,3 +59,20 @@ class TestJlpteiOddConstraints(unittest.TestCase):
         )
         self.assertTrue(member, "Expected j:divineName to be member of model.nameLike.agent")
 
+    def test_corresp_is_unique_within_a_document(self):
+        """A repeated URN breaks alignment and resolution silently, so the schema rejects it."""
+        reports = self.tree.xpath(
+            "//tei:constraintSpec[@ident='corresp-uniqueness']//sch:report",
+            namespaces=self.ns,
+        )
+        self.assertTrue(reports, "Expected a schematron report for duplicate @corresp")
+
+    def test_edition_verse_milestone_must_not_carry_a_urn(self):
+        """unit='edition-verse' records an edition's own numbering, never an identity."""
+        asserts = self.tree.xpath(
+            "//tei:constraintSpec[@ident='edition-verse-constraints']//sch:assert/@test",
+            namespaces=self.ns,
+        )
+        self.assertIn("not(@corresp)", asserts)
+        self.assertIn("@n", asserts)
+

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -56,7 +56,9 @@ An example complete Biblical URN is:
 urn:x-opensiddur:text:bible:genesis/1/1@wlc
 ```
 which identifies the verse Genesis 1:1 in the WLC source.
-The URN `urn:x-opensiddur:text:bible:genesis/1` identifies the chapter Genesis 1 in *every possible* source.
+The URN `urn:x-opensiddur:text:bible:genesis/1` identifies the chapter Genesis 1 in *every* source. A biblical
+URN names a stretch of text, not one edition's way of numbering it, so every project must mean the same thing by
+it — see [Versification](#versification).
 
 While Biblical texts have a natural hierarchical scheme, liturgical texts do not. Siddur texts also have a canonical naming scheme, using the `prayer` namespace. Names will normally be in 
 transliterated Hebrew. Spaces are replaced by `_` characters. Unless the text has a common name (with a common
@@ -115,6 +117,76 @@ All URIs reference the following scopes:
 1. If the URI is on an element with non-empty content, it references that content.
 2. If the URI is on an empty milestone like element (`milestone`, `pb`, `lb`, etc.) it references that milestone unit until the next milestone of the same unit *or* the end of the file if no subsequent milestone of the same unit exists.
 3. If the URI is on an empty anchor (`anchor`), it references that specific point in the document.
+
+## Versification
+
+Editions of the Tanakh do not all divide the text into verses the same way, but a verse URN has to denote the
+same words everywhere or nothing can be joined to anything. The URN space therefore has one **canonical** verse
+division, and every project maps its own numbering onto it.
+
+> **A canonical verse boundary is any point that is a verse boundary under _either_ ta'am elyon or ta'am
+> tachton.**
+
+The two cantillations divide the Decalogue differently. Ta'am tachton merges the four short commandments into a
+single verse — they are too short to stand alone — and reads אנכי together with לא יהיה לך. Ta'am elyon does the
+reverse: one verse per commandment, so the four short ones are four verses, while the first two commandments
+each run long. Neither division is a refinement of the other, but their union is finer than both, and every
+edition's division is a coarsening of that union. An edition verse is therefore always a whole number of
+consecutive canonical verses, which is what makes a mapping possible at all.
+
+The canonical division is the one the Leningrad Codex numbers, so `wlc` needs no mapping. Exodus 20 has **26**
+canonical verses and Deuteronomy 5 has **33**:
+
+| canonical | text | MAM (ta'am tachton) | JPS 1917 (common) |
+|---|---|---|---|
+| `exodus/20/2` | אנכי | 20:2 | 20:2 |
+| `exodus/20/3` | לא יהיה לך | 20:2 | 20:3 |
+| `exodus/20/13` | לא תרצח | 20:12 | 20:13 |
+| `exodus/20/14` | לא תנאף | 20:12 | 20:13 |
+| `exodus/20/15` | לא תגנב | 20:12 | 20:13 |
+| `exodus/20/16` | לא תענה | 20:12 | 20:13 |
+| `exodus/20/17` | לא תחמד | 20:13 | 20:14 |
+| `exodus/20/26` | ולא תעלה במעלת | 20:22 | 20:23 |
+
+A handful of chapters diverge for reasons unrelated to cantillation — a chapter boundary one verse further on,
+a verse a witness does not contain. Those are recorded in `opensiddur/common/versification.py`, which is the
+single place any edition's numbering is stated.
+
+### Recording an edition's own numbering
+
+Two milestone units carry the two numberings, and they must not be confused:
+
+| unit | `@corresp` | `@n` | role |
+|---|---|---|---|
+| `verse` | required, canonical URN | canonical number | identity, alignment, transclusion |
+| `edition-verse` | **never** | the edition's own number | display only |
+
+```xml
+<!-- Miqra al pi ha-Masorah, Exodus 20. One MAM verse, four canonical verses. -->
+<tei:milestone unit="edition-verse" n="12"/>
+<tei:p><tei:milestone unit="verse" n="13" corresp="urn:x-opensiddur:text:bible:exodus/20/13"/>לֹא תִרְצָח</tei:p>
+<tei:p><tei:milestone unit="verse" n="14" corresp="urn:x-opensiddur:text:bible:exodus/20/14"/>לֹא תִנְאָף</tei:p>
+<tei:p><tei:milestone unit="verse" n="15" corresp="urn:x-opensiddur:text:bible:exodus/20/15"/>לֹא תִגְנֹב</tei:p>
+<tei:p><tei:milestone unit="verse" n="16" corresp="urn:x-opensiddur:text:bible:exodus/20/16"/>לֹא תַעֲנֶה</tei:p>
+<tei:milestone unit="edition-verse" n="13"/>
+<tei:milestone unit="verse" n="17" corresp="urn:x-opensiddur:text:bible:exodus/20/17"/>לֹא תַחְמֹד
+```
+
+Because `edition-verse` carries no `@corresp`, the reference database and the parallel compiler — which look
+only at `@corresp` — ignore it entirely. Which numbering a reader sees is a rendering choice, driven by the
+`opensiddur:verse-numbering` setting.
+
+### Rules
+
+- **One milestone per canonical verse, exactly once per project.** A verse split across paragraphs by a
+  parashah break in the middle of it is still one verse and keeps one milestone; its scope runs to the next
+  verse milestone regardless of paragraph boundaries. Repeating the milestone gives the verse two identical
+  `@corresp` values, and both the reference database and the parallel compiler keep only the first and silently
+  drop the rest.
+- **Never renumber to paper over a disagreement.** If an edition's verse count does not match the canonical
+  one and the reason is not in the versification table, that is a defect in the importer or an unrecorded
+  divergence, not something to be shifted into alignment.
+- `opensiddur/exporter/validate_versification.py` checks both of these across the Tanakh projects.
 
 #### Contributors and contributor URNs
 Contributions are credited in the file header using `tei:respStmt` entries, with a contributor URN stored in `tei:name/@ref`.
@@ -1152,5 +1224,10 @@ The truth tables are here:
 
 ### Alignment
 
-Translation (or other alternate text) alignment can be performed if both texts declare their correspondence to common URNs using the `corresp` attribute. For example, if two Bibles declare that a verse corresponds to `urn:x-opensiddur:text:bible:song_of_songs/1/5`, then that segment of text can be aligned with each other. The alignment will starting from the declared milestone until the next verse-level unit.
+Translation (or other alternate text) alignment can be performed if both texts declare their correspondence to common URNs using the `corresp` attribute. For example, if two Bibles declare that a verse corresponds to `urn:x-opensiddur:text:bible:song_of_songs/1/5`, then that segment of text can be aligned with each other. The alignment starts from the declared milestone and runs until the next verse-level unit.
+
+The join is on exact URN equality and nothing else: the compiler has no notion of one edition's verse
+corresponding to several of another's. Two texts therefore align correctly only if both number their verses
+canonically — see [Versification](#versification) — and a `@corresp` repeated within a document breaks the join
+silently, because only the first segment carrying a given URN is kept.
 

--- a/schema/jlptei.odd.xml
+++ b/schema/jlptei.odd.xml
@@ -539,6 +539,53 @@
             </sch:rule>
           </constraint>
         </constraintSpec>
+        <constraintSpec ident="corresp-uniqueness" scheme="schematron">
+          <desc>
+            A text URN names one stretch of text, so it may appear on at most one element per
+            document. A repeated corresp breaks alignment and resolution silently: the
+            reference database keeps only the first element bearing it, and the parallel
+            compiler drops every segment after the first.
+
+            Only text URNs are identities. A condition URN is a feature *name* and is meant
+            to repeat — one setting selects the ta'am elyon reading everywhere it occurs —
+            so it is deliberately outside this rule.
+          </desc>
+          <constraint>
+            <sch:rule context="//*[starts-with(@corresp, 'urn:x-opensiddur:text:')]"
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+              <sch:report test="preceding::*[@corresp = current()/@corresp]">
+                The corresp <sch:value-of select="@corresp"/> is used more than once in this
+                document. Each text URN must identify exactly one element.
+              </sch:report>
+            </sch:rule>
+          </constraint>
+        </constraintSpec>
+    </elementSpec>
+
+    <!-- Verse milestones carry two numberings. unit="verse" is the canonical division and
+         carries the URN that joins projects together; unit="edition-verse" carries the
+         edition's own verse number for display and must never carry a URN, so that the
+         reference database and the parallel compiler ignore it. See JLPTEI-3.md,
+         "Versification". -->
+    <elementSpec ident="milestone" module="core" mode="change">
+        <constraintSpec ident="edition-verse-constraints" scheme="schematron">
+          <desc>
+            An edition-verse milestone records an edition's own numbering, not an identity.
+          </desc>
+          <constraint>
+            <sch:rule context="tei:milestone[@unit = 'edition-verse']"
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+              <sch:assert test="@n">
+                A milestone with unit="edition-verse" must carry the edition's verse number in @n.
+              </sch:assert>
+              <sch:assert test="not(@corresp)">
+                A milestone with unit="edition-verse" must not carry @corresp: it records an
+                edition's own numbering for display, and only the canonical unit="verse"
+                milestone identifies the text.
+              </sch:assert>
+            </sch:rule>
+          </constraint>
+        </constraintSpec>
     </elementSpec>
 
     </schemaSpec>


### PR DESCRIPTION
## The problem

A verse URN is the only join key between projects: `external_compiler.make_rows` pairs parallel text by exact `@corresp` equality, and the reference database resolves transclusion ranges by it. But WLC, MAM and JPS each minted URNs in their own numbering, and they divide the Decalogue differently:

| | Exodus 20 | Deuteronomy 5 |
|---|---|---|
| WLC | 26 verses | 33 |
| JPS 1917 | 23 | 30 |
| MAM | 22 | 29 |

So `exodus/20/14` meant לא תנאף in WLC and "Thou shalt not covet" in JPS. Nothing failed — the compiler simply paired the wrong verses, `exodus/20/26` and `deuteronomy/5/33` resolved only in `wlc`, and MAM's four short commandments all carried the *same* URN, which `refdb` and `make_rows` each resolve by keeping the first and silently dropping the rest.

## The canonical division

> A canonical verse boundary is any point that is a verse boundary under **either** ta'am elyon or ta'am tachton.

The two cantillations divide the Decalogue in opposite directions — tachton merges the four short commandments and runs the first two commandments long, elyon splits the four and merges the first two. Neither is a refinement of the other, but their union is finer than both, so every edition's division is a coarsening of it and an edition verse is always a whole number of consecutive canonical verses.

That union is exactly what the Leningrad Codex numbers (26 and 33), so `wlc` needs no remapping. Verified mechanically against MAM's own source, which ships both strands: MAM verses + interior elyon sof-pasuk boundaries = WLC's count in **923 of 929** chapters, including both Decalogue chapters exactly.

## How each importer gets there

- **MAM** derives the boundaries from its own `{{מ:כפול}}` strands rather than from a table — a table would be a second, divergent statement of the same fact.
- **JPS** sets the four commandments as separate paragraphs, so its boundaries are in its source too.
- **WLC** is unchanged; it is already canonical.

Each edition's own numbering is preserved on a new `tei:milestone[@unit='edition-verse']` that carries **no** `@corresp`, so `refdb` and the parallel compiler ignore it entirely — no exporter changes were needed — while a renderer can still show it.

## Divergences unrelated to cantillation

`opensiddur/common/versification.py` records the rest, verified by aligning MAM's TSV against the WLC XML verse by verse across the whole Tanakh: Numbers 25/26 (a merge across a chapter boundary), Joshua 21:36-37 (absent from MAM), Jeremiah 30/31 and 1 Samuel 23/24 (chapter boundary one verse further on). Note **Numbers 10 is not divergent** — that was a project defect, not a source one.

## Two bugs this surfaced

Both were silently dropping text and are fixed here:

- MAM repeated a verse's milestone after a mid-verse parashah break, giving לא תחמד two identical `corresp` values.
- JPS emitted a chapter milestone from *both* the `dropinitial` and the verse-1 marker (10 duplicates across 7 files).

## Guards added

- `refdb.add_urn_mapping` raises `DuplicateUrnError` instead of resolving a conflict silently.
- New `exporter/validate_versification.py` compares verse URNs across the Tanakh projects. Verses genuinely absent from a witness are documented; chapters still under investigation are reported separately from regressions so they do not drown out new ones.
- Schematron: `@corresp` unique per document for `urn:x-opensiddur:text:` (condition URNs are feature *names* and are meant to repeat), and `unit='edition-verse'` must have `@n` and must not have `@corresp`.
- `JLPTEI-3.md` gains a **Versification** section; the claim that a verse URN "identifies the chapter in *every possible* source" is replaced with the rule that makes it true.

## Verification

- 1220 tests pass.
- All 26 canonical verses of Exodus 20 now resolve in all three projects; previously `exodus/20/26` resolved only in `wlc`.
- Cross-project validator: **330 duplicates + 19 coverage problems → 27 + 0**.
- Chapter milestones checked before/after: none lost, none gained, 10 duplicates fixed.

Companion data PR: opensiddur/opensiddur-projects#9

## Not in this PR

- **The humash change.** `opensiddur/importer/humash` exists only on the unmerged `feat/humash` branch. Once these meet, `DIVERGENT_CHAPTER_VERSES` can go and `_numbered_variants`/`_restated` collapse to a single unconditional canonical range — which also fixes Parashat Yitro silently losing four verses.
- **`jonah` and `habakkuk`.** Both books' page ranges overlap the next book's first page and the importer mints the next book's opening verses under this book's name (Micah 1:1 becomes `jonah/1/1`). Fixing it needs a decision, since the multi-heading branch it lives in exists for Psalms' genuine sub-books.
- **10 chapters where JPS's verse count still differs**, listed in `UNRESOLVED_CHAPTERS`. The validator's output suggests `zechariah` 4 and 14 are transposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
