### PR TITLE
Fix MAM importer: use tei:anchor for note targets, not empty tei:seg

### DIFF
--- a/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
@@ -237,11 +237,7 @@
   <!-- Variant documentation (נוסח) -->
   <xsl:template match="miqra:variant" mode="inline">
     <xsl:if test="@noteId">
-      <!-- Use tei:seg instead of tei:anchor because the compiler inserts resolved
-           annotations as children of the referenced element; tei:anchor must be empty. -->
-      <tei:seg>
-        <xsl:attribute name="xml:id" select="concat(@noteId, '-ref')"/>
-      </tei:seg>
+      <tei:anchor xml:id="{concat(@noteId, '-ref')}"/>
     </xsl:if>
     <xsl:apply-templates select="miqra:display" mode="inline"/>
   </xsl:template>
@@ -358,18 +354,17 @@
   </xsl:template>
 
   <xsl:template match="miqra:anchor" mode="inline">
-    <!-- Use tei:seg instead of tei:anchor because annotations get inserted as children. -->
-    <tei:seg>
+    <tei:anchor>
       <xsl:copy-of select="@xml:id"/>
-    </tei:seg>
+    </tei:anchor>
   </xsl:template>
 
   <!-- An anchor lifted out of column C sits beside the parashah breaks, not inside a verse,
        so it reaches mode="block"; without this rule the built-in one would discard it. -->
   <xsl:template match="miqra:anchor" mode="block">
-    <tei:seg>
+    <tei:anchor>
       <xsl:copy-of select="@xml:id"/>
-    </tei:seg>
+    </tei:anchor>
   </xsl:template>
 
   <!-- Dual cantillation (מ:כפול): the two readings are alternate wordings of the same text,
@@ -396,13 +391,13 @@
   </xsl:template>
 
   <xsl:template match="miqra:variant[@noteId]" mode="anchor-only">
-    <tei:seg xml:id="{@noteId}-ref"/>
+    <tei:anchor xml:id="{@noteId}-ref"/>
   </xsl:template>
 
   <xsl:template match="miqra:anchor" mode="anchor-only">
-    <tei:seg>
+    <tei:anchor>
       <xsl:copy-of select="@xml:id"/>
-    </tei:seg>
+    </tei:anchor>
   </xsl:template>
 
   <!-- A strand is only ever reached through miqra:dual-accent, which selects its children

--- a/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
+++ b/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
@@ -76,8 +76,8 @@ def _verse_text(body: etree._Element, chapter: str, verse: str) -> str:
 
 def _anchor_ids(element: etree._Element) -> list[str]:
     return [
-        seg.get(f"{{http://www.w3.org/XML/1998/namespace}}id")
-        for seg in element.findall(f".//{{{TEI_NS}}}seg")
+        anchor.get(f"{{http://www.w3.org/XML/1998/namespace}}id")
+        for anchor in element.findall(f".//{{{TEI_NS}}}anchor")
     ]
 
 
@@ -128,8 +128,8 @@ class TestDualAccent(unittest.TestCase):
         note = stand_off.find(f".//{{{TEI_NS}}}note")
         self.assertEqual("#n1-ref", note.get("target"))
         anchors = [
-            seg.get(f"{{http://www.w3.org/XML/1998/namespace}}id")
-            for seg in body.findall(f".//{{{TEI_NS}}}seg")
+            anchor.get(f"{{http://www.w3.org/XML/1998/namespace}}id")
+            for anchor in body.findall(f".//{{{TEI_NS}}}anchor")
         ]
         self.assertIn("n1-ref", anchors)
 


### PR DESCRIPTION
## Summary
- The Miqra al pi ha-Masorah (MAM) importer minted empty `<tei:seg>` elements as note anchor targets. `JLPTEI-3.md`'s "Anchors" / "Comments and Notes" sections document `tei:anchor` as the correct element for this; `tei:seg` is meant to wrap actual segmented text content.
- Each occurrence carried a comment claiming `tei:anchor` couldn't be used because the compiler inserts resolved notes as children, which would violate `tei:anchor`'s empty content model. That premise doesn't hold: the note insertion happens on the exporter's compiled "pseudo-TEI" linear intermediate, which is explicitly documented as not required to be schema-valid (`compiler.py` docstring, `exporter/README.md`), and `tex/reledmac.xslt` already special-cases `tei:anchor` to emit nothing at that stage. The `wlc` and `jps1917` importers already use `tei:anchor` this way without issue.
- Swapped all 5 `tei:seg` occurrences in `miqra_to_tei.xslt` for `tei:anchor` and removed the stale comments; updated the corresponding test assertions.

## Test plan
- [x] `bash scripts/build-schema.sh`
- [x] `uv run pytest opensiddur/tests/importer/miqra_al_pi_hamasorah/` — 95 passed, 1 skipped
- [x] `uv run pytest` (full suite) — 1209 passed, 21 skipped

## Follow-up (not in this PR)
Any MAM-derived files already imported into `opensiddur-projects/` still carry the old `tei:seg` encoding and would need the importer re-run against real sources to pick up this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)