### PR TITLE
Fix Jonah and Habakkuk page ranges bleeding into next book

### DIFF
--- a/opensiddur/exporter/validate_versification.py
+++ b/opensiddur/exporter/validate_versification.py
@@ -49,8 +49,7 @@ KNOWN_ABSENCES: dict[str, set[tuple[str, int, int]]] = {
 #: Chapters where a project's verse division is known to differ and has not yet been
 #: reconciled with the canonical numbering. These predate the canonical URN space and are
 #: reported as unresolved rather than as regressions. Each needs the edition's own text
-#: aligned against the canonical division before it can be encoded or fixed; zechariah 4
-#: and 14 in particular look transposed rather than genuinely divergent.
+#: aligned against the canonical division before it can be encoded or fixed.
 UNRESOLVED_CHAPTERS: set[tuple[str, str, int]] = {
     ("jps1917", "ezra", 2),
     ("jps1917", "ezra", 4),
@@ -59,9 +58,6 @@ UNRESOLVED_CHAPTERS: set[tuple[str, str, int]] = {
     ("jps1917", "leviticus", 14),
     ("jps1917", "nehemiah", 7),
     ("jps1917", "psalms", 30),
-    ("jps1917", "zechariah", 4),
-    ("jps1917", "zechariah", 8),
-    ("jps1917", "zechariah", 14),
 }
 
 

--- a/opensiddur/importer/jps1917/convert_wikisource.py
+++ b/opensiddur/importer/jps1917/convert_wikisource.py
@@ -234,7 +234,7 @@ JPS_1917 = [
                                 book_name_he = "יונה",
                                 file_name = "jonah",
                                 start_page = 736+PAGE_OFFSET,
-                                end_page = 739+PAGE_OFFSET,
+                                end_page = 738+PAGE_OFFSET,
                                 is_section = True,
                             ),
                             Book(
@@ -258,7 +258,7 @@ JPS_1917 = [
                                 book_name_he = "חבקוק",
                                 file_name = "habakkuk",
                                 start_page = 749+PAGE_OFFSET,
-                                end_page = 753+PAGE_OFFSET,
+                                end_page = 752+PAGE_OFFSET,
                                 is_section = True,
                             ),
                             Book(


### PR DESCRIPTION
## Summary
- Jonah->Micah and Habakkuk->Zephaniah were the only 2 of 9 boundary pages in "The Twelve" with no `<section>` tags marking a genuinely shared page. The declared `end_page` for each extended one page too far into the next book's opening page, so the XSLT's section-fallback kept the whole page and minted the next book's opening verses under the wrong book's URN (e.g. Micah 1:1 as `jonah/1/1`).
- Narrowed Jonah's `end_page` 739->738 and Habakkuk's 753->752 (in printed-page terms). No change needed to the multi-heading branch used for Psalms' sub-books, since with correct ranges only one heading is ever in scope for these two books.
- Removed `("jps1917","zechariah",4)`, `("jps1917","zechariah",8)`, `("jps1917","zechariah",14)` from `UNRESOLVED_CHAPTERS` now that the underlying transcription errors are fixed (opensiddur/sourcetexts#2).

## Test plan
- [x] Regenerated `jonah.xml`/`habakkuk.xml`/`zechariah.xml` from the fixed sourcetexts branch; confirmed no leaked next-book content and correct Zechariah 4/8/14 verse URNs
- [x] `uv run python -m opensiddur.exporter.validate_versification` reports OK with only the remaining 7 known unresolved chapters
- [x] `uv run pytest` — 1209 passed, 21 skipped, including the Psalms multi-heading test

🤖 Generated with [Claude Code](https://claude.com/claude-code)