### PR TITLE
Add the humash: the Torah arranged by liturgical reading (Hebrew edition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Shared table of the 54 weekly parshiyot (`opensiddur/importer/util/parshiyot.py`), mapping any
   source's spelling of a parshah name to a canonical Hebrew name and a URN slug.
+- The humash emits the triennial haftarot: 150 readings over 51 parshiyot, each a headed
+  alternative to the annual haftarah of its week rather than an addition to it.
+- `opensiddur:reading-cycle`, the feature structure by which a volume says which haftarot it
+  carries: `annual`, and one binary per year of the triennial cycle, so that a volume may be
+  for one Shabbat or for a whole three-year cycle. `opensiddur:torah-reading` gains
+  `triennial-year`, the cycle year of the declared date.
 
 ### Fixed
+- `readings.triennial_haftarot` was read but never called, and dropped the 36 readings hebcal
+  records as a list of pieces. A piece lying inside one already listed is the verse the pairing
+  with the parshah turns on, and is no longer taken for a continuation of the reading.
+- `parse_hebcal_ref` no longer raises on a boundary stated inside a verse, such as the
+  Nachum 2:2b-2:3a of Emor's third year.
 - Miqra al pi ha-Masorah importer: the `{{מ:כפול}}` template, which carries a verse in both
   cantillations (ta'am elyon and ta'am tachton), was discarded by the stylesheet, emitting the
   Ten Commandments as empty verses in Exodus 20 and Deuteronomy 5. The two readings now become a

--- a/doc/humash-settings.example.yaml
+++ b/doc/humash-settings.example.yaml
@@ -1,0 +1,58 @@
+---
+# Example settings for compiling the humash.
+#
+# The humash holds no text of its own: every reading is transcluded by URN, and the targets
+# carry no project suffix, so these priorities decide which edition supplies the words.
+
+priority:
+  # Miqra al pi ha-Masorah first: the aliyah and maftir divisions were taken from MAM, so its
+  # verse numbering is the one the ranges are stated in. Put wlc first instead and the four
+  # chapters the editions divide differently — Exodus 20, Numbers 10, Numbers 25 and
+  # Deuteronomy 5 — will need opensiddur:verse-numbering set to match; see below.
+  transclusion:
+    - miqra_al_pi_hamasorah
+    - wlc
+    - jps1917
+  instructions:
+    - humash
+    - miqra_al_pi_hamasorah
+
+annotations:
+  - miqra_al_pi_hamasorah
+
+# Hebrew against the JPS 1917 English. Drop this block for a Hebrew-only volume.
+parallel:
+  projects:
+    - miqra_al_pi_hamasorah
+    - jps1917
+  column_order: primary_first
+
+declarations:
+  # Which edition's verse division the transclusion ranges are stated in. Leaving this unset
+  # uses MAM's, which is the default the humash is generated for. Set one of leningrad or
+  # common — and match priority.transclusion to it — to read the four divergent chapters as
+  # wlc or as the common printed editions divide them.
+  opensiddur:verse-numbering:
+    masorah: true
+
+  # Which rite's haftarot to print. Leaving the group out entirely keeps *every* variant,
+  # each under a heading naming whose custom it is, which is usually what a printed volume
+  # wants. Several may be true at once.
+  opensiddur:rite:
+    ashkenaz: true
+
+  # The megillot and the festival readings are conditioned on the occasion. Declaring a date
+  # derives opensiddur:holiday and opensiddur:torah-reading from it, so a volume compiled for
+  # one day carries only that day's readings. Omit the date to keep them all.
+  #
+  # opensiddur:gregorian-date:
+  #   year: 2025
+  #   month: 3
+  #   day: 1
+
+typography:
+  hebrew_font: "Frank Ruehl CLM"
+  latin_font: "Linux Libertine O"
+  layout: pairs
+  paper: letterpaper
+  fontsize: "11pt"

--- a/doc/humash-settings.example.yaml
+++ b/doc/humash-settings.example.yaml
@@ -5,10 +5,9 @@
 # carry no project suffix, so these priorities decide which edition supplies the words.
 
 priority:
-  # Miqra al pi ha-Masorah first: the aliyah and maftir divisions were taken from MAM, so its
-  # verse numbering is the one the ranges are stated in. Put wlc first instead and the four
-  # chapters the editions divide differently — Exodus 20, Numbers 10, Numbers 25 and
-  # Deuteronomy 5 — will need opensiddur:verse-numbering set to match; see below.
+  # Miqra al pi ha-Masorah first, since the aliyah and maftir divisions were taken from MAM.
+  # The order decides only which edition's words are set: every project mints URNs in the one
+  # canonical verse division, so any order resolves the same verses.
   transclusion:
     - miqra_al_pi_hamasorah
     - wlc
@@ -28,13 +27,6 @@ parallel:
   column_order: primary_first
 
 declarations:
-  # Which edition's verse division the transclusion ranges are stated in. Leaving this unset
-  # uses MAM's, which is the default the humash is generated for. Set one of leningrad or
-  # common — and match priority.transclusion to it — to read the four divergent chapters as
-  # wlc or as the common printed editions divide them.
-  opensiddur:verse-numbering:
-    masorah: true
-
   # Which rite's haftarot to print. Leaving the group out entirely keeps *every* variant,
   # each under a heading naming whose custom it is, which is usually what a printed volume
   # wants. Several may be true at once.

--- a/doc/humash-settings.example.yaml
+++ b/doc/humash-settings.example.yaml
@@ -45,6 +45,14 @@ declarations:
   # derives opensiddur:holiday and opensiddur:torah-reading from it, so a volume compiled for
   # one day carries only that day's readings. Omit the date to keep them all.
   #
+  # A date also settles the triennial division of the twelve parshiyot that are sometimes read
+  # together with their partner, which divide differently depending on how the pair fell in
+  # that three-year cycle: opensiddur:torah-reading gets a triennial-pattern- feature per pair,
+  # and each file keeps only the division that pattern calls for. Without a date every division
+  # is kept, each marked with its cycle year, the way leaving opensiddur:rite out keeps every
+  # rite's haftarah. The reading of the weeks the pair is read together is always kept, marked
+  # מחוברות in the margin.
+  #
   # opensiddur:gregorian-date:
   #   year: 2025
   #   month: 3

--- a/doc/humash-settings.example.yaml
+++ b/doc/humash-settings.example.yaml
@@ -58,6 +58,36 @@ declarations:
   #   month: 3
   #   day: 1
 
+  # Which haftarot this volume carries. Leaving the group out reads annually, which is the one
+  # place the humash decides rather than keeping every variant: 51 parshiyot have a haftarah of
+  # their own for each year of the triennial cycle, and those are alternatives to the annual
+  # haftarah of the same Shabbat rather than additions to it, so a volume that kept them all
+  # would print four haftarot for one week.
+  #
+  # For one Shabbat, set triennial true and declare a date above — that settles which of the
+  # three years is read, and drops the annual haftarah:
+  #
+  # opensiddur:reading-cycle:
+  #   triennial: true
+  #
+  # For a volume covering a whole three-year cycle, name the years instead. Each is its own
+  # setting, so any combination is possible; keep annual as well to print all four.
+  #
+  # opensiddur:reading-cycle:
+  #   annual: false
+  #   triennial-year-1: true
+  #   triennial-year-2: true
+  #   triennial-year-3: true
+  #
+  # Either way the parshiyot with no triennial haftarah keep their annual one — Devarim,
+  # Vaetchanan and Vezot Haberakhah, which never have one; the pairs, which have none of their
+  # own; and Tazria, Achrei Mot and Behar in year 3, when they are read with their partner. So
+  # no week is ever left without a haftarah, whichever years are chosen.
+  #
+  # The triennial *Torah* divisions do not go through this: they are markers over the annual
+  # text rather than a separate reading, so every year's are always present, marked with the
+  # cycle year in the margin.
+
 typography:
   hebrew_font: "Frank Ruehl CLM"
   latin_font: "Linux Libertine O"

--- a/opensiddur/exporter/calendar/compute.py
+++ b/opensiddur/exporter/calendar/compute.py
@@ -81,9 +81,29 @@ AGGREGATE_FEATURES = (
     "day-after-holiday",
 )
 
+# The modern triennial cycle as reckoned by the CJLS, whose first year was 5756.
+_TRIENNIAL_EPOCH_YEAR = 5756
+
+# The six pairs of parshiyot whose triennial division depends on how the pair fell in the
+# cycle, each with the index pyluach gives the first of the two. Nitzavim-Vayeilech is doubled
+# as well but divides the same way however it falls, so it needs no feature.
+TRIENNIAL_PAIRS: tuple[tuple[str, int], ...] = (
+    ("vayakhel-pekudei", 21),
+    ("tazria-metzora", 26),
+    ("achrei-mot-kedoshim", 28),
+    ("behar-bechukotai", 31),
+    ("chukat-balak", 38),
+    ("matot-masei", 41),
+)
+
+TRIENNIAL_PATTERN_FEATURES = tuple(
+    f"triennial-pattern-{pair}" for pair, _ in TRIENNIAL_PAIRS
+)
+
 TORAH_FEATURES = (
     "diaspora-parsha",
     "israel-parsha",
+    *TRIENNIAL_PATTERN_FEATURES,
     "shabbat-shuva",
     "shabbat-shira",
     "shabbat-shkalim",
@@ -551,6 +571,32 @@ def _parsha_slug(name: str) -> str:
     return name.lower().replace(" ", "-").replace(",", "")
 
 
+def _triennial_cycle_patterns(hebrew_year: int, israel: bool) -> dict[str, str]:
+    """For each pair, whether it was read [T]ogether or [S]eparately in each year of the cycle.
+
+    The three characters run from the first year of the cycle, so ``"TSS"`` means the pair was
+    read together in the first year and apart in the other two. The triennial division of a
+    parshah that is sometimes doubled depends on this pattern rather than on the cycle year
+    alone, which is why it is derived here; the humash conditions on it.
+
+    The Hebrew year is enough to identify a pair's week, even though the reading year turns
+    over at Simhat Torah rather than at Rosh Hashanah: every one of these pairs is read
+    between Adar and Av.
+    """
+    start = hebrew_year - ((hebrew_year - _TRIENNIAL_EPOCH_YEAR) % 3)
+    combined_per_year = []
+    for year in (start, start + 1, start + 2):
+        table = parshios.parshatable(year, israel=israel)
+        combined_per_year.append({
+            reading[0] for reading in table.values()
+            if reading is not None and len(reading) > 1
+        })
+    return {
+        pair: "".join("T" if index in combined else "S" for combined in combined_per_year)
+        for pair, index in TRIENNIAL_PAIRS
+    }
+
+
 def compute_torah_reading(snapshot: SettingSnapshot) -> dict[str, Any] | None:
     gdate = snapshot.gregorian_date()
     if gdate is None:
@@ -562,6 +608,11 @@ def compute_torah_reading(snapshot: SettingSnapshot) -> dict[str, Any] | None:
         "diaspora-parsha": _parsha_slug(diaspora),
         "israel-parsha": _parsha_slug(israel),
     }
+    patterns = _triennial_cycle_patterns(
+        g.to_heb().year, israel=not snapshot.is_diaspora()
+    )
+    for pair, pattern in patterns.items():
+        result[f"triennial-pattern-{pair}"] = pattern
     for feature in TORAH_FEATURES:
         if feature not in result:
             result[feature] = False

--- a/opensiddur/exporter/calendar/compute.py
+++ b/opensiddur/exporter/calendar/compute.py
@@ -27,6 +27,7 @@ FS_DAY_OF_WEEK = "opensiddur:day-of-week"
 FS_HOLIDAY = "opensiddur:holiday"
 FS_HOLIDAY_AGG = "opensiddur:holiday-aggregate"
 FS_TORAH = "opensiddur:torah-reading"
+FS_READING_CYCLE = "opensiddur:reading-cycle"
 FS_SERVICE_TIME = "opensiddur:service-time"
 FS_QUORUM = "opensiddur:quorum"
 FS_HOUSEHOLD = "opensiddur:household"
@@ -103,6 +104,7 @@ TRIENNIAL_PATTERN_FEATURES = tuple(
 TORAH_FEATURES = (
     "diaspora-parsha",
     "israel-parsha",
+    "triennial-year",
     *TRIENNIAL_PATTERN_FEATURES,
     "shabbat-shuva",
     "shabbat-shira",
@@ -113,6 +115,29 @@ TORAH_FEATURES = (
     "shabbat-hazon",
     "shabbat-nahamu",
 )
+
+# Which readings the volume carries: the annual haftarah of each week, or the triennial one of
+# a given cycle year, or several at once. One binary per year rather than a single year number,
+# so that a volume for a whole three-year cycle can turn on all three — a printed humash is a
+# durable book, and covering a cycle is at least as natural as being for one Shabbat. Several
+# may be true together, the way several rites may be.
+#
+# `triennial` is the volume's opt-in, and is what makes a date mean anything here: every date
+# falls in some year of the cycle, including the dates a volume that reads annually is compiled
+# for, so the date alone can never select a reading. It is never derived.
+#
+# These take a value rather than staying undefined, unlike most features. The annual haftarah
+# and the three triennial ones are read on the same Shabbat, and an undefined condition keeps
+# its text, so leaving them open would print four haftarot for one week.
+TRIENNIAL_YEARS = (1, 2, 3)
+
+TRIENNIAL_YEAR_FEATURES = tuple(f"triennial-year-{year}" for year in TRIENNIAL_YEARS)
+
+READING_CYCLE_DEFAULTS: dict[str, Any] = {
+    "annual": True,
+    "triennial": False,
+    **dict.fromkeys(TRIENNIAL_YEAR_FEATURES, False),
+}
 
 SERVICE_TIME_FEATURES = (
     "shaharit",
@@ -571,6 +596,15 @@ def _parsha_slug(name: str) -> str:
     return name.lower().replace(" ", "-").replace(",", "")
 
 
+def _triennial_year(hebrew_year: int) -> int:
+    """Which of the three years of the modern triennial cycle a Hebrew year is (1, 2 or 3).
+
+    The reading year turns over at Simhat Torah rather than at Rosh Hashanah, but both fall in
+    Tishrei, so the Hebrew year identifies the cycle year for every Shabbat that has a reading.
+    """
+    return ((hebrew_year - _TRIENNIAL_EPOCH_YEAR) % 3) + 1
+
+
 def _triennial_cycle_patterns(hebrew_year: int, israel: bool) -> dict[str, str]:
     """For each pair, whether it was read [T]ogether or [S]eparately in each year of the cycle.
 
@@ -607,6 +641,7 @@ def compute_torah_reading(snapshot: SettingSnapshot) -> dict[str, Any] | None:
     result: dict[str, Any] = {
         "diaspora-parsha": _parsha_slug(diaspora),
         "israel-parsha": _parsha_slug(israel),
+        "triennial-year": _triennial_year(g.to_heb().year),
     }
     patterns = _triennial_cycle_patterns(
         g.to_heb().year, israel=not snapshot.is_diaspora()
@@ -648,6 +683,25 @@ def compute_service_time(snapshot: SettingSnapshot) -> dict[str, Any] | None:
         ),
         "neila": holidays.get("yom-kippur", 0) > 0 and aware_dt >= z.plag_hamincha.local,
         "slihot": z.alot_hashachar.local <= aware_dt < z.netz_hachama.local,
+    }
+
+
+def compute_reading_cycle(snapshot: SettingSnapshot) -> dict[str, Any] | None:
+    """Turn a triennial volume's date into the one cycle year it reads.
+
+    This is where the volume's choice of cycle and its date meet: the cycle year of the date
+    sits on ``opensiddur:torah-reading`` whatever cycle the volume follows, so it cannot select
+    a reading by itself. A volume that reads annually is left alone however its date falls.
+
+    Only the volume compiled for a particular Shabbat is derived. One that turns the year
+    features on itself — a volume for a whole cycle, which turns on all three — says so
+    explicitly and is not overridden, since a declared value beats a derived one.
+    """
+    triennial = snapshot.get_bool(FS_READING_CYCLE, "triennial") is True
+    year = snapshot.get_int(FS_TORAH, "triennial-year") if triennial else None
+    return {
+        "annual": year is None,
+        **{f"triennial-year-{n}": n == year for n in TRIENNIAL_YEARS},
     }
 
 

--- a/opensiddur/exporter/compiler.py
+++ b/opensiddur/exporter/compiler.py
@@ -166,10 +166,20 @@ class CompilerProcessor:
                     (context.get('element_path') or "")
                 )
             else:
-                # For the current context include project/file but not element_path —
-                # element_path varies per element and would break ID-rewriting consistency.
-                # When a specific element is needed it is appended separately below.
-                context_path_element = context['project'] + '/' + context['file_name']
+                # For the current context include project/file and the bounds of the range
+                # being transcluded, but not element_path — element_path is reset per element
+                # as it is processed and would break ID-rewriting consistency, since an
+                # xml:id and a target pointing at it must hash alike. The range bounds are
+                # fixed for the whole transclusion, so they are safe, and they are what
+                # distinguishes two ranges of the same file transcluded into one document:
+                # without them a humash pulling eleven ranges out of genesis.xml gives every
+                # copy of an anchor the same rewritten id.
+                context_path_element = (
+                    context['project'] + '/' +
+                    context['file_name'] + '@' +
+                    (context.get('from_start') or "") + '-' +
+                    (context.get('to_end') or "")
+                )
             context_path_elements.append(context_path_element)
         if element is not None:
             element_path = element.getroottree().getpath(element)

--- a/opensiddur/exporter/derivation_graph.py
+++ b/opensiddur/exporter/derivation_graph.py
@@ -15,6 +15,7 @@ from opensiddur.exporter.calendar.compute import (
     FS_ISRAEL,
     FS_LOCATION,
     FS_QUORUM,
+    FS_READING_CYCLE,
     FS_SERVICE_TIME,
     FS_TIME,
     FS_TORAH,
@@ -28,6 +29,7 @@ from opensiddur.exporter.calendar.compute import (
     compute_israel,
     compute_location,
     compute_quorum,
+    compute_reading_cycle,
     compute_service_time,
     compute_torah_reading,
 )
@@ -122,6 +124,12 @@ DERIVATION_SPECS: tuple[DerivationSpec, ...] = (
         fs_type=FS_SERVICE_TIME,
         required_inputs=_gregorian_inputs() | _location_inputs() | _time_inputs(),
         compute=compute_service_time,
+    ),
+    # After the Torah reading, whose cycle year it draws on when the volume reads triennially.
+    DerivationSpec(
+        fs_type=FS_READING_CYCLE,
+        required_inputs=frozenset({(FS_READING_CYCLE, "triennial"), (FS_TORAH, "triennial-year")}),
+        compute=compute_reading_cycle,
     ),
     DerivationSpec(
         fs_type=FS_QUORUM,

--- a/opensiddur/exporter/derived_settings.py
+++ b/opensiddur/exporter/derived_settings.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any
 
-from opensiddur.exporter.calendar.compute import SettingSnapshot
+from opensiddur.exporter.calendar.compute import (
+    FS_READING_CYCLE,
+    READING_CYCLE_DEFAULTS,
+    SettingSnapshot,
+)
 from opensiddur.exporter.conditional_settings import INIT_DECLARE_ID
 from opensiddur.exporter.derivation_graph import DerivationSpec, topological_derivation_order
 from opensiddur.exporter.linear import ConditionalSettingEntry, LinearData, Undefined
@@ -19,6 +23,15 @@ OVERRIDE_FEATURES = (
     "wedding",
     "sheva-brachot",
 )
+
+# Features that are never computed from anything and take a fixed value unless the volume
+# declares otherwise. An undeclared feature is normally *undefined*, which keeps every variant
+# of a conditional text; these are the ones that instead have to answer true or false, because
+# leaving them open would keep alternatives that contradict one another.
+STATIC_DEFAULTS: dict[str, dict[str, Any]] = {
+    FS_OVERRIDE: dict.fromkeys(OVERRIDE_FEATURES, False),
+    FS_READING_CYCLE: READING_CYCLE_DEFAULTS,
+}
 
 
 class SettingChangeTrigger(StrEnum):
@@ -88,23 +101,24 @@ def _collect_contributors(
     return contributors, True
 
 
-def _push_static_override_defaults(linear_data: LinearData) -> None:
-    for feature_name in OVERRIDE_FEATURES:
-        if get_active_setting_entry(linear_data, FS_OVERRIDE, feature_name) is not None:
-            continue
-        declare_id = derived_declare_id(FS_OVERRIDE, feature_name)
-        _remove_derived_for_feature(linear_data, FS_OVERRIDE, feature_name)
-        register_derived_entry(
-            linear_data,
-            ConditionalSettingEntry(
-                declare_id=declare_id,
-                fs_type=FS_OVERRIDE,
-                feature_name=feature_name,
-                value=False,
-                source="derived",
-                contributors={INIT_DECLARE_ID},
-            ),
-        )
+def _push_static_defaults(linear_data: LinearData) -> None:
+    for fs_type, features in STATIC_DEFAULTS.items():
+        for feature_name, value in features.items():
+            if get_active_setting_entry(linear_data, fs_type, feature_name) is not None:
+                continue
+            declare_id = derived_declare_id(fs_type, feature_name)
+            _remove_derived_for_feature(linear_data, fs_type, feature_name)
+            register_derived_entry(
+                linear_data,
+                ConditionalSettingEntry(
+                    declare_id=declare_id,
+                    fs_type=fs_type,
+                    feature_name=feature_name,
+                    value=value,
+                    source="derived",
+                    contributors={INIT_DECLARE_ID},
+                ),
+            )
 
 
 def _apply_derivation_spec(
@@ -171,7 +185,7 @@ def recalculate_derived_settings(
     del declare_id  # reserved for incremental invalidation in future
 
     if trigger == SettingChangeTrigger.INIT:
-        _push_static_override_defaults(linear_data)
+        _push_static_defaults(linear_data)
 
     snapshot = SettingSnapshot(
         get_setting=lambda fs_type, feature_name: _get_setting_from_linear_data(

--- a/opensiddur/exporter/external_compiler.py
+++ b/opensiddur/exporter/external_compiler.py
@@ -22,7 +22,7 @@ from opensiddur.exporter.constants import (
     is_element_node,
 )
 from opensiddur.exporter.linear import LinearData
-from opensiddur.exporter.refdb import ReferenceDatabase
+from opensiddur.exporter.refdb import UNIT_CONTAINED_BY, ReferenceDatabase
 from opensiddur.exporter.urn import ResolvedUrnRange, UrnResolver
 from lxml import etree
 
@@ -119,6 +119,26 @@ class ExternalCompilerProcessor(CompilerProcessor):
 
         # None = marker mode off; [] = marker mode active
         self.marker_stack: list[tuple[str, ElementBase]] | None = None
+
+    def _is_boundary_container_milestone(self, element: ElementBase) -> bool:
+        """True when `element` is a milestone that opens the container the range's start
+        opens into — e.g. a chapter milestone immediately before the verse milestone a
+        range starts at — so it belongs to the range even though it sits just before it.
+
+        Everything else immediately preceding the start is deliberately excluded (#51: a
+        verse milestone from the verse before would otherwise print a spurious number), but
+        a milestone whose unit *contains* the start's unit (refdb.UNIT_CONTAINED_BY) carries
+        no such content of its own — it only announces the boundary the range is stepping
+        into, which is exactly the range's own first moment.
+        """
+        tei_milestone_tag = f"{{{TEI_NS}}}milestone"
+        if element.tag != tei_milestone_tag or self.start_element is None:
+            return False
+        if self.start_element.tag != tei_milestone_tag:
+            return False
+        start_unit = self.start_element.get("unit")
+        containers = UNIT_CONTAINED_BY.get(start_unit, frozenset())
+        return element.get("unit") in containers and element.getnext() is self.start_element
 
     # ── Marker-mode helpers ─────────────────────────────────────────────────
 
@@ -818,6 +838,9 @@ class ExternalCompilerProcessor(CompilerProcessor):
                 # empty shell of each one -- including verse milestones, which then printed
                 # spurious verse numbers and broke parallel alignment (#51).
                 context['command'] = _ProcessingCommand.COPY_ELEMENT_AND_RECURSE
+                return context
+            elif self._is_boundary_container_milestone(element):
+                context['command'] = _ProcessingCommand.COPY_AND_RECURSE
                 return context
             else:
                 context['command'] = _ProcessingCommand.RECURSE

--- a/opensiddur/exporter/marker_reconstruct.py
+++ b/opensiddur/exporter/marker_reconstruct.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from lxml import etree
 
-from opensiddur.exporter.constants import PROCESSING_NAMESPACE, STRUCTURAL_BLOCKS
+from opensiddur.exporter.constants import PROCESSING_NAMESPACE, STRUCTURAL_BLOCKS, TEI_NS
 
 _P_START = f"{{{PROCESSING_NAMESPACE}}}start"
 _P_END = f"{{{PROCESSING_NAMESPACE}}}end"
@@ -21,6 +21,7 @@ _P_LOGICAL = f"{{{PROCESSING_NAMESPACE}}}logical-id"
 _P_PART = f"{{{PROCESSING_NAMESPACE}}}part"
 _PARALLEL_ITEM = f"{{{PROCESSING_NAMESPACE}}}parallelItem"
 _PARALLEL = f"{{{PROCESSING_NAMESPACE}}}parallel"
+_TEI_MILESTONE = f"{{{TEI_NS}}}milestone"
 
 
 def _structural_marker_map(el: etree.ElementBase) -> dict[str, str]:
@@ -37,7 +38,19 @@ def _structural_marker_map(el: etree.ElementBase) -> dict[str, str]:
 
 
 def substantive_content(el: etree.ElementBase) -> bool:
+    """Whether `el` carries anything worth keeping: real text, or a tei:milestone.
+
+    A milestone (chapter, aliyah, citation, parsha...) has no text of its own, but it is
+    never filler — it is a deliberate marker the source placed there, and the exporter has
+    its own rendering for each kind (or explicitly renders nothing for the ones it doesn't
+    know, see reledmac.xslt's generic milestone fallback). Pruning the wrapper that holds
+    one, on the same footing as a genuinely empty leftover paragraph shell, would drop it
+    from the compiled document before the exporter ever sees it — which is what silently
+    erased chapter numbers whenever one landed alone in its own parallel-aligned segment.
+    """
     def walk(x: etree.ElementBase) -> bool:
+        if x.tag == _TEI_MILESTONE:
+            return True
         if (x.text or "").strip():
             return True
         for c in x:

--- a/opensiddur/exporter/refdb.py
+++ b/opensiddur/exporter/refdb.py
@@ -30,11 +30,19 @@ UNIT_CONTAINED_BY: dict[str, frozenset[str]] = {
     "parsha.annual": frozenset(),
     "aliyah.annual": frozenset({"parsha.annual"}),
     "aliyah.weekday": frozenset({"parsha.annual"}),
-    "aliyah.triennial": frozenset({"parsha.annual"}),
     "maftir.annual": frozenset({"parsha.annual"}),
     "aliyah.festival": frozenset(),
     "maftir.festival": frozenset(),
 }
+
+# Each year of the triennial cycle divides the same parshah differently, and consecutive years
+# deliberately overlap — in Beshalach, year 1's fifth aliyah and year 2's first are the same
+# verses — so every year is its own unit-space rather than all three sharing one.
+UNIT_CONTAINED_BY.update({
+    f"{unit}.{year}": frozenset({"parsha.annual"})
+    for unit in ("aliyah.triennial", "maftir.triennial")
+    for year in (1, 2, 3)
+})
 
 
 class UrnMapping(BaseModel):

--- a/opensiddur/exporter/refdb.py
+++ b/opensiddur/exporter/refdb.py
@@ -44,6 +44,36 @@ UNIT_CONTAINED_BY.update({
     for year in (1, 2, 3)
 })
 
+# Two parshiyot that are sometimes read together share a file, and the reading of the combined
+# week is a division of the pair rather than of either single: the fourth aliyah of the
+# combined Vayakhel-Pekudei runs through the point where Pekudei begins. So it is scoped by
+# the pair and not by parsha.annual, which would cut it there.
+UNIT_CONTAINED_BY.update({
+    "parsha.combined": frozenset(),
+    "aliyah.combined": frozenset({"parsha.combined"}),
+    "aliyah.weekday.combined": frozenset({"parsha.combined"}),
+    "maftir.combined": frozenset({"parsha.combined"}),
+})
+
+_TRIENNIAL_PREFIXES = ("aliyah.triennial.", "maftir.triennial.")
+
+
+def containing_units(unit: str | None) -> frozenset[str] | None:
+    """Which units end `unit`'s scope, or None if the unit is not one this table knows.
+
+    Inside a pair's file a triennial unit-space names the parshah it belongs to and, where the
+    division depends on how the pair fell that cycle, the variation — `aliyah.triennial.
+    behar.IL3.2`. Those are open-ended, so they are matched by shape rather than listed: any
+    triennial unit that names more than a cycle year belongs to a pair's file and is scoped by
+    the pair, since such a division may cross from one of the two parshiyot into the other.
+    """
+    known = UNIT_CONTAINED_BY.get(unit)
+    if known is not None or unit is None:
+        return known
+    if unit.startswith(_TRIENNIAL_PREFIXES):
+        return frozenset({"parsha.combined"})
+    return None
+
 
 class UrnMapping(BaseModel):
     project: str
@@ -253,15 +283,16 @@ class ReferenceDatabase:
         """Whether `following` ends the scope opened by the milestone `element`.
 
         Scope ends at the next milestone of the same unit, or of a unit that contains it
-        (`UNIT_CONTAINED_BY`). When either milestone carries no `@unit`, or carries one that
+        (`containing_units`). When either milestone carries no `@unit`, or carries one that
         is not in the containment table, fall back to comparing the number of path components
         in the URN — the original heuristic, kept so that unit-less documents keep working.
         """
         unit = element.get('unit')
         following_unit = following.get('unit')
+        containers = containing_units(unit)
 
-        if unit and following_unit and unit in UNIT_CONTAINED_BY and following_unit in UNIT_CONTAINED_BY:
-            return following_unit == unit or following_unit in UNIT_CONTAINED_BY[unit]
+        if containers is not None and containing_units(following_unit) is not None:
+            return following_unit == unit or following_unit in containers
 
         num_dividers = element.get('corresp', '').split(':')[-1].count('/')
         following_dividers = following.get('corresp', '').split(':')[-1].count('/')

--- a/opensiddur/exporter/refdb.py
+++ b/opensiddur/exporter/refdb.py
@@ -13,6 +13,30 @@ from opensiddur.common.constants import PROJECT_DIRECTORY, INDEX_DB_DIRECTORY
 
 INDEX_DB_FILE = INDEX_DB_DIRECTORY / "reference.db"
 
+# Which milestone units contain which others.
+#
+# A milestone's URN scopes from the milestone to the next milestone of the *same* unit
+# (schema/JLPTEI-3.md, "URN scope"), or to the next milestone of a unit that *contains* it,
+# since no division crosses the boundary of a division that contains it. A verse therefore
+# ends at the next verse or at the next chapter, but a chapter does not end at the next verse.
+#
+# Reading divisions deliberately overlap and so are absent from each other's containment sets:
+# maftir re-reads the close of the seventh aliyah, weekday aliyot subdivide the Shabbat ones,
+# and triennial breaks cut across the annual ones. Each is contained only by the parsha.
+UNIT_CONTAINED_BY: dict[str, frozenset[str]] = {
+    "verse": frozenset({"chapter"}),
+    "chapter": frozenset(),
+    "parsha": frozenset(),
+    "parsha.annual": frozenset(),
+    "aliyah.annual": frozenset({"parsha.annual"}),
+    "aliyah.weekday": frozenset({"parsha.annual"}),
+    "aliyah.triennial": frozenset({"parsha.annual"}),
+    "maftir.annual": frozenset({"parsha.annual"}),
+    "aliyah.festival": frozenset(),
+    "maftir.festival": frozenset(),
+}
+
+
 class UrnMapping(BaseModel):
     project: str
     file_name: str
@@ -216,11 +240,30 @@ class ReferenceDatabase:
         ''', (urn, project, file_name, element_path, element_tag, element_type, end_element_path, end_includes_tail))
         self.conn.commit()
 
+    @staticmethod
+    def _milestone_terminates(element: ElementBase, following: ElementBase) -> bool:
+        """Whether `following` ends the scope opened by the milestone `element`.
+
+        Scope ends at the next milestone of the same unit, or of a unit that contains it
+        (`UNIT_CONTAINED_BY`). When either milestone carries no `@unit`, or carries one that
+        is not in the containment table, fall back to comparing the number of path components
+        in the URN — the original heuristic, kept so that unit-less documents keep working.
+        """
+        unit = element.get('unit')
+        following_unit = following.get('unit')
+
+        if unit and following_unit and unit in UNIT_CONTAINED_BY and following_unit in UNIT_CONTAINED_BY:
+            return following_unit == unit or following_unit in UNIT_CONTAINED_BY[unit]
+
+        num_dividers = element.get('corresp', '').split(':')[-1].count('/')
+        following_dividers = following.get('corresp', '').split(':')[-1].count('/')
+        return following_dividers <= num_dividers
+
     def _find_end_of_mapping(self, element: ElementBase) -> tuple[str, bool]:
         """Find the end element path and tail-inclusion flag for a URN mapping.
 
-        For milestone elements, finds the element just before the next same-level milestone.
-        For non-milestones, the element itself is the end.
+        For milestone elements, finds the element just before the next milestone that ends
+        this one's scope. For non-milestones, the element itself is the end.
 
         Returns:
             (end_element_path, include_tail)
@@ -230,16 +273,11 @@ class ReferenceDatabase:
 
         is_milestone = element.tag == '{http://www.tei-c.org/ns/1.0}milestone'
         if is_milestone:
-            corresp = element.get('corresp', '')
-            last_part = corresp.split(':')[-1]
-            num_dividers = last_part.count('/')
             following_milestones = element.xpath(
                 './following::tei:milestone[@corresp][ancestor::tei:text]', namespaces=ns_map)
             actual_end = None
             for milestone in following_milestones:
-                following_corresp = milestone.attrib.get('corresp', '')
-                following_last_part = following_corresp.split(':')[-1]
-                if following_last_part.count('/') <= num_dividers:
+                if self._milestone_terminates(element, milestone):
                     preceding = milestone.xpath('./preceding::*[1]')
                     if preceding:
                         actual_end = preceding[0]

--- a/opensiddur/exporter/tex/latex.py
+++ b/opensiddur/exporter/tex/latex.py
@@ -105,6 +105,10 @@ def group_licenses(licenses: dict[Path, LicenseRecord]) -> list[LicenseRecord]:
 
 def licenses_to_tex(licenses: list[LicenseRecord]) -> str:
     """Convert a list of LicenseRecord objects into a LaTeX section."""
+    if not licenses:
+        # An itemize with no items is a LaTeX error, and a Legal section listing nothing
+        # would be misleading anyway. Matches credits_to_tex, which already guards.
+        return ""
     items = "\n".join(
         f"\\item {license.name} (\\url{{{license.url}}})" for license in licenses
     )

--- a/opensiddur/exporter/tex/reledmac.xslt
+++ b/opensiddur/exporter/tex/reledmac.xslt
@@ -722,6 +722,18 @@
                             <xsl:with-param name="in-pstart" select="false()"/>
                         </xsl:next-iteration>
                     </xsl:when>
+                    <xsl:when test="self::tei:milestone">
+                        <!-- A milestone this stylesheet does not set: unit="edition-verse",
+                             which records an edition's own verse numbering beside the
+                             canonical one, and anything else a source marks but a printed
+                             page does not show. Falling through to the generic branch would
+                             open a \pstart that then receives no text, and reledmac cannot
+                             set an empty paragraph — it dies with "You can't use \lastbox in
+                             vertical mode". Skip it, leaving any open pstart as it is. -->
+                        <xsl:next-iteration>
+                            <xsl:with-param name="in-pstart" select="$in-pstart"/>
+                        </xsl:next-iteration>
+                    </xsl:when>
                     <xsl:when test="self::f:head">
                         <xsl:choose>
                             <xsl:when test="$single-pstart">

--- a/opensiddur/exporter/tex/reledmac.xslt
+++ b/opensiddur/exporter/tex/reledmac.xslt
@@ -141,6 +141,12 @@
              tei:div[@type='book'] (Bible exports), where the chapter exists solely as a
              milestone and would otherwise be invisible. -->
         <xsl:text>\newcommand{\chno}[1]{{\large\bfseries{\textdir TLT\selectlanguage{english}#1}}\,}&#10;</xsl:text>
+        <!-- A scriptural citation ("<book> <chapter>:<verse>-..."), on a line of its own:
+             either the source of a haftarah/festival reading the humash otherwise never
+             states (see tei:milestone[@unit='citation'] below), or where a reading resumes
+             after a backward jump or a skip. Centred like \OSheadA-D but italic, not bold,
+             so it reads as a caption on the reading rather than another level of heading. -->
+        <xsl:text>\newcommand{\OScitation}[1]{\mbox{}\hfill{\normalfont\normalsize\itshape #1}\hfill\mbox{}}&#10;</xsl:text>
         <!-- Aliyah and maftir markers, inline at the verse the reading division begins on.
              Deliberately inline rather than a break: the maftir opens *inside* the seventh
              aliyah rather than after it, and the weekday and triennial divisions cut across
@@ -622,6 +628,51 @@
                             <xsl:otherwise>
                                 <xsl:next-iteration>
                                     <xsl:with-param name="in-pstart" select="$in-pstart"/>
+                                </xsl:next-iteration>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:when>
+                    <xsl:when test="self::tei:milestone[@unit='citation']">
+                        <!-- A scriptural citation the humash generator inserts to state a
+                             haftarah/festival reading's source, or to mark where it resumes
+                             after a backward jump or a skip (build._citation). It is not a
+                             tei:head — it earns no bookmark entry, being a caption on a
+                             reading already headed by its own tei:head — but it is treated
+                             the way a heading is for reledpar column-pairing: only the
+                             Hebrew source carries this milestone (an English/JPS column has
+                             no matching one), so closing and reopening the pstart here would
+                             desync the two sides' \pstart counts. Stay inside whatever is
+                             already open in single-pstart (parallel) mode, the way f:head
+                             does above. -->
+                        <xsl:choose>
+                            <xsl:when test="$single-pstart">
+                                <xsl:choose>
+                                    <xsl:when test="$in-pstart">
+                                        <xsl:text>\par&#10;</xsl:text>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:text>\pstart </xsl:text>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                                <xsl:text>\OScitation{</xsl:text>
+                                <xsl:value-of select="f:emit-bidi-text(string(@n))"/>
+                                <xsl:text>}</xsl:text>
+                                <xsl:text>\par&#10;</xsl:text>
+                                <xsl:next-iteration>
+                                    <xsl:with-param name="in-pstart" select="true()"/>
+                                </xsl:next-iteration>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:if test="$in-pstart">
+                                    <xsl:text>\pend&#10;</xsl:text>
+                                </xsl:if>
+                                <xsl:text>\pstart \skipnumbering&#10;</xsl:text>
+                                <xsl:text>\OScitation{</xsl:text>
+                                <xsl:value-of select="f:emit-bidi-text(string(@n))"/>
+                                <xsl:text>}</xsl:text>
+                                <xsl:text>&#10;\pend&#10;</xsl:text>
+                                <xsl:next-iteration>
+                                    <xsl:with-param name="in-pstart" select="false()"/>
                                 </xsl:next-iteration>
                             </xsl:otherwise>
                         </xsl:choose>
@@ -1442,18 +1493,20 @@
         )[1])"/>
     </xsl:function>
 
-    <!-- Hebrew titles stay in the stream direction; other languages need an
-         explicit LTR wrapper so Latin text is not reversed in RTL blocks. -->
+    <!-- Hebrew titles stay in the stream direction, but any embedded digit/Latin run (e.g. a
+         "52:13" citation range inside a Hebrew heading) still needs its own LTR wrap or it
+         renders reversed — the same problem f:emit-bidi-text already solves for Hebrew notes
+         with embedded sigla, so it is reused here rather than left as raw escaped text.
+         Other languages need the whole title wrapped, since it's Latin throughout. -->
     <xsl:function name="f:format-section-title" as="xs:string">
         <xsl:param name="title" as="xs:string"/>
         <xsl:param name="lang" as="xs:string"/>
-        <xsl:variable name="escaped" select="f:escape-tex($title)"/>
         <xsl:choose>
             <xsl:when test="$lang = 'he' or starts-with($lang, 'he-')">
-                <xsl:sequence select="$escaped"/>
+                <xsl:sequence select="f:emit-bidi-text($title)"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:sequence select="concat('{\textdir TLT\selectlanguage{english}', $escaped, '}')"/>
+                <xsl:sequence select="concat('{\textdir TLT\selectlanguage{english}', f:escape-tex($title), '}')"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>

--- a/opensiddur/exporter/tex/reledmac.xslt
+++ b/opensiddur/exporter/tex/reledmac.xslt
@@ -116,13 +116,12 @@
              misconfigured on some systems. -->
         <xsl:text>\usepackage[backend=bibtex]{biblatex}&#10;</xsl:text>
         <xsl:text>\usepackage{hyperref}&#10;</xsl:text>
-        <!-- Headings go three deep (index > book > parshah), and f:head-level emits the
-             third as \addcontentsline{toc}{subsubsection}. The book class stops the table of
-             contents at subsection, and hyperref takes its bookmark depth from that, so
-             without this the deepest level is silently missing from the PDF outline — a
-             humash bookmarked by book and by haftarah but not by parshah. -->
-        <xsl:text>\setcounter{tocdepth}{3}&#10;</xsl:text>
-        <xsl:text>\hypersetup{bookmarksdepth=3}&#10;</xsl:text>
+        <!-- Headings go four deep (index > section > haftarah > rite), and f:heading-toc-level
+             emits the fourth as \addcontentsline{toc}{paragraph}. The book class stops the
+             table of contents at subsection, and hyperref takes its bookmark depth from that,
+             so without this the deeper levels are silently missing from the PDF outline. -->
+        <xsl:text>\setcounter{tocdepth}{4}&#10;</xsl:text>
+        <xsl:text>\hypersetup{bookmarksdepth=4}&#10;</xsl:text>
         <!-- hyperref builds PDF strings for bookmarks/outlines.  Direction and
              language switches (luabidi/polyglossia) are not representable in
              PDF strings and generate warnings (and sometimes broken outlines).
@@ -189,6 +188,7 @@
         <xsl:text>\newcommand{\OSheadA}[1]{\mbox{}\hfill{\normalfont\LARGE\bfseries #1}\hfill\mbox{}}&#10;</xsl:text>
         <xsl:text>\newcommand{\OSheadB}[1]{\mbox{}\hfill{\normalfont\Large\bfseries #1}\hfill\mbox{}}&#10;</xsl:text>
         <xsl:text>\newcommand{\OSheadC}[1]{\mbox{}\hfill{\normalfont\large\bfseries #1}\hfill\mbox{}}&#10;</xsl:text>
+        <xsl:text>\newcommand{\OSheadD}[1]{\mbox{}\hfill{\normalfont\normalsize\bfseries #1}\hfill\mbox{}}&#10;</xsl:text>
 
         <!-- Title page (tei:titlePage).
              Unlike \OSheadA/B/C, these are never emitted inside a reledmac \pstart — a
@@ -912,7 +912,7 @@
             <xsl:call-template name="head-sentinel">
                 <xsl:with-param name="head" select="tei:head[1]"/>
                 <xsl:with-param name="level"
-                                select="min((count(ancestor::tei:div[tei:head]) + 1, 3))"/>
+                                select="min((count(ancestor::tei:div[tei:head]) + 1, 4))"/>
             </xsl:call-template>
         </xsl:if>
         <xsl:apply-templates select="node()[not(self::tei:head)]" mode="leaves"/>
@@ -1382,16 +1382,17 @@
         <xsl:sequence select="count($ctx/preceding::tei:note[not(@type='instruction') and not(ancestor::tei:standOff)])"/>
     </xsl:function>
 
-    <!-- Heading level (1-3) to the \OSheadA/B/C macro suffix. -->
+    <!-- Heading level (1-4) to the \OSheadA/B/C/D macro suffix. -->
     <xsl:function name="f:heading-suffix" as="xs:string">
         <xsl:param name="level" as="xs:integer"/>
-        <xsl:sequence select="('A', 'B', 'C')[min((max(($level, 1)), 3))]"/>
+        <xsl:sequence select="('A', 'B', 'C', 'D')[min((max(($level, 1)), 4))]"/>
     </xsl:function>
 
-    <!-- Heading level (1-3) to the \addcontentsline level driving hyperref bookmarks. -->
+    <!-- Heading level (1-4) to the \addcontentsline level driving hyperref bookmarks. -->
     <xsl:function name="f:heading-toc-level" as="xs:string">
         <xsl:param name="level" as="xs:integer"/>
-        <xsl:sequence select="('section', 'subsection', 'subsubsection')[min((max(($level, 1)), 3))]"/>
+        <xsl:sequence select="('section', 'subsection', 'subsubsection', 'paragraph')[
+            min((max(($level, 1)), 4))]"/>
     </xsl:function>
 
     <!-- Nearest xml:lang in scope for any element, falling back to the document language. -->

--- a/opensiddur/exporter/tex/reledmac.xslt
+++ b/opensiddur/exporter/tex/reledmac.xslt
@@ -123,6 +123,13 @@
              tei:div[@type='book'] (Bible exports), where the chapter exists solely as a
              milestone and would otherwise be invisible. -->
         <xsl:text>\newcommand{\chno}[1]{{\large\bfseries{\textdir TLT\selectlanguage{english}#1}}\,}&#10;</xsl:text>
+        <!-- Aliyah and maftir markers, inline at the verse the reading division begins on.
+             Deliberately inline rather than a break: the maftir opens *inside* the seventh
+             aliyah rather than after it, and the weekday and triennial divisions cut across
+             the Shabbat ones, so a marker that ended a paragraph would assert a break that is
+             not there. Staying inline also keeps \pstart counts identical on both sides of a
+             reledpar pairing, which a block-level marker would desynchronise. -->
+        <xsl:text>\newcommand{\OSaliyah}[1]{{\bfseries[#1]}\,}&#10;</xsl:text>
 
         <!-- Section headings (tei:head).
              reledmac's \eledchapter/\eledsection/\eledsubsection are deliberately NOT used:
@@ -602,6 +609,31 @@
                                 </xsl:next-iteration>
                             </xsl:otherwise>
                         </xsl:choose>
+                    </xsl:when>
+                    <xsl:when test="self::tei:milestone[
+                            starts-with(@unit, 'aliyah') or starts-with(@unit, 'maftir')]">
+                        <!-- Aliyah, maftir, weekday and triennial markers, inline at the
+                             verse the division begins on. See \OSaliyah in the preamble for
+                             why these are inline and not breaks. -->
+                        <xsl:if test="not($in-pstart)">
+                            <xsl:text>\pstart </xsl:text>
+                        </xsl:if>
+                        <xsl:text>\OSaliyah{</xsl:text>
+                        <xsl:value-of select="f:escape-tex(string(@n))"/>
+                        <xsl:text>}</xsl:text>
+                        <xsl:next-iteration>
+                            <xsl:with-param name="in-pstart" select="true()"/>
+                        </xsl:next-iteration>
+                    </xsl:when>
+                    <xsl:when test="self::tei:milestone[starts-with(@unit, 'parsha.')]">
+                        <!-- A qualified parsha unit (parsha.annual) comes from the humash,
+                             where every parshah is a tei:div with a tei:head carrying its
+                             name. Rendering the milestone too would print the name twice, so
+                             it is left to the heading. The unqualified @unit='parsha' below
+                             is the wlc/jps1917 case, where there is no such heading. -->
+                        <xsl:next-iteration>
+                            <xsl:with-param name="in-pstart" select="$in-pstart"/>
+                        </xsl:next-iteration>
                     </xsl:when>
                     <xsl:when test="self::tei:milestone[@unit='parsha']">
                         <!-- Parsha boundary: emit as a B-series footnote anchored

--- a/opensiddur/exporter/tex/reledmac.xslt
+++ b/opensiddur/exporter/tex/reledmac.xslt
@@ -1493,11 +1493,10 @@
         )[1])"/>
     </xsl:function>
 
-    <!-- Hebrew titles stay in the stream direction, but any embedded digit/Latin run (e.g. a
-         "52:13" citation range inside a Hebrew heading) still needs its own LTR wrap or it
-         renders reversed — the same problem f:emit-bidi-text already solves for Hebrew notes
-         with embedded sigla, so it is reused here rather than left as raw escaped text.
-         Other languages need the whole title wrapped, since it's Latin throughout. -->
+    <!-- Hebrew titles stay in the stream direction, but any embedded digit range (e.g. a
+         "52:13" citation inside a Hebrew heading) still needs an LTR wrap kept together as
+         one run or it renders reversed — see f:emit-bidi-text. Other languages need the
+         whole title wrapped, since it's Latin throughout. -->
     <xsl:function name="f:format-section-title" as="xs:string">
         <xsl:param name="title" as="xs:string"/>
         <xsl:param name="lang" as="xs:string"/>
@@ -1533,17 +1532,27 @@
     </xsl:function>
 
     <!-- Sources like the MAM apparatus notes are Hebrew prose that embeds short Latin
-         tokens (manuscript sigla such as "EVR-II-B-8", "BHS"). \textdir TRT forces the
-         whole Hebrew note into strict RTL layout (note-content), which has no per-run
-         bidi detection, so an embedded Latin token renders with its characters
-         back-to-front unless explicitly switched back to LTR. Wrap each such token the
-         same way \vno/\chno/note-content already wrap other LTR content in RTL context,
-         leaving a hyphen that merely touches Hebrew (e.g. "פטרבורג-EVR-II-B-8") outside
-         the wrap so its direction still resolves normally. -->
+         tokens (manuscript sigla such as "EVR-II-B-8", "BHS") and citation ranges (build.
+         _citation, e.g. "42:5-43:10"). \textdir TRT forces the whole Hebrew note/heading
+         into strict RTL layout, which has no per-run bidi detection, so an embedded Latin
+         or digit token renders with its characters back-to-front unless explicitly
+         switched back to LTR. Wrap each such token the same way \vno/\chno already wrap
+         other LTR content in RTL context, leaving a hyphen that merely touches Hebrew
+         (e.g. "פטרבורג-EVR-II-B-8") outside the wrap so its direction still resolves
+         normally.
+
+         A citation's separators (":", ";", the en dash) join a whole run into ONE
+         embedding rather than one per token, because two separate LTR embeds sitting side
+         by side in RTL text, with nothing but a colon or dash between them, do not
+         reliably keep their *relative* order — the bidi algorithm has no strong character
+         between them to anchor on, so wrapping "42" and "5" and "43" and "10" separately
+         can come out as "43:10-42:5". A Hebrew book name, not in this character class,
+         still ends a run and starts a fresh one, so "18:46; מלאכי 3:4" wraps its two
+         ranges separately, each still safe on its own. -->
     <xsl:function name="f:emit-bidi-text" as="xs:string">
         <xsl:param name="s" as="xs:string"/>
         <xsl:variable name="parts" as="xs:string*">
-            <xsl:analyze-string select="$s" regex="[A-Za-z0-9]+([-'.][A-Za-z0-9]+)*">
+            <xsl:analyze-string select="$s" regex="[A-Za-z0-9]+([-'.:;–]\s?[A-Za-z0-9]+)*">
                 <xsl:matching-substring>
                     <xsl:sequence select="concat('{{\textdir TLT\selectlanguage{english}', f:escape-tex(.), '}}')"/>
                 </xsl:matching-substring>

--- a/opensiddur/importer/humash/aliyot.py
+++ b/opensiddur/importer/humash/aliyot.py
@@ -15,8 +15,12 @@ The parameters are:
 ב2   the weekday honour — כהן, לוי, ישראל, or ע"כ ישראל
 ב3   מפטיר
 ג0   the parshah name when this week is combined with the next, e.g. ויקהל–פקודי
-ג1/ג3 the Shabbat aliyah or maftir of that combined reading
+ג1/ג2/ג3 the Shabbat aliyah, weekday honour or maftir of that combined reading
 ==== ================================================================================
+
+The ``ג`` parameters are a second, independent division of the same text: the combined
+reading's fourth aliyah runs through the point where the second parshah begins, so it is read
+into its own unit-spaces rather than as a subdivision of either single.
 
 Ends are not marked and must be inferred, separately within each unit-space, from the next
 start in that same space — which is why the maftir, whose start falls inside the seventh
@@ -33,13 +37,21 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from opensiddur.importer.miqra_al_pi_hamasorah.convert_tsv import _hebrew_numeral_to_int
-from opensiddur.importer.humash.names import slug_for_hebrew
+from opensiddur.importer.humash.names import (
+    PAIR_MEMBERS,
+    slug_for_combined_hebrew,
+    slug_for_hebrew,
+)
 from opensiddur.importer.humash.refs import (
     HEBREW_BOOK_TO_SLUG,
     UNIT_ALIYAH,
+    UNIT_ALIYAH_COMBINED,
     UNIT_MAFTIR,
+    UNIT_MAFTIR_COMBINED,
     UNIT_PARSHA,
+    UNIT_PARSHA_COMBINED,
     UNIT_WEEKDAY,
+    UNIT_WEEKDAY_COMBINED,
     ReadingSpan,
     VerseRef,
     chapters_in_book,
@@ -82,6 +94,48 @@ class Parsha:
 
     def spans_in(self, unit: str) -> list[ReadingSpan]:
         return [span for span in self.spans if span.unit == unit]
+
+
+@dataclass
+class CombinedParsha:
+    """A pair read together on one Shabbat, with the divisions of that combined reading.
+
+    It covers exactly the two singles' text end to end; those keep their own divisions, which
+    are what is read on a year the pair is read apart.
+    """
+
+    slug: str
+    hebrew_name: str
+    book: str
+    members: tuple[str, str]
+    start: VerseRef
+    end: VerseRef
+    spans: list[ReadingSpan] = field(default_factory=list)
+
+    @property
+    def parsha_span(self) -> ReadingSpan:
+        return ReadingSpan(UNIT_PARSHA_COMBINED, self.slug, self.start, self.end)
+
+    def spans_in(self, unit: str) -> list[ReadingSpan]:
+        return [span for span in self.spans if span.unit == unit]
+
+
+@dataclass(frozen=True)
+class _Division:
+    """One of the two divisions a marker may carry: the single reading or the combined one."""
+
+    aliyah_key: str
+    weekday_key: str
+    maftir_key: str
+    aliyah_unit: str
+    weekday_unit: str
+    maftir_unit: str
+
+
+SINGLE_DIVISION = _Division("ב1", "ב2", "ב3", UNIT_ALIYAH, UNIT_WEEKDAY, UNIT_MAFTIR)
+COMBINED_DIVISION = _Division(
+    "ג1", "ג2", "ג3", UNIT_ALIYAH_COMBINED, UNIT_WEEKDAY_COMBINED, UNIT_MAFTIR_COMBINED
+)
 
 
 @dataclass
@@ -165,7 +219,22 @@ def _close_spans(
 
 def parse_parshiyot(sourcetexts_root: Path | None = None) -> list[Parsha]:
     """Build the 54 weekly parshiyot, each with its aliyot, weekday aliyot and maftir."""
+    return parse_readings(sourcetexts_root)[0]
+
+
+def parse_readings(
+    sourcetexts_root: Path | None = None,
+) -> tuple[list[Parsha], list[CombinedParsha]]:
+    """The 54 weekly parshiyot and the seven combined readings, from one pass over the TSV."""
     markers = read_markers(sourcetexts_root)
+    parshiyot = _parse_parshiyot(markers, sourcetexts_root)
+    return parshiyot, _parse_combined(markers, parshiyot, sourcetexts_root)
+
+
+def _parse_parshiyot(
+    markers: list[_Marker],
+    sourcetexts_root: Path | None = None,
+) -> list[Parsha]:
 
     # Group markers by parshah, in the order the parshiyot appear.
     parshiyot: list[Parsha] = []
@@ -193,13 +262,56 @@ def parse_parshiyot(sourcetexts_root: Path | None = None) -> list[Parsha]:
             parsha.end = _end_of_book(parsha.book, sourcetexts_root)
 
     for parsha in parshiyot:
-        parsha.spans = _spans_for(grouped[parsha.slug], parsha, sourcetexts_root)
+        parsha.spans = _spans_for(
+            grouped[parsha.slug], parsha.end, SINGLE_DIVISION, sourcetexts_root
+        )
     return parshiyot
+
+
+def _parse_combined(
+    markers: list[_Marker],
+    parshiyot: list[Parsha],
+    sourcetexts_root: Path | None = None,
+) -> list[CombinedParsha]:
+    """Build the combined readings out of the ``ג`` parameters of the same markers.
+
+    The pair's extent is taken from its two members rather than from the markers, so that it
+    ends where the second parshah ends even though the last marker falls before that.
+    """
+    by_slug = {parsha.slug: parsha for parsha in parshiyot}
+    grouped: dict[str, list[_Marker]] = {}
+    order: list[str] = []
+    for marker in markers:
+        name = marker.params.get("ג0")
+        if not name:
+            continue
+        slug = slug_for_combined_hebrew(name)
+        if slug not in grouped:
+            grouped[slug] = []
+            order.append(slug)
+        grouped[slug].append(marker)
+
+    combined: list[CombinedParsha] = []
+    for slug in order:
+        first_slug, second_slug = PAIR_MEMBERS[slug]
+        first, second = by_slug[first_slug], by_slug[second_slug]
+        pair = CombinedParsha(
+            slug=slug,
+            hebrew_name=grouped[slug][0].params["ג0"],
+            book=first.book,
+            members=(first_slug, second_slug),
+            start=first.start,
+            end=second.end,
+        )
+        pair.spans = _spans_for(grouped[slug], pair.end, COMBINED_DIVISION, sourcetexts_root)
+        combined.append(pair)
+    return combined
 
 
 def _spans_for(
     markers: list[_Marker],
-    parsha: Parsha,
+    reading_end: VerseRef,
+    division: _Division,
     sourcetexts_root: Path | None,
 ) -> list[ReadingSpan]:
     """Close each unit-space's markers into spans independently of the others."""
@@ -210,26 +322,26 @@ def _spans_for(
 
     for marker in markers:
         params = marker.params
-        aliyah = params.get("ב1")
+        aliyah = params.get(division.aliyah_key)
         if aliyah in ALIYAH_NUMBER:
             aliyah_starts.append((ALIYAH_NUMBER[aliyah], marker.ref, None))
-        honour = params.get("ב2")
+        honour = params.get(division.weekday_key)
         if honour in WEEKDAY_NUMBER:
             weekday_starts.append((WEEKDAY_NUMBER[honour], marker.ref, None))
         elif honour == WEEKDAY_END:
             # "Thus far Yisrael" marks where the weekday reading stops, so the last weekday
-            # aliyah ends at the preceding verse rather than running on to the parshah's end.
+            # aliyah ends at the preceding verse rather than running on to the reading's end.
             weekday_end = previous_verse(marker.ref, sourcetexts_root)
-        if params.get("ב3") == MAFTIR:
+        if params.get(division.maftir_key) == MAFTIR:
             maftir_start = marker.ref
 
-    spans = _close_spans(aliyah_starts, UNIT_ALIYAH, parsha.end, sourcetexts_root)
+    spans = _close_spans(aliyah_starts, division.aliyah_unit, reading_end, sourcetexts_root)
     spans += _close_spans(
-        weekday_starts, UNIT_WEEKDAY, weekday_end or parsha.end, sourcetexts_root
+        weekday_starts, division.weekday_unit, weekday_end or reading_end, sourcetexts_root
     )
     if maftir_start is not None:
-        # The maftir runs to the end of the parshah, overlapping the seventh aliyah.
+        # The maftir runs to the end of the reading, overlapping the seventh aliyah.
         spans.append(
-            ReadingSpan(UNIT_MAFTIR, MAFTIR, maftir_start, parsha.end)
+            ReadingSpan(division.maftir_unit, MAFTIR, maftir_start, reading_end)
         )
     return spans

--- a/opensiddur/importer/humash/aliyot.py
+++ b/opensiddur/importer/humash/aliyot.py
@@ -52,8 +52,10 @@ from opensiddur.importer.humash.refs import (
     UNIT_PARSHA_COMBINED,
     UNIT_WEEKDAY,
     UNIT_WEEKDAY_COMBINED,
+    NUMBERING_MASORAH,
     ReadingSpan,
     VerseRef,
+    canonical_ref,
     chapters_in_book,
     previous_verse,
     verses_in_chapter,
@@ -168,7 +170,10 @@ def _parse_verse_position(scaffold: str) -> VerseRef | None:
     verse = _hebrew_numeral_to_int(match.group(3))
     if chapter is None or verse is None:
         return None
-    return VerseRef(book, chapter, verse)
+    # MAM's own numbering, which the canonical URN space does not share in the Decalogue and
+    # a few other chapters. A marker names where an aliyah begins, so where MAM reads several
+    # canonical verses as one, the aliyah begins at the first of them.
+    return canonical_ref(NUMBERING_MASORAH, VerseRef(book, chapter, verse))
 
 
 def read_markers(sourcetexts_root: Path | None = None) -> list[_Marker]:

--- a/opensiddur/importer/humash/aliyot.py
+++ b/opensiddur/importer/humash/aliyot.py
@@ -1,0 +1,235 @@
+"""Read the weekly parshiyot and their aliyot out of Miqra al pi ha-Masorah.
+
+MAM marks the *start* of every reading division inline in the verse scaffolding of
+``sheets/torah.tsv``, in a ``{{מ:עלייה}}`` template nested inside the ``{{מ:פסוק}}`` that
+opens the verse:
+
+    {{מ:פסוק|בראשית|א|א|סדר=א|עלייה={{מ:עלייה|א=בראשית|ב0=בראשית|ב1=ראשון|ב2=כהן}}}}
+
+The parameters are:
+
+==== ================================================================================
+א    the label as printed in the margin
+ב0   the weekly parshah this reading belongs to
+ב1   the Shabbat aliyah — ראשון through שביעי
+ב2   the weekday honour — כהן, לוי, ישראל, or ע"כ ישראל
+ב3   מפטיר
+ג0   the parshah name when this week is combined with the next, e.g. ויקהל–פקודי
+ג1/ג3 the Shabbat aliyah or maftir of that combined reading
+==== ================================================================================
+
+Ends are not marked and must be inferred, separately within each unit-space, from the next
+start in that same space — which is why the maftir, whose start falls inside the seventh
+aliyah, does not shorten it. The one explicit end marker is ``ע"כ ישראל`` (עד כאן ישראל,
+"thus far Yisrael"), which closes the weekday reading rather than opening a fourth aliyah.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from opensiddur.importer.miqra_al_pi_hamasorah.convert_tsv import _hebrew_numeral_to_int
+from opensiddur.importer.humash.names import slug_for_hebrew
+from opensiddur.importer.humash.refs import (
+    HEBREW_BOOK_TO_SLUG,
+    UNIT_ALIYAH,
+    UNIT_MAFTIR,
+    UNIT_PARSHA,
+    UNIT_WEEKDAY,
+    ReadingSpan,
+    VerseRef,
+    chapters_in_book,
+    previous_verse,
+    verses_in_chapter,
+)
+from opensiddur.importer.util.pages import miqra_al_pi_hamasorah_data_directory
+
+logger = logging.getLogger(__name__)
+
+# The seven Shabbat aliyot, in order, as MAM spells them.
+SHABBAT_ALIYOT = ("ראשון", "שני", "שלישי", "רביעי", "חמישי", "ששי", "שביעי")
+ALIYAH_NUMBER = {name: str(index + 1) for index, name in enumerate(SHABBAT_ALIYOT)}
+
+# The weekday honours. ע"כ ישראל closes the reading instead of opening an aliyah.
+WEEKDAY_HONOURS = ("כהן", "לוי", "ישראל")
+WEEKDAY_END = 'ע"כ ישראל'
+WEEKDAY_NUMBER = {name: str(index + 1) for index, name in enumerate(WEEKDAY_HONOURS)}
+
+MAFTIR = "מפטיר"
+
+_VERSE_TEMPLATE = re.compile(r"\{\{מ:פסוק\|([^{}]*?)(?=\||\}\})")
+_ALIYAH_TEMPLATE = re.compile(r"\{\{מ:עלייה\|([^{}]*)\}\}")
+
+
+@dataclass
+class Parsha:
+    """One weekly reading, with every division that begins inside it."""
+
+    slug: str
+    hebrew_name: str
+    book: str
+    start: VerseRef
+    end: VerseRef | None = None
+    spans: list[ReadingSpan] = field(default_factory=list)
+
+    @property
+    def parsha_span(self) -> ReadingSpan:
+        return ReadingSpan(UNIT_PARSHA, self.slug, self.start, self.end)
+
+    def spans_in(self, unit: str) -> list[ReadingSpan]:
+        return [span for span in self.spans if span.unit == unit]
+
+
+@dataclass
+class _Marker:
+    """One ``{{מ:עלייה}}`` occurrence, before ends have been worked out."""
+
+    ref: VerseRef
+    params: dict[str, str]
+
+
+def _parse_template_params(body: str) -> dict[str, str]:
+    """Split ``a=1|b=2`` into a dict, ignoring positional parameters."""
+    params: dict[str, str] = {}
+    for part in body.split("|"):
+        key, sep, value = part.partition("=")
+        if sep:
+            params[key.strip()] = value.strip()
+    return params
+
+
+def _parse_verse_position(scaffold: str) -> VerseRef | None:
+    """Read the book, chapter and verse out of the ``{{מ:פסוק}}`` that opens a row."""
+    match = re.search(r"\{\{מ:פסוק\|([^|]+)\|([^|]+)\|([^|}]+)", scaffold)
+    if not match:
+        return None
+    book = HEBREW_BOOK_TO_SLUG.get(match.group(1).strip())
+    if book is None:
+        return None
+    chapter = _hebrew_numeral_to_int(match.group(2))
+    verse = _hebrew_numeral_to_int(match.group(3))
+    if chapter is None or verse is None:
+        return None
+    return VerseRef(book, chapter, verse)
+
+
+def read_markers(sourcetexts_root: Path | None = None) -> list[_Marker]:
+    """Every aliyah marker in torah.tsv, in reading order."""
+    path = miqra_al_pi_hamasorah_data_directory(sourcetexts_root) / "sheets" / "torah.tsv"
+    markers: list[_Marker] = []
+    with open(path, encoding="utf-8", newline="") as handle:
+        for row in csv.reader(handle, delimiter="\t"):
+            if len(row) < 4:
+                continue
+            scaffold = row[3]
+            if "מ:עלייה" not in scaffold:
+                continue
+            ref = _parse_verse_position(scaffold)
+            if ref is None:
+                logger.warning("Could not locate the verse for an aliyah marker: %s", scaffold[:80])
+                continue
+            for body in _ALIYAH_TEMPLATE.findall(scaffold):
+                markers.append(_Marker(ref=ref, params=_parse_template_params(body)))
+    return markers
+
+
+def _end_of_book(book: str, sourcetexts_root: Path | None) -> VerseRef:
+    last_chapter = chapters_in_book(book, sourcetexts_root)
+    return VerseRef(book, last_chapter, verses_in_chapter(book, last_chapter, sourcetexts_root))
+
+
+def _close_spans(
+    starts: list[tuple[str, VerseRef, str | None]],
+    unit: str,
+    final_end: VerseRef,
+    sourcetexts_root: Path | None,
+) -> list[ReadingSpan]:
+    """Turn a unit-space's start points into spans, each ending before the next start.
+
+    Only starts within the same unit-space are considered, so that a division belonging to
+    another space cannot cut one of these short.
+    """
+    spans: list[ReadingSpan] = []
+    for index, (label, start, note) in enumerate(starts):
+        if index + 1 < len(starts):
+            end = previous_verse(starts[index + 1][1], sourcetexts_root)
+        else:
+            end = final_end
+        spans.append(ReadingSpan(unit=unit, label=label, start=start, end=end, note=note))
+    return spans
+
+
+def parse_parshiyot(sourcetexts_root: Path | None = None) -> list[Parsha]:
+    """Build the 54 weekly parshiyot, each with its aliyot, weekday aliyot and maftir."""
+    markers = read_markers(sourcetexts_root)
+
+    # Group markers by parshah, in the order the parshiyot appear.
+    parshiyot: list[Parsha] = []
+    by_slug: dict[str, Parsha] = {}
+    grouped: dict[str, list[_Marker]] = {}
+    for marker in markers:
+        name = marker.params.get("ב0")
+        if not name:
+            continue
+        slug = slug_for_hebrew(name)
+        parsha = by_slug.get(slug)
+        if parsha is None:
+            parsha = Parsha(slug=slug, hebrew_name=name, book=marker.ref.book, start=marker.ref)
+            by_slug[slug] = parsha
+            parshiyot.append(parsha)
+            grouped[slug] = []
+        grouped[slug].append(marker)
+
+    # A parshah runs to the verse before the next one starts, or to the end of its book.
+    for index, parsha in enumerate(parshiyot):
+        following = parshiyot[index + 1] if index + 1 < len(parshiyot) else None
+        if following is not None and following.book == parsha.book:
+            parsha.end = previous_verse(following.start, sourcetexts_root)
+        else:
+            parsha.end = _end_of_book(parsha.book, sourcetexts_root)
+
+    for parsha in parshiyot:
+        parsha.spans = _spans_for(grouped[parsha.slug], parsha, sourcetexts_root)
+    return parshiyot
+
+
+def _spans_for(
+    markers: list[_Marker],
+    parsha: Parsha,
+    sourcetexts_root: Path | None,
+) -> list[ReadingSpan]:
+    """Close each unit-space's markers into spans independently of the others."""
+    aliyah_starts: list[tuple[str, VerseRef, str | None]] = []
+    weekday_starts: list[tuple[str, VerseRef, str | None]] = []
+    weekday_end: VerseRef | None = None
+    maftir_start: VerseRef | None = None
+
+    for marker in markers:
+        params = marker.params
+        aliyah = params.get("ב1")
+        if aliyah in ALIYAH_NUMBER:
+            aliyah_starts.append((ALIYAH_NUMBER[aliyah], marker.ref, None))
+        honour = params.get("ב2")
+        if honour in WEEKDAY_NUMBER:
+            weekday_starts.append((WEEKDAY_NUMBER[honour], marker.ref, None))
+        elif honour == WEEKDAY_END:
+            # "Thus far Yisrael" marks where the weekday reading stops, so the last weekday
+            # aliyah ends at the preceding verse rather than running on to the parshah's end.
+            weekday_end = previous_verse(marker.ref, sourcetexts_root)
+        if params.get("ב3") == MAFTIR:
+            maftir_start = marker.ref
+
+    spans = _close_spans(aliyah_starts, UNIT_ALIYAH, parsha.end, sourcetexts_root)
+    spans += _close_spans(
+        weekday_starts, UNIT_WEEKDAY, weekday_end or parsha.end, sourcetexts_root
+    )
+    if maftir_start is not None:
+        # The maftir runs to the end of the parshah, overlapping the seventh aliyah.
+        spans.append(
+            ReadingSpan(UNIT_MAFTIR, MAFTIR, maftir_start, parsha.end)
+        )
+    return spans

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -5,9 +5,9 @@ content is the headings and the reading instructions, so nothing here duplicates
 already exists in another project.
 
 Targets carry no ``@project`` suffix, so which edition supplies the text is decided at compile
-time by ``priority.transclusion``. The exception is the four chapters the editions divide into
-verses differently, where one range cannot serve them all; those are emitted once per
-numbering under ``opensiddur:verse-numbering``, defaulting to MAM's division.
+time by ``priority.transclusion``. Every range is stated in the canonical verse division that
+the bible URN space uses (opensiddur.common.versification), so one range serves every edition;
+the sources are converted to it as they are read.
 """
 
 from __future__ import annotations
@@ -39,10 +39,7 @@ from opensiddur.importer.humash.readings import (
     triennial_patterns,
 )
 from opensiddur.importer.humash.refs import (
-    DEFAULT_NUMBERING,
-    DIVERGENT_CHAPTER_VERSES,
     MEGILLOT,
-    NUMBERINGS,
     SLUG_TO_VOCALIZED_BOOK,
     TORAH_BOOKS,
     UNIT_ALIYAH,
@@ -197,6 +194,13 @@ def _milestone(span: ReadingSpan, urn_base: str) -> str:
         # A parshah's own URN, not one below the file's: inside a combined file the marker for
         # each single is what makes urn:...:parsha/<slug> resolve to that single's text.
         urn = f"{URN_PREFIX}:parsha/{span.label}"
+        if urn == urn_base:
+            # A parshah read alone: the file's own div already carries this URN and covers
+            # exactly the same text. Naming it twice maps one URN to two places, which is
+            # what a text URN may not do — it is the join key the parallel compiler and the
+            # reference database resolve by. The marker still opens the division; it just
+            # does not claim the name.
+            return f'<tei:milestone unit="{span.unit}" n="{_escape(title)}"/>'
     else:
         base = f"{URN_PREFIX}:parsha/{span.owner}" if span.owner else urn_base
         urn = f"{base}/{span.unit.replace('.', '_')}/{slugify_reading_name(span.label)}"
@@ -282,29 +286,6 @@ def _triennial_year_feature(year: int) -> str:
     return f"triennial-year-{year}"
 
 
-def _default_numbering_conditional(content: str) -> str:
-    """Wrap `content` so it is used unless another numbering is explicitly selected.
-
-    ``j:none`` over the other numberings is false as soon as one of them is true, and
-    undefined while none is set — which keeps MAM's division as the default.
-    """
-    identifier = _condition_id("numbering_default")
-    others = "".join(
-        f'<tei:fs type="opensiddur:verse-numbering"><tei:f name="{numbering}">'
-        f'<tei:binary value="true"/></tei:f></tei:fs>'
-        for numbering in NUMBERINGS
-        if numbering != DEFAULT_NUMBERING
-    )
-    return (
-        f'<j:conditional xml:id="{identifier}"><j:none>{others}</j:none></j:conditional>'
-        f"{content}"
-        f'<j:endConditional target="#{identifier}"/>'
-    )
-
-
-Conditions = dict[str, tuple[str, list[str]]]
-
-
 def _segment_xml(
     segment: model.Segment,
     urn_base: str,
@@ -331,58 +312,6 @@ def _segment_xml(
     return "".join(parts)
 
 
-def _numbered_variants(
-    spans: list[ReadingSpan],
-    start: VerseRef,
-    end: VerseRef,
-    urn_base: str,
-    sourcetexts_root: Path | None,
-    conditions: Conditions | None = None,
-) -> str:
-    """Emit one variant of a reading per verse numbering, under conditional control.
-
-    Only reached for readings touching Exodus 20, Numbers 10, Numbers 25 or Deuteronomy 5.
-    Everywhere else a single range resolves in every edition and no variant is needed.
-    """
-    parts: list[str] = []
-    for numbering in NUMBERINGS:
-        segments = model.segment_reading(
-            _restated(spans, numbering), start, end, sourcetexts_root, numbering,
-            allow_duplication=False,
-        )
-        content = "".join(
-            _segment_xml(s, urn_base, sourcetexts_root, conditions) for s in segments
-        )
-        if numbering == DEFAULT_NUMBERING:
-            parts.append(_default_numbering_conditional(content))
-        else:
-            parts.append(_conditional(
-                "opensiddur:verse-numbering", numbering, content, f"numbering_{numbering}"
-            ))
-    return "".join(parts)
-
-
-def _restated(spans: list[ReadingSpan], numbering: str) -> list[ReadingSpan]:
-    """The spans as the given edition numbers them.
-
-    Only the ends that fall on the last verse of a divergent chapter move: those are stated as
-    "to the end of the chapter", and each edition ends the chapter at a different verse. A
-    boundary inside such a chapter cannot be restated without a verse-by-verse alignment of the
-    editions, so it is left alone and the reading keeps the numbering it was recorded in.
-    """
-    restated: list[ReadingSpan] = []
-    for span in spans:
-        end = span.end
-        counts = DIVERGENT_CHAPTER_VERSES.get((end.book, end.chapter))
-        if counts is not None and end.verse == counts[span.numbering]:
-            end = VerseRef(end.book, end.chapter, counts[numbering])
-        restated.append(ReadingSpan(
-            unit=span.unit, label=span.label, start=span.start, end=end,
-            note=span.note, numbering=numbering, owner=span.owner,
-        ))
-    return restated
-
-
 TriennialDivisions = dict[tuple[str | None, int], list[ReadingSpan]]
 
 
@@ -406,18 +335,11 @@ def _reading_document(
             "than to their recorded end", slug, ", ".join(sorted(overlapping)),
         )
 
-    needs_variants = any(span.crosses_divergent_chapter for span in spans)
-    if needs_variants:
-        body_inner = _numbered_variants(
-            spans, start, end, urn_base, sourcetexts_root, conditions
-        )
-    else:
-        segments = model.segment_reading(
-            spans, start, end, sourcetexts_root, DEFAULT_NUMBERING,
-            allow_duplication=False,
-        )
-        body_inner = "".join(
-            _segment_xml(s, urn_base, sourcetexts_root, conditions) for s in segments
+    segments = model.segment_reading(
+        spans, start, end, sourcetexts_root, allow_duplication=False,
+    )
+    body_inner = "".join(
+        _segment_xml(s, urn_base, sourcetexts_root, conditions) for s in segments
         )
 
     body = (
@@ -653,7 +575,7 @@ def festival_file(
         for book_spans in by_book.values():
             ordered = sorted(book_spans, key=lambda span: (span.start, span.end))
             segments = model.segment_reading(
-                ordered, sourcetexts_root=sourcetexts_root, numbering=ordered[0].numbering
+                ordered, sourcetexts_root=sourcetexts_root
             )
             parts.extend(_segment_xml(s, urn_base, sourcetexts_root) for s in segments)
 

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -439,7 +439,7 @@ def index_file(extra_urns: list[str]) -> tuple[str, str]:
     <tei:sourceDesc>
       <tei:bibl xml:id="source_mam">
         <tei:title>Miqra al pi ha-Masorah</tei:title>
-        <tei:ptr target="{URN_PREFIX}:tanakh@miqra_al_pi_hamasorah"/>
+        <tei:ptr target="{URN_PREFIX}:index@miqra_al_pi_hamasorah"/>
         <tei:note>Source of the weekly parshah, aliyah and maftir divisions.</tei:note>
       </tei:bibl>
       <tei:bibl xml:id="source_hebcal">

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -109,6 +109,11 @@ def _document(header: str, body: str, lang: str = "he") -> str:
     )
 
 
+# Cycle years, as the marker names them. Latin or digits here would be reversed when set in
+# the surrounding right-to-left text, which is how "1.maftir" comes out as "ritfam.1".
+TRIENNIAL_YEARS = {1: "א׳", 2: "ב׳", 3: "ג׳"}
+
+
 def _milestone(span: ReadingSpan, urn_base: str) -> str:
     """The marker that opens a reading division. Its scope runs to the next of the same unit."""
     label = span.label
@@ -119,6 +124,13 @@ def _milestone(span: ReadingSpan, urn_base: str) -> str:
         title = WEEKDAY_TITLES.get(label, label)
     elif span.unit == UNIT_MAFTIR:
         title = ALIYAH_TITLES["maftir"]
+    elif span.unit.startswith("aliyah.triennial") or span.unit.startswith("maftir.triennial"):
+        # Labels arrive as "<year>.<aliyah>", e.g. "2.7" or "1.maftir".
+        year, _, aliyah = label.partition(".")
+        title = (
+            f"{TRIENNIAL_YEARS.get(int(year), year)} "
+            f"{ALIYAH_TITLES.get(aliyah, aliyah)}"
+        )
     else:
         title = label
     urn = f"{urn_base}/{span.unit.replace('.', '_')}/{slugify_reading_name(label)}"

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -15,12 +15,17 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 from opensiddur.importer.feinstein_haggadah.tei_builder import validate_and_write
 from opensiddur.importer.humash import model
-from opensiddur.importer.humash.aliyot import Parsha, parse_parshiyot
-from opensiddur.importer.humash.names import SLUG_TO_HEBREW, slugify_reading_name
+from opensiddur.importer.humash.aliyot import CombinedParsha, Parsha, parse_readings
+from opensiddur.importer.humash.names import (
+    PAIR_FOR_MEMBER,
+    SLUG_TO_HEBREW,
+    slugify_reading_name,
+)
 from opensiddur.importer.humash.readings import (
     REPEATED_VERSE_INSTRUCTION,
     Passage,
@@ -28,6 +33,7 @@ from opensiddur.importer.humash.readings import (
     haftarot,
     triennial,
     triennial_haftarot,
+    triennial_patterns,
 )
 from opensiddur.importer.humash.refs import (
     DEFAULT_NUMBERING,
@@ -37,10 +43,15 @@ from opensiddur.importer.humash.refs import (
     SLUG_TO_HEBREW_BOOK,
     TORAH_BOOKS,
     UNIT_ALIYAH,
+    UNIT_ALIYAH_COMBINED,
     UNIT_MAFTIR,
+    UNIT_MAFTIR_COMBINED,
     UNIT_PARSHA,
+    UNIT_PARSHA_COMBINED,
     UNIT_TRIENNIAL,
     UNIT_WEEKDAY,
+    UNIT_WEEKDAY_COMBINED,
+    VARIATION_COMBINED,
     ReadingSpan,
     VerseRef,
 )
@@ -59,6 +70,9 @@ UNIT_TITLES = {
     UNIT_WEEKDAY: "עליית חול",
     UNIT_MAFTIR: "מפטיר",
     UNIT_TRIENNIAL: "מחזור תלת־שנתי",
+    UNIT_ALIYAH_COMBINED: "עלייה (מחוברות)",
+    UNIT_WEEKDAY_COMBINED: "עליית חול (מחוברות)",
+    UNIT_MAFTIR_COMBINED: "מפטיר (מחוברות)",
 }
 
 ALIYAH_TITLES = {
@@ -113,27 +127,60 @@ def _document(header: str, body: str, lang: str = "he") -> str:
 # the surrounding right-to-left text, which is how "1.maftir" comes out as "ritfam.1".
 TRIENNIAL_YEARS = {1: "א׳", 2: "ב׳", 3: "ג׳"}
 
+# What the margin says of a division that belongs to the pair read together, so that it is not
+# mistaken for the same-numbered aliyah of either single, which is beside it in the same file.
+COMBINED_SUFFIX = "מְחֻבָּרוֹת"
+
+
+def _triennial_title(label: str) -> str:
+    """The margin text of a triennial marker.
+
+    Labels are "<year>.<aliyah>", or "<variation>.<year>.<aliyah>" for a parshah that is
+    sometimes read combined. A variation letter is dropped: only one variation is ever read in
+    a given cycle, so naming it would say nothing to a reader of the volume it survives in.
+    The combined reading is called out, because it sits beside the singles in the same file.
+    """
+    parts = label.split(".")
+    variation = parts[0] if len(parts) == 3 else None
+    year, aliyah = parts[-2], parts[-1]
+    title = f"{TRIENNIAL_YEARS.get(int(year), year)} {ALIYAH_TITLES.get(aliyah, aliyah)}"
+    if variation == VARIATION_COMBINED:
+        return f"{title} ({COMBINED_SUFFIX})"
+    return title
+
+
+def _milestone_title(span: ReadingSpan) -> str:
+    label = span.label
+    if span.unit == UNIT_ALIYAH:
+        return ALIYAH_TITLES.get(label, label)
+    if span.unit == UNIT_WEEKDAY:
+        return WEEKDAY_TITLES.get(label, label)
+    if span.unit == UNIT_MAFTIR:
+        return ALIYAH_TITLES["maftir"]
+    if span.unit in (UNIT_PARSHA, UNIT_PARSHA_COMBINED):
+        return SLUG_TO_HEBREW.get(label, label)
+    if span.unit == UNIT_ALIYAH_COMBINED:
+        return f"{ALIYAH_TITLES.get(label, label)} ({COMBINED_SUFFIX})"
+    if span.unit == UNIT_WEEKDAY_COMBINED:
+        return f"{WEEKDAY_TITLES.get(label, label)} ({COMBINED_SUFFIX})"
+    if span.unit == UNIT_MAFTIR_COMBINED:
+        return f"{ALIYAH_TITLES['maftir']} ({COMBINED_SUFFIX})"
+    if span.unit.startswith("aliyah.triennial") or span.unit.startswith("maftir.triennial"):
+        # Labels arrive as "<year>.<aliyah>" or "<variation>.<year>.<aliyah>".
+        return _triennial_title(label)
+    return label
+
 
 def _milestone(span: ReadingSpan, urn_base: str) -> str:
     """The marker that opens a reading division. Its scope runs to the next of the same unit."""
-    label = span.label
-    title = ""
-    if span.unit == UNIT_ALIYAH:
-        title = ALIYAH_TITLES.get(label, label)
-    elif span.unit == UNIT_WEEKDAY:
-        title = WEEKDAY_TITLES.get(label, label)
-    elif span.unit == UNIT_MAFTIR:
-        title = ALIYAH_TITLES["maftir"]
-    elif span.unit.startswith("aliyah.triennial") or span.unit.startswith("maftir.triennial"):
-        # Labels arrive as "<year>.<aliyah>", e.g. "2.7" or "1.maftir".
-        year, _, aliyah = label.partition(".")
-        title = (
-            f"{TRIENNIAL_YEARS.get(int(year), year)} "
-            f"{ALIYAH_TITLES.get(aliyah, aliyah)}"
-        )
+    title = _milestone_title(span)
+    if span.unit in (UNIT_PARSHA, UNIT_PARSHA_COMBINED):
+        # A parshah's own URN, not one below the file's: inside a combined file the marker for
+        # each single is what makes urn:...:parsha/<slug> resolve to that single's text.
+        urn = f"{URN_PREFIX}:parsha/{span.label}"
     else:
-        title = label
-    urn = f"{urn_base}/{span.unit.replace('.', '_')}/{slugify_reading_name(label)}"
+        base = f"{URN_PREFIX}:parsha/{span.owner}" if span.owner else urn_base
+        urn = f"{base}/{span.unit.replace('.', '_')}/{slugify_reading_name(span.label)}"
     return (
         f'<tei:milestone unit="{span.unit}" n="{_escape(title)}" corresp="{urn}"/>'
     )
@@ -163,6 +210,30 @@ def _conditional(feature_type: str, feature: str, content: str, prefix: str) -> 
     )
 
 
+TRIENNIAL_PATTERN_FEATURE = "triennial-pattern-{pair}"
+
+
+def _pattern_conditional(pair_slug: str, patterns: list[str], content: str) -> str:
+    """Wrap `content` so it survives only in a cycle with one of these combine/separate patterns.
+
+    ``opensiddur:torah-reading`` carries one pattern feature per pair, derived from the date.
+    With no date declared the feature is undefined and every variation is kept, the way
+    leaving ``opensiddur:rite`` unset keeps every rite's haftarah.
+    """
+    identifier = _condition_id("triennial")
+    feature = TRIENNIAL_PATTERN_FEATURE.format(pair=pair_slug.replace("_", "-"))
+    alternatives = "".join(
+        f'<tei:fs type="opensiddur:torah-reading"><tei:f name="{feature}">'
+        f"<tei:string>{pattern}</tei:string></tei:f></tei:fs>"
+        for pattern in sorted(patterns)
+    )
+    return (
+        f'<j:conditional xml:id="{identifier}"><j:any>{alternatives}</j:any></j:conditional>'
+        f"{content}"
+        f'<j:endConditional target="#{identifier}"/>'
+    )
+
+
 def _default_numbering_conditional(content: str) -> str:
     """Wrap `content` so it is used unless another numbering is explicitly selected.
 
@@ -183,13 +254,29 @@ def _default_numbering_conditional(content: str) -> str:
     )
 
 
+Conditions = dict[str, tuple[str, list[str]]]
+
+
 def _segment_xml(
     segment: model.Segment,
     urn_base: str,
     sourcetexts_root: Path | None,
+    conditions: Conditions | None = None,
 ) -> str:
-    """Milestones opening at this segment, then the text itself."""
-    parts = [_milestone(span, urn_base) for span in segment.opening]
+    """Milestones opening at this segment, then the text itself.
+
+    `conditions` maps a unit-space to the pair and patterns its markers depend on. Each marker
+    is wrapped on its own rather than the whole division at once, since the markers of a
+    division are spread through the text they divide.
+    """
+    parts: list[str] = []
+    for span in segment.opening:
+        marker = _milestone(span, urn_base)
+        condition = (conditions or {}).get(span.unit)
+        parts.append(
+            _pattern_conditional(condition[0], condition[1], marker)
+            if condition is not None else marker
+        )
     if segment.duplicate:
         parts.append(
             f'<tei:note type="instruction" xml:lang="he">{_escape("חוזרים על הפסוק")}</tei:note>'
@@ -204,6 +291,7 @@ def _numbered_variants(
     end: VerseRef,
     urn_base: str,
     sourcetexts_root: Path | None,
+    conditions: Conditions | None = None,
 ) -> str:
     """Emit one variant of a reading per verse numbering, under conditional control.
 
@@ -216,7 +304,9 @@ def _numbered_variants(
             _restated(spans, numbering), start, end, sourcetexts_root, numbering,
             allow_duplication=False,
         )
-        content = "".join(_segment_xml(s, urn_base, sourcetexts_root) for s in segments)
+        content = "".join(
+            _segment_xml(s, urn_base, sourcetexts_root, conditions) for s in segments
+        )
         if numbering == DEFAULT_NUMBERING:
             parts.append(_default_numbering_conditional(content))
         else:
@@ -242,51 +332,116 @@ def _restated(spans: list[ReadingSpan], numbering: str) -> list[ReadingSpan]:
             end = VerseRef(end.book, end.chapter, counts[numbering])
         restated.append(ReadingSpan(
             unit=span.unit, label=span.label, start=span.start, end=end,
-            note=span.note, numbering=numbering,
+            note=span.note, numbering=numbering, owner=span.owner,
         ))
     return restated
 
 
-def parsha_file(
-    parsha: Parsha,
-    triennial_spans: dict[int, list[ReadingSpan]],
-    sourcetexts_root: Path | None = None,
+TriennialDivisions = dict[tuple[str | None, int], list[ReadingSpan]]
+
+
+def _reading_document(
+    slug: str,
+    hebrew: str,
+    spans: list[ReadingSpan],
+    start: VerseRef,
+    end: VerseRef,
+    conditions: Conditions | None,
+    sourcetexts_root: Path | None,
 ) -> tuple[str, str]:
-    """One weekly parshah: its heading, its reading divisions, and the text between them."""
-    urn_base = f"{URN_PREFIX}:parsha/{parsha.slug}"
-    spans = list(parsha.spans)
-    for year_spans in triennial_spans.values():
-        spans.extend(year_spans)
+    """A parshah file: its heading, its reading divisions, and the text between them."""
+    urn_base = f"{URN_PREFIX}:parsha/{slug}"
 
     # A parshah is one continuous reading, so it is always emitted once; see segment_reading.
     overlapping = model.overlapping_units(spans)
     if overlapping:
         logger.info(
             "%s: %s overlap themselves, so those milestones scope to the next marker rather "
-            "than to their recorded end", parsha.slug, ", ".join(sorted(overlapping)),
+            "than to their recorded end", slug, ", ".join(sorted(overlapping)),
         )
 
     needs_variants = any(span.crosses_divergent_chapter for span in spans)
     if needs_variants:
         body_inner = _numbered_variants(
-            spans, parsha.start, parsha.end, urn_base, sourcetexts_root
+            spans, start, end, urn_base, sourcetexts_root, conditions
         )
     else:
         segments = model.segment_reading(
-            spans, parsha.start, parsha.end, sourcetexts_root, DEFAULT_NUMBERING,
+            spans, start, end, sourcetexts_root, DEFAULT_NUMBERING,
             allow_duplication=False,
         )
-        body_inner = "".join(_segment_xml(s, urn_base, sourcetexts_root) for s in segments)
+        body_inner = "".join(
+            _segment_xml(s, urn_base, sourcetexts_root, conditions) for s in segments
+        )
 
-    hebrew = SLUG_TO_HEBREW.get(parsha.slug, parsha.hebrew_name)
     body = (
-        f'<tei:div corresp="{urn_base}" n="{parsha.slug}">'
-        f"<tei:head>{_escape(hebrew)}</tei:head>"
-        f'<tei:milestone unit="{UNIT_PARSHA}" n="{_escape(hebrew)}" corresp="{urn_base}"/>'
-        f"{body_inner}</tei:div>"
+        f'<tei:div corresp="{urn_base}" n="{slug}">'
+        f"<tei:head>{_escape(hebrew)}</tei:head>{body_inner}</tei:div>"
     )
-    header = _header(hebrew, parsha.slug.replace("_", " ").title(), f"parsha/{parsha.slug}")
-    return f"parashat_{parsha.slug}", _document(header, body)
+    header = _header(hebrew, slug.replace("_", " ").title(), f"parsha/{slug}")
+    return f"parashat_{slug}", _document(header, body)
+
+
+def parsha_file(
+    parsha: Parsha,
+    triennial_divisions: TriennialDivisions,
+    sourcetexts_root: Path | None = None,
+) -> tuple[str, str]:
+    """One weekly parshah, read on its own week."""
+    spans = [parsha.parsha_span, *parsha.spans]
+    for division in triennial_divisions.values():
+        spans.extend(division)
+    hebrew = SLUG_TO_HEBREW.get(parsha.slug, parsha.hebrew_name)
+    return _reading_document(
+        parsha.slug, hebrew, spans, parsha.start, parsha.end, None, sourcetexts_root
+    )
+
+
+def pair_file(
+    pair: CombinedParsha,
+    members: list[Parsha],
+    triennial_divisions: dict[str, TriennialDivisions],
+    patterns: dict[str, str],
+    sourcetexts_root: Path | None = None,
+) -> tuple[str, str]:
+    """A pair that may be read together, holding both singles and the combined reading.
+
+    The two are alternatives, not a whole and its parts, so they are separate unit-spaces over
+    one copy of the text: the combined fourth aliyah runs through the point where the second
+    parshah begins, and would be cut there if it were scoped by ``parsha.annual``.
+
+    The combined divisions are unconditioned, so a volume carries the pair both ways. Each
+    single's triennial divisions are not: which of them applies depends on how the pair fell
+    in that cycle, and the condition says which cycles each is for.
+    """
+    spans = [pair.parsha_span]
+    conditions: Conditions = {}
+    for member in members:
+        spans.append(member.parsha_span)
+        # The singles' divisions keep their own URN space: both parshiyot have a first aliyah.
+        spans.extend(replace(span, owner=member.slug) for span in member.spans)
+        for (variation, _year), division in triennial_divisions.get(member.slug, {}).items():
+            matching = sorted(
+                pattern for pattern, name in patterns.items() if name == variation
+            )
+            if variation is not None and not matching:
+                logger.warning(
+                    "%s: no cycle pattern selects triennial variation %s, so its markers are "
+                    "emitted unconditionally", member.slug, variation,
+                )
+            for span in division:
+                if variation is not None and matching:
+                    conditions[span.unit] = (pair.slug, matching)
+            spans.extend(division)
+
+    spans.extend(pair.spans)
+    for division in triennial_divisions.get(pair.slug, {}).values():
+        spans.extend(division)
+
+    return _reading_document(
+        pair.slug, SLUG_TO_HEBREW.get(pair.slug, pair.hebrew_name), spans,
+        pair.start, pair.end, conditions, sourcetexts_root,
+    )
 
 
 def _passage_xml(passage: Passage, urn_base: str) -> str:
@@ -400,12 +555,19 @@ def festival_file(
 
 
 def book_file(book: str, parshiyot: list[Parsha]) -> tuple[str, str]:
-    """One of the five books, transcluding its parshiyot in order."""
+    """One of the five books, transcluding its parshiyot in order.
+
+    A pair is transcluded once, by the pair's own URN: its file holds both singles, so
+    transcluding the members as well would print their text twice.
+    """
     urn_base = f"{URN_PREFIX}:humash/{book}"
     hebrew = SLUG_TO_HEBREW_BOOK[book]
-    inner = "".join(
-        _transclude(f"{URN_PREFIX}:parsha/{parsha.slug}") for parsha in parshiyot
-    )
+    targets: list[str] = []
+    for parsha in parshiyot:
+        slug = PAIR_FOR_MEMBER.get(parsha.slug, parsha.slug)
+        if not targets or targets[-1] != slug:
+            targets.append(slug)
+    inner = "".join(_transclude(f"{URN_PREFIX}:parsha/{slug}") for slug in targets)
     body = (
         f'<tei:div type="book" corresp="{urn_base}" n="{book}">'
         f"<tei:head>{_escape(hebrew)}</tei:head>{inner}</tei:div>"
@@ -474,15 +636,25 @@ def build(
     project_dir = project_directory / PROJECT
     project_dir.mkdir(parents=True, exist_ok=True)
 
-    parshiyot = parse_parshiyot(sourcetexts_root)
+    parshiyot, pairs = parse_readings(sourcetexts_root)
     all_haftarot = haftarot(sourcetexts_root)
     all_triennial = triennial(sourcetexts_root)
+    all_patterns = triennial_patterns(sourcetexts_root)
     festivals = festival_readings(sourcetexts_root)
 
     documents: list[tuple[str, str]] = []
+    by_slug = {parsha.slug: parsha for parsha in parshiyot}
     for parsha in parshiyot:
+        # The fourteen that have a partner are emitted inside their pair's file instead.
+        if parsha.slug in PAIR_FOR_MEMBER:
+            continue
         documents.append(parsha_file(
             parsha, all_triennial.get(parsha.slug, {}), sourcetexts_root
+        ))
+    for pair in pairs:
+        documents.append(pair_file(
+            pair, [by_slug[slug] for slug in pair.members], all_triennial,
+            all_patterns.get(pair.slug, {}), sourcetexts_root,
         ))
 
     by_book: dict[str, list[Parsha]] = {}

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -40,6 +40,7 @@ from opensiddur.importer.humash.readings import (
 )
 from opensiddur.importer.humash.refs import (
     MEGILLOT,
+    SLUG_TO_HEBREW_ANY_BOOK,
     SLUG_TO_VOCALIZED_BOOK,
     TORAH_BOOKS,
     UNIT_ALIYAH,
@@ -55,6 +56,7 @@ from opensiddur.importer.humash.refs import (
     ReadingSpan,
     VerseRef,
     chapters_in_book,
+    next_verse,
     verses_in_chapter,
 )
 
@@ -215,6 +217,48 @@ def _transclude(target: str) -> str:
 
 def _instruction(text: str) -> str:
     return f'<tei:note type="instruction" xml:lang="he">{_escape(text)}</tei:note>'
+
+
+def _citation_range(book: str, start: VerseRef, end: VerseRef) -> str:
+    """"<book> <chapter>:<verse>[–<chapter>:<verse>]" for one contiguous range."""
+    book_he = SLUG_TO_HEBREW_ANY_BOOK.get(book, book)
+    start_ref = f"{start.chapter}:{start.verse}"
+    end_ref = f"{end.chapter}:{end.verse}"
+    return f"{book_he} {start_ref if start == end else f'{start_ref}–{end_ref}'}"
+
+
+def _citation(spans: list[ReadingSpan]) -> str:
+    """A citation for a passage's spans, in reading order: one clause per span, joined by
+    "; ". Only the first span of a run in one book states the book name; a passage that
+    bridges books (readings.Passage) or backtracks within one (Mishpatim's haftarah) states
+    it again wherever the book changes.
+    """
+    clauses: list[str] = []
+    prev_book: str | None = None
+    for span in spans:
+        if span.book == prev_book:
+            start_ref = f"{span.start.chapter}:{span.start.verse}"
+            end_ref = f"{span.end.chapter}:{span.end.verse}"
+            clauses.append(start_ref if span.start == span.end else f"{start_ref}–{end_ref}")
+        else:
+            clauses.append(_citation_range(span.book, span.start, span.end))
+        prev_book = span.book
+    return "; ".join(clauses)
+
+
+def _citation_milestone(text: str) -> str:
+    return f'<tei:milestone unit="citation" n="{_escape(text)}"/>'
+
+
+def _is_contiguous(
+    prev: ReadingSpan, following: ReadingSpan, sourcetexts_root: Path | None,
+) -> bool:
+    """Whether `following` picks up exactly where `prev` left off: same book, and its first
+    verse is the one right after `prev`'s last. False for a backward jump, a skip ahead, or
+    a change of book — see readings.Passage."""
+    if prev.book != following.book:
+        return False
+    return next_verse(prev.end, sourcetexts_root) == following.start
 
 
 _CONDITION_INDEX = {"value": 0}
@@ -421,10 +465,21 @@ HALF_VERSE_START_INSTRUCTION = "מתחילים מאמצע הפסוק"
 HALF_VERSE_END_INSTRUCTION = "מסיימים באמצע הפסוק"
 
 
-def _passage_xml(passage: Passage, urn_base: str) -> str:
-    """A haftarah or megillah: its spans in order, then any repeated closing verse."""
+def _passage_xml(
+    passage: Passage, urn_base: str, sourcetexts_root: Path | None = None,
+) -> str:
+    """A haftarah or megillah: its citation, its spans in order, then any repeated closing verse.
+
+    A citation opens the passage, and another opens again at any span that does not pick up
+    where the one before it left off — a backward jump, a skip ahead, or a change of book (see
+    readings.Passage) — so the reading always states where it is even when it is discontinuous.
+    """
     parts: list[str] = []
-    for span in passage.spans:
+    if passage.spans:
+        parts.append(_citation_milestone(_citation(passage.spans)))
+    for i, span in enumerate(passage.spans):
+        if i > 0 and not _is_contiguous(passage.spans[i - 1], span, sourcetexts_root):
+            parts.append(_citation_milestone(_citation([span])))
         if span.start_half == "b":
             parts.append(_instruction(HALF_VERSE_START_INSTRUCTION))
         parts.append(_transclude(span.start.range_urn(span.end)))
@@ -447,6 +502,7 @@ def haftarah_file(
     slug: str,
     passages: list[Passage],
     triennial_passages: dict[int, Passage] | None = None,
+    sourcetexts_root: Path | None = None,
 ) -> tuple[str, str]:
     """The haftarah of one parshah: the annual reading, and the triennial ones as alternatives.
 
@@ -470,7 +526,7 @@ def haftarah_file(
 
     annual: list[str] = []
     for passage in passages:
-        content = _passage_xml(passage, urn_base)
+        content = _passage_xml(passage, urn_base, sourcetexts_root)
         if passage.rite is None:
             annual.append(content)
             continue
@@ -503,7 +559,7 @@ def haftarah_file(
         division = (
             f'<tei:div corresp="{urn_base}/triennial/{year}" n="triennial_{year}">'
             f"<tei:head>{_escape(year_title)}</tei:head>"
-            f"{_passage_xml(triennial_passages[year], urn_base)}</tei:div>"
+            f"{_passage_xml(triennial_passages[year], urn_base, sourcetexts_root)}</tei:div>"
         )
         inner += (
             f'<j:conditional xml:id="{identifier}">'
@@ -574,6 +630,10 @@ def festival_file(
             by_book.setdefault(span.book, []).append(span)
         for book_spans in by_book.values():
             ordered = sorted(book_spans, key=lambda span: (span.start, span.end))
+            book = ordered[0].book
+            start = min(span.start for span in ordered)
+            end = max(span.end for span in ordered)
+            parts.append(_citation_milestone(_citation_range(book, start, end)))
             segments = model.segment_reading(
                 ordered, sourcetexts_root=sourcetexts_root
             )
@@ -585,7 +645,7 @@ def festival_file(
     # from the end of the Torah reading as though it were more of the same.
     haftarah_parts: list[str] = []
     for passage in reading["haftarot"]:
-        content = _passage_xml(passage, urn_base)
+        content = _passage_xml(passage, urn_base, sourcetexts_root)
         if passage.rite is None:
             haftarah_parts.append(content)
         else:
@@ -773,7 +833,10 @@ def build(
     sections: dict[str, list[str]] = {name: [] for name, _ in SECTIONS}
     for slug in haftarah_order(parshiyot, all_haftarot):
         documents.append(
-            haftarah_file(slug, all_haftarot[slug], all_triennial_haftarot.get(slug, {}))
+            haftarah_file(
+                slug, all_haftarot[slug], all_triennial_haftarot.get(slug, {}),
+                sourcetexts_root,
+            )
         )
         sections["haftarot"].append(f"{URN_PREFIX}:haftarah/{slug}")
 

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -83,6 +83,12 @@ ALIYAH_TITLES = {
 
 WEEKDAY_TITLES = {"1": "כֹּהֵן", "2": "לֵוִי", "3": "יִשְׂרָאֵל"}
 
+# Sukkot's Chol HaMoed Shabbat maftir varies by which intermediate day it falls on
+# ("maftir_day1".."maftir_day5"). Latin/digits here would be reversed when set in the
+# surrounding right-to-left text, same as TRIENNIAL_YEARS below, so days are spelled out
+# as Hebrew letters rather than left as the raw source label.
+MAFTIR_DAY_LETTERS = {1: "א׳", 2: "ב׳", 3: "ג׳", 4: "ד׳", 5: "ה׳"}
+
 
 def _escape(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
@@ -156,6 +162,9 @@ def _milestone_title(span: ReadingSpan) -> str:
     if span.unit == UNIT_WEEKDAY:
         return WEEKDAY_TITLES.get(label, label)
     if span.unit == UNIT_MAFTIR:
+        if label.startswith("maftir_day"):
+            day = int(label[len("maftir_day"):])
+            return f"{ALIYAH_TITLES['maftir']} לְיוֹם {MAFTIR_DAY_LETTERS[day]}"
         return ALIYAH_TITLES["maftir"]
     if span.unit in (UNIT_PARSHA, UNIT_PARSHA_COMBINED):
         return SLUG_TO_HEBREW.get(label, label)

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -1,0 +1,523 @@
+"""Emit the humash project: structure over text transcluded from the Tanakh projects.
+
+Every word of Torah, haftarah and megillah text is transcluded by URN. The only original
+content is the headings and the reading instructions, so nothing here duplicates a text that
+already exists in another project.
+
+Targets carry no ``@project`` suffix, so which edition supplies the text is decided at compile
+time by ``priority.transclusion``. The exception is the four chapters the editions divide into
+verses differently, where one range cannot serve them all; those are emitted once per
+numbering under ``opensiddur:verse-numbering``, defaulting to MAM's division.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from opensiddur.importer.feinstein_haggadah.tei_builder import validate_and_write
+from opensiddur.importer.humash import model
+from opensiddur.importer.humash.aliyot import Parsha, parse_parshiyot
+from opensiddur.importer.humash.names import SLUG_TO_HEBREW, slugify_reading_name
+from opensiddur.importer.humash.readings import (
+    REPEATED_VERSE_INSTRUCTION,
+    Passage,
+    festival_readings,
+    haftarot,
+    triennial,
+    triennial_haftarot,
+)
+from opensiddur.importer.humash.refs import (
+    DEFAULT_NUMBERING,
+    DIVERGENT_CHAPTER_VERSES,
+    MEGILLOT,
+    NUMBERINGS,
+    SLUG_TO_HEBREW_BOOK,
+    TORAH_BOOKS,
+    UNIT_ALIYAH,
+    UNIT_MAFTIR,
+    UNIT_PARSHA,
+    UNIT_TRIENNIAL,
+    UNIT_WEEKDAY,
+    ReadingSpan,
+    VerseRef,
+)
+
+logger = logging.getLogger(__name__)
+
+PROJECT = "humash"
+URN_PREFIX = "urn:x-opensiddur:text:bible"
+
+TEI_NS = "http://www.tei-c.org/ns/1.0"
+J_NS = "http://jewishliturgy.org/ns/jlptei/2"
+
+# What each unit-space is called in the margin.
+UNIT_TITLES = {
+    UNIT_ALIYAH: "עלייה",
+    UNIT_WEEKDAY: "עליית חול",
+    UNIT_MAFTIR: "מפטיר",
+    UNIT_TRIENNIAL: "מחזור תלת־שנתי",
+}
+
+ALIYAH_TITLES = {
+    "1": "רִאשׁוֹן", "2": "שֵׁנִי", "3": "שְׁלִישִׁי", "4": "רְבִיעִי",
+    "5": "חֲמִישִׁי", "6": "שִׁשִּׁי", "7": "שְׁבִיעִי", "maftir": "מַפְטִיר",
+    "מפטיר": "מַפְטִיר",
+}
+
+WEEKDAY_TITLES = {"1": "כֹּהֵן", "2": "לֵוִי", "3": "יִשְׂרָאֵל"}
+
+
+def _escape(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _header(title_he: str, title_en: str, urn_suffix: str) -> str:
+    """A leaf header, deferring version and source information to the project index."""
+    index_urn = f"{URN_PREFIX}:humash@{PROJECT}"
+    return f"""<tei:teiHeader>
+  <tei:fileDesc>
+    <tei:titleStmt>
+      <tei:title type="main" xml:lang="he">{_escape(title_he)}</tei:title>
+      <tei:title type="alt" xml:lang="en">{_escape(title_en)}</tei:title>
+    </tei:titleStmt>
+    <tei:editionStmt>
+      <tei:p>See <tei:ref target="{index_urn}">the humash project header for version information</tei:ref>.</tei:p>
+    </tei:editionStmt>
+    <tei:publicationStmt>
+      <tei:distributor>
+        <tei:ref target="http://opensiddur.org">Open Siddur Project</tei:ref>
+      </tei:distributor>
+      <tei:idno type="urn">{URN_PREFIX}:{urn_suffix}@{PROJECT}</tei:idno>
+      <tei:availability status="free">
+        <tei:licence target="http://www.creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero Public Domain Declaration (CC0)</tei:licence>
+      </tei:availability>
+    </tei:publicationStmt>
+    <tei:sourceDesc>
+      <tei:p>See <tei:ref target="{index_urn}">the humash project header for source information</tei:ref>.</tei:p>
+    </tei:sourceDesc>
+  </tei:fileDesc>
+</tei:teiHeader>"""
+
+
+def _document(header: str, body: str, lang: str = "he") -> str:
+    return (
+        f'<tei:TEI xmlns:tei="{TEI_NS}" xmlns:j="{J_NS}" xml:lang="{lang}">'
+        f"{header}<tei:text xml:lang=\"{lang}\"><tei:body>{body}</tei:body></tei:text></tei:TEI>"
+    )
+
+
+def _milestone(span: ReadingSpan, urn_base: str) -> str:
+    """The marker that opens a reading division. Its scope runs to the next of the same unit."""
+    label = span.label
+    title = ""
+    if span.unit == UNIT_ALIYAH:
+        title = ALIYAH_TITLES.get(label, label)
+    elif span.unit == UNIT_WEEKDAY:
+        title = WEEKDAY_TITLES.get(label, label)
+    elif span.unit == UNIT_MAFTIR:
+        title = ALIYAH_TITLES["maftir"]
+    else:
+        title = label
+    urn = f"{urn_base}/{span.unit.replace('.', '_')}/{slugify_reading_name(label)}"
+    return (
+        f'<tei:milestone unit="{span.unit}" n="{_escape(title)}" corresp="{urn}"/>'
+    )
+
+
+def _transclude(target: str) -> str:
+    return f'<j:transclude type="external" target="{target}"/>'
+
+
+_CONDITION_INDEX = {"value": 0}
+
+
+def _condition_id(prefix: str) -> str:
+    _CONDITION_INDEX["value"] += 1
+    return f"{prefix}_{_CONDITION_INDEX['value']}"
+
+
+def _conditional(feature_type: str, feature: str, content: str, prefix: str) -> str:
+    """Wrap `content` in a condition on one binary feature being true."""
+    identifier = _condition_id(prefix)
+    return (
+        f'<j:conditional xml:id="{identifier}">'
+        f'<tei:fs type="{feature_type}"><tei:f name="{feature}">'
+        f'<tei:binary value="true"/></tei:f></tei:fs>'
+        f"</j:conditional>{content}"
+        f'<j:endConditional target="#{identifier}"/>'
+    )
+
+
+def _default_numbering_conditional(content: str) -> str:
+    """Wrap `content` so it is used unless another numbering is explicitly selected.
+
+    ``j:none`` over the other numberings is false as soon as one of them is true, and
+    undefined while none is set — which keeps MAM's division as the default.
+    """
+    identifier = _condition_id("numbering_default")
+    others = "".join(
+        f'<tei:fs type="opensiddur:verse-numbering"><tei:f name="{numbering}">'
+        f'<tei:binary value="true"/></tei:f></tei:fs>'
+        for numbering in NUMBERINGS
+        if numbering != DEFAULT_NUMBERING
+    )
+    return (
+        f'<j:conditional xml:id="{identifier}"><j:none>{others}</j:none></j:conditional>'
+        f"{content}"
+        f'<j:endConditional target="#{identifier}"/>'
+    )
+
+
+def _segment_xml(
+    segment: model.Segment,
+    urn_base: str,
+    sourcetexts_root: Path | None,
+) -> str:
+    """Milestones opening at this segment, then the text itself."""
+    parts = [_milestone(span, urn_base) for span in segment.opening]
+    if segment.duplicate:
+        parts.append(
+            f'<tei:note type="instruction" xml:lang="he">{_escape("חוזרים על הפסוק")}</tei:note>'
+        )
+    parts.append(_transclude(segment.start.range_urn(segment.end)))
+    return "".join(parts)
+
+
+def _numbered_variants(
+    spans: list[ReadingSpan],
+    start: VerseRef,
+    end: VerseRef,
+    urn_base: str,
+    sourcetexts_root: Path | None,
+) -> str:
+    """Emit one variant of a reading per verse numbering, under conditional control.
+
+    Only reached for readings touching Exodus 20, Numbers 10, Numbers 25 or Deuteronomy 5.
+    Everywhere else a single range resolves in every edition and no variant is needed.
+    """
+    parts: list[str] = []
+    for numbering in NUMBERINGS:
+        segments = model.segment_reading(
+            _restated(spans, numbering), start, end, sourcetexts_root, numbering,
+            allow_duplication=False,
+        )
+        content = "".join(_segment_xml(s, urn_base, sourcetexts_root) for s in segments)
+        if numbering == DEFAULT_NUMBERING:
+            parts.append(_default_numbering_conditional(content))
+        else:
+            parts.append(_conditional(
+                "opensiddur:verse-numbering", numbering, content, f"numbering_{numbering}"
+            ))
+    return "".join(parts)
+
+
+def _restated(spans: list[ReadingSpan], numbering: str) -> list[ReadingSpan]:
+    """The spans as the given edition numbers them.
+
+    Only the ends that fall on the last verse of a divergent chapter move: those are stated as
+    "to the end of the chapter", and each edition ends the chapter at a different verse. A
+    boundary inside such a chapter cannot be restated without a verse-by-verse alignment of the
+    editions, so it is left alone and the reading keeps the numbering it was recorded in.
+    """
+    restated: list[ReadingSpan] = []
+    for span in spans:
+        end = span.end
+        counts = DIVERGENT_CHAPTER_VERSES.get((end.book, end.chapter))
+        if counts is not None and end.verse == counts[span.numbering]:
+            end = VerseRef(end.book, end.chapter, counts[numbering])
+        restated.append(ReadingSpan(
+            unit=span.unit, label=span.label, start=span.start, end=end,
+            note=span.note, numbering=numbering,
+        ))
+    return restated
+
+
+def parsha_file(
+    parsha: Parsha,
+    triennial_spans: dict[int, list[ReadingSpan]],
+    sourcetexts_root: Path | None = None,
+) -> tuple[str, str]:
+    """One weekly parshah: its heading, its reading divisions, and the text between them."""
+    urn_base = f"{URN_PREFIX}:parsha/{parsha.slug}"
+    spans = list(parsha.spans)
+    for year_spans in triennial_spans.values():
+        spans.extend(year_spans)
+
+    # A parshah is one continuous reading, so it is always emitted once; see segment_reading.
+    overlapping = model.overlapping_units(spans)
+    if overlapping:
+        logger.info(
+            "%s: %s overlap themselves, so those milestones scope to the next marker rather "
+            "than to their recorded end", parsha.slug, ", ".join(sorted(overlapping)),
+        )
+
+    needs_variants = any(span.crosses_divergent_chapter for span in spans)
+    if needs_variants:
+        body_inner = _numbered_variants(
+            spans, parsha.start, parsha.end, urn_base, sourcetexts_root
+        )
+    else:
+        segments = model.segment_reading(
+            spans, parsha.start, parsha.end, sourcetexts_root, DEFAULT_NUMBERING,
+            allow_duplication=False,
+        )
+        body_inner = "".join(_segment_xml(s, urn_base, sourcetexts_root) for s in segments)
+
+    hebrew = SLUG_TO_HEBREW.get(parsha.slug, parsha.hebrew_name)
+    body = (
+        f'<tei:div corresp="{urn_base}" n="{parsha.slug}">'
+        f"<tei:head>{_escape(hebrew)}</tei:head>"
+        f'<tei:milestone unit="{UNIT_PARSHA}" n="{_escape(hebrew)}" corresp="{urn_base}"/>'
+        f"{body_inner}</tei:div>"
+    )
+    header = _header(hebrew, parsha.slug.replace("_", " ").title(), f"parsha/{parsha.slug}")
+    return f"parashat_{parsha.slug}", _document(header, body)
+
+
+def _passage_xml(passage: Passage, urn_base: str) -> str:
+    """A haftarah or megillah: its spans in order, then any repeated closing verse."""
+    parts: list[str] = []
+    for span in passage.spans:
+        parts.append(_transclude(span.start.range_urn(span.end)))
+    if passage.repeated is not None:
+        parts.append(
+            f'<tei:note type="instruction" xml:lang="he">'
+            f"{_escape(REPEATED_VERSE_INSTRUCTION)}</tei:note>"
+        )
+        parts.append(_transclude(
+            passage.repeated.start.range_urn(passage.repeated.end)
+        ))
+    return "".join(parts)
+
+
+def haftarah_file(slug: str, passages: list[Passage]) -> tuple[str, str]:
+    """The haftarah of one parshah, with a division per rite where the rites differ."""
+    urn_base = f"{URN_PREFIX}:haftarah/{slug}"
+    hebrew = SLUG_TO_HEBREW.get(slug, slug)
+    title = f"הַפְטָרַת {hebrew}"
+
+    inner: list[str] = []
+    for passage in passages:
+        content = _passage_xml(passage, urn_base)
+        if passage.rite is None:
+            inner.append(content)
+            continue
+        variant = (
+            f'<tei:div corresp="{urn_base}/{passage.rite}" n="{passage.rite}">'
+            f"<tei:head>{_escape(passage.title or passage.rite)}</tei:head>"
+            f"{content}</tei:div>"
+        )
+        inner.append(_conditional("opensiddur:rite", passage.rite, variant, "rite"))
+
+    body = (
+        f'<tei:div corresp="{urn_base}" n="haftarah_{slug}">'
+        f"<tei:head>{_escape(title)}</tei:head>{''.join(inner)}</tei:div>"
+    )
+    header = _header(title, f"Haftarah for {slug.replace('_', ' ').title()}", f"haftarah/{slug}")
+    return f"haftarat_{slug}", _document(header, body)
+
+
+def megillah_file(book: str, hebrew: str, holiday: str) -> tuple[str, str]:
+    """One of the five megillot, read whole on its festival."""
+    from opensiddur.importer.humash.readings import REPEATED_CLOSING_VERSES
+
+    urn_base = f"{URN_PREFIX}:megillah/{book}"
+    parts = [_transclude(f"{URN_PREFIX}:{book}")]
+    repeat = REPEATED_CLOSING_VERSES.get((f"megillah:{book}", book))
+    if repeat is not None:
+        chapter, verse = repeat
+        ref = VerseRef(book, chapter, verse)
+        parts.append(
+            f'<tei:note type="instruction" xml:lang="he">'
+            f"{_escape(REPEATED_VERSE_INSTRUCTION)}</tei:note>"
+        )
+        parts.append(_transclude(ref.range_urn(ref)))
+
+    content = (
+        f'<tei:div corresp="{urn_base}" n="megillah_{book}">'
+        f"<tei:head>{_escape(hebrew)}</tei:head>{''.join(parts)}</tei:div>"
+    )
+    body = _conditional("opensiddur:holiday", holiday, content, "megillah")
+    header = _header(hebrew, book.replace("_", " ").title(), f"megillah/{book}")
+    return f"megillat_{book}", _document(header, body)
+
+
+def festival_file(
+    slug: str,
+    reading: dict,
+    sourcetexts_root: Path | None = None,
+) -> tuple[str, str]:
+    """One festival or special-Shabbat reading, with its haftarah."""
+    urn_base = f"{URN_PREFIX}:reading/{slug}"
+    name = reading["name"]
+    parts: list[str] = []
+
+    spans = reading["aliyot"]
+    if spans:
+        by_book: dict[str, list[ReadingSpan]] = {}
+        for span in spans:
+            by_book.setdefault(span.book, []).append(span)
+        for book_spans in by_book.values():
+            ordered = sorted(book_spans, key=lambda span: (span.start, span.end))
+            segments = model.segment_reading(
+                ordered, sourcetexts_root=sourcetexts_root, numbering=ordered[0].numbering
+            )
+            parts.extend(_segment_xml(s, urn_base, sourcetexts_root) for s in segments)
+
+    for passage in reading["haftarot"]:
+        content = _passage_xml(passage, urn_base)
+        if passage.rite is None:
+            parts.append(content)
+        else:
+            variant = (
+                f'<tei:div corresp="{urn_base}/{passage.rite}" n="{passage.rite}">'
+                f"<tei:head>{_escape(passage.title or passage.rite)}</tei:head>"
+                f"{content}</tei:div>"
+            )
+            parts.append(_conditional("opensiddur:rite", passage.rite, variant, "rite"))
+
+    body = (
+        f'<tei:div corresp="{urn_base}" n="reading_{slug}">'
+        f'<tei:head xml:lang="en">{_escape(name)}</tei:head>{"".join(parts)}</tei:div>'
+    )
+    header = _header(name, name, f"reading/{slug}")
+    return f"reading_{slug}", _document(header, body, lang="he")
+
+
+def book_file(book: str, parshiyot: list[Parsha]) -> tuple[str, str]:
+    """One of the five books, transcluding its parshiyot in order."""
+    urn_base = f"{URN_PREFIX}:humash/{book}"
+    hebrew = SLUG_TO_HEBREW_BOOK[book]
+    inner = "".join(
+        _transclude(f"{URN_PREFIX}:parsha/{parsha.slug}") for parsha in parshiyot
+    )
+    body = (
+        f'<tei:div type="book" corresp="{urn_base}" n="{book}">'
+        f"<tei:head>{_escape(hebrew)}</tei:head>{inner}</tei:div>"
+    )
+    header = _header(hebrew, book.title(), f"humash/{book}")
+    return book, _document(header, body)
+
+
+def index_file(extra_urns: list[str]) -> tuple[str, str]:
+    """The project entry point, holding the bibliography and transcluding everything."""
+    urn = f"{URN_PREFIX}:humash"
+    inner = "".join(
+        _transclude(f"{URN_PREFIX}:humash/{slug}") for _, slug, _ in TORAH_BOOKS
+    ) + "".join(_transclude(target) for target in extra_urns)
+    body = (
+        f'<tei:div corresp="{urn}" n="humash">'
+        f"<tei:head>{_escape('חֻמָּשׁ')}</tei:head>{inner}</tei:div>"
+    )
+    header = f"""<tei:teiHeader>
+  <tei:fileDesc>
+    <tei:titleStmt>
+      <tei:title type="main" xml:lang="he">חֻמָּשׁ</tei:title>
+      <tei:title type="alt" xml:lang="en">Humash</tei:title>
+      <tei:respStmt>
+        <tei:resp key="mrk">Markup</tei:resp>
+        <tei:name ref="urn:x-opensiddur:opensiddur.org/efraim-feinstein">Efraim Feinstein</tei:name>
+      </tei:respStmt>
+    </tei:titleStmt>
+    <tei:editionStmt>
+      <tei:p>The Torah arranged by liturgical reading. This project holds no text of its own:
+        every reading is transcluded by URN from a Tanakh project, and only the headings and
+        instructions originate here.</tei:p>
+    </tei:editionStmt>
+    <tei:publicationStmt>
+      <tei:distributor>
+        <tei:ref target="http://opensiddur.org">Open Siddur Project</tei:ref>
+      </tei:distributor>
+      <tei:idno type="urn">{urn}@{PROJECT}</tei:idno>
+      <tei:availability status="free">
+        <tei:licence target="http://www.creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero Public Domain Declaration (CC0)</tei:licence>
+      </tei:availability>
+    </tei:publicationStmt>
+    <tei:sourceDesc>
+      <tei:bibl xml:id="source_mam">
+        <tei:title>Miqra al pi ha-Masorah</tei:title>
+        <tei:ptr target="{URN_PREFIX}:tanakh@miqra_al_pi_hamasorah"/>
+        <tei:note>Source of the weekly parshah, aliyah and maftir divisions.</tei:note>
+      </tei:bibl>
+      <tei:bibl xml:id="source_hebcal">
+        <tei:title>hebcal leyning</tei:title>
+        <tei:ptr target="https://github.com/hebcal/hebcal-leyning"/>
+        <tei:note>Source of the haftarot, the festival readings and the triennial cycle.</tei:note>
+      </tei:bibl>
+    </tei:sourceDesc>
+  </tei:fileDesc>
+</tei:teiHeader>"""
+    return "index", _document(header, body)
+
+
+def build(
+    project_directory: Path,
+    sourcetexts_root: Path | None = None,
+    validate: bool = True,
+) -> list[Path]:
+    """Generate the whole humash project. Returns the files written."""
+    project_dir = project_directory / PROJECT
+    project_dir.mkdir(parents=True, exist_ok=True)
+
+    parshiyot = parse_parshiyot(sourcetexts_root)
+    all_haftarot = haftarot(sourcetexts_root)
+    all_triennial = triennial(sourcetexts_root)
+    festivals = festival_readings(sourcetexts_root)
+
+    documents: list[tuple[str, str]] = []
+    for parsha in parshiyot:
+        documents.append(parsha_file(
+            parsha, all_triennial.get(parsha.slug, {}), sourcetexts_root
+        ))
+
+    by_book: dict[str, list[Parsha]] = {}
+    for parsha in parshiyot:
+        by_book.setdefault(parsha.book, []).append(parsha)
+    for _, book, _ in TORAH_BOOKS:
+        documents.append(book_file(book, by_book.get(book, [])))
+
+    extra_urns: list[str] = []
+    for slug, passages in sorted(all_haftarot.items()):
+        documents.append(haftarah_file(slug, passages))
+        extra_urns.append(f"{URN_PREFIX}:haftarah/{slug}")
+    for book, hebrew, holiday in MEGILLOT:
+        documents.append(megillah_file(book, hebrew, holiday))
+        extra_urns.append(f"{URN_PREFIX}:megillah/{book}")
+    for slug, reading in sorted(festivals.items()):
+        documents.append(festival_file(slug, reading, sourcetexts_root))
+        extra_urns.append(f"{URN_PREFIX}:reading/{slug}")
+
+    documents.append(index_file(extra_urns))
+
+    written: list[Path] = []
+    for file_name, content in documents:
+        if validate:
+            written.append(validate_and_write(content, file_name, project_dir))
+        else:
+            path = project_dir / f"{file_name}.xml"
+            path.write_text(content, encoding="utf-8")
+            written.append(path)
+    logger.info("Wrote %d files to %s", len(written), project_dir)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-dir", type=Path, required=True)
+    parser.add_argument("--sourcetexts-root", type=Path, default=None)
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Skip RelaxNG/Schematron validation (requires the compiled schema otherwise).",
+    )
+    args = parser.parse_args(argv)
+    build(args.project_dir, args.sourcetexts_root, validate=not args.no_validate)
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    sys.exit(main())

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -190,6 +190,10 @@ def _transclude(target: str) -> str:
     return f'<j:transclude type="external" target="{target}"/>'
 
 
+def _instruction(text: str) -> str:
+    return f'<tei:note type="instruction" xml:lang="he">{_escape(text)}</tei:note>'
+
+
 _CONDITION_INDEX = {"value": 0}
 
 
@@ -232,6 +236,31 @@ def _pattern_conditional(pair_slug: str, patterns: list[str], content: str) -> s
         f"{content}"
         f'<j:endConditional target="#{identifier}"/>'
     )
+
+
+# Which readings the volume carries: `annual`, and one feature per year of the triennial cycle.
+# All are false by default but `annual`, and several may be true at once, so one volume may be
+# for a single Shabbat and another for a whole cycle. See exporter/calendar/compute.py.
+CYCLE_FS = "opensiddur:reading-cycle"
+ANNUAL_FEATURE = "annual"
+CYCLE_YEARS = tuple(TRIENNIAL_YEARS)
+
+
+def _cycle_condition(feature: str) -> str:
+    """The test for one reading-cycle feature being true.
+
+    Always a single feature, so that the answer is decisive. ``j:all`` over a false test and an
+    undefined one is undefined per the truth tables, and undefined keeps the text it guards —
+    which for readings that are alternatives to one another would print several at once.
+    """
+    return (
+        f'<tei:fs type="{CYCLE_FS}"><tei:f name="{feature}">'
+        f'<tei:binary value="true"/></tei:f></tei:fs>'
+    )
+
+
+def _triennial_year_feature(year: int) -> str:
+    return f"triennial-year-{year}"
 
 
 def _default_numbering_conditional(content: str) -> str:
@@ -278,9 +307,7 @@ def _segment_xml(
             if condition is not None else marker
         )
     if segment.duplicate:
-        parts.append(
-            f'<tei:note type="instruction" xml:lang="he">{_escape("חוזרים על הפסוק")}</tei:note>'
-        )
+        parts.append(_instruction("חוזרים על הפסוק"))
     parts.append(_transclude(segment.start.range_urn(segment.end)))
     return "".join(parts)
 
@@ -444,44 +471,109 @@ def pair_file(
     )
 
 
+# hebcal states a few boundaries inside a verse — Emor's third year names Nachum 2:2b-2:3a —
+# and a URN reaches no further than a whole verse. Every such reference in the data today is on
+# an anchor verse that readings.triennial_haftarot drops, so nothing emits these yet; they are
+# here because the alternative, if hebcal moves one into a span that is read, is to silently
+# read half a verse too much.
+HALF_VERSE_START_INSTRUCTION = "מתחילים מאמצע הפסוק"
+HALF_VERSE_END_INSTRUCTION = "מסיימים באמצע הפסוק"
+
+
 def _passage_xml(passage: Passage, urn_base: str) -> str:
     """A haftarah or megillah: its spans in order, then any repeated closing verse."""
     parts: list[str] = []
     for span in passage.spans:
+        if span.start_half == "b":
+            parts.append(_instruction(HALF_VERSE_START_INSTRUCTION))
         parts.append(_transclude(span.start.range_urn(span.end)))
+        if span.end_half == "a":
+            parts.append(_instruction(HALF_VERSE_END_INSTRUCTION))
     if passage.repeated is not None:
-        parts.append(
-            f'<tei:note type="instruction" xml:lang="he">'
-            f"{_escape(REPEATED_VERSE_INSTRUCTION)}</tei:note>"
-        )
+        parts.append(_instruction(REPEATED_VERSE_INSTRUCTION))
         parts.append(_transclude(
             passage.repeated.start.range_urn(passage.repeated.end)
         ))
     return "".join(parts)
 
 
-def haftarah_file(slug: str, passages: list[Passage]) -> tuple[str, str]:
-    """The haftarah of one parshah, with a division per rite where the rites differ."""
+# The heading over a triennial haftarah. Unlike the triennial Torah divisions, which are
+# markers in the margin of the annual text, these are whole alternative readings.
+TRIENNIAL_HAFTARAH_TITLE = "מַחֲזוֹר תְּלַת־שְׁנָתִי, שָׁנָה {year}"
+
+
+def haftarah_file(
+    slug: str,
+    passages: list[Passage],
+    triennial_passages: dict[int, Passage] | None = None,
+) -> tuple[str, str]:
+    """The haftarah of one parshah: the annual reading, and the triennial ones as alternatives.
+
+    The annual haftarah has a division per rite where the rites differ. The triennial readings
+    have none — hebcal records a single reading per cycle year — so each is one headed division
+    conditioned on the volume reading that year of the cycle.
+
+    They are alternatives for the same Shabbat, so the annual reading is kept when the volume
+    asks for it and also whenever the volume's cycle year has nothing to put in its place.
+    Tazria, Achrei Mot and Behar are read alone only in years 1 and 2 and so have no reading
+    for year 3; a parshah with no triennial reading at all is unconditional, as are the pairs,
+    which have no triennial haftarah of their own.
+
+    This is the one place the humash decides rather than keeping every variant. A volume that
+    asks for nothing gets the annual reading, not all four: they belong to one week, and
+    printing four haftarot for it would be wrong however they were headed.
+    """
     urn_base = f"{URN_PREFIX}:haftarah/{slug}"
     hebrew = SLUG_TO_HEBREW.get(slug, slug)
     title = f"הַפְטָרַת {hebrew}"
 
-    inner: list[str] = []
+    annual: list[str] = []
     for passage in passages:
         content = _passage_xml(passage, urn_base)
         if passage.rite is None:
-            inner.append(content)
+            annual.append(content)
             continue
         variant = (
             f'<tei:div corresp="{urn_base}/{passage.rite}" n="{passage.rite}">'
             f"<tei:head>{_escape(passage.title or passage.rite)}</tei:head>"
             f"{content}</tei:div>"
         )
-        inner.append(_conditional("opensiddur:rite", passage.rite, variant, "rite"))
+        annual.append(_conditional("opensiddur:rite", passage.rite, variant, "rite"))
+
+    years = sorted(triennial_passages or {})
+    inner = "".join(annual)
+    if years:
+        # The annual reading also stands in for the cycle years this parshah has none of, so a
+        # triennial volume is never left with no haftarah at all for the week.
+        missing = [year for year in CYCLE_YEARS if year not in years]
+        identifier = _condition_id("annual_haftarah")
+        alternatives = "".join(
+            _cycle_condition(feature) for feature in
+            [ANNUAL_FEATURE, *(_triennial_year_feature(year) for year in missing)]
+        )
+        inner = (
+            f'<j:conditional xml:id="{identifier}"><j:any>{alternatives}</j:any>'
+            f"</j:conditional>{inner}"
+            f'<j:endConditional target="#{identifier}"/>'
+        )
+    for year in years:
+        identifier = _condition_id("triennial_haftarah")
+        year_title = TRIENNIAL_HAFTARAH_TITLE.format(year=TRIENNIAL_YEARS.get(year, year))
+        division = (
+            f'<tei:div corresp="{urn_base}/triennial/{year}" n="triennial_{year}">'
+            f"<tei:head>{_escape(year_title)}</tei:head>"
+            f"{_passage_xml(triennial_passages[year], urn_base)}</tei:div>"
+        )
+        inner += (
+            f'<j:conditional xml:id="{identifier}">'
+            f"{_cycle_condition(_triennial_year_feature(year))}</j:conditional>"
+            f"{division}"
+            f'<j:endConditional target="#{identifier}"/>'
+        )
 
     body = (
         f'<tei:div corresp="{urn_base}" n="haftarah_{slug}">'
-        f"<tei:head>{_escape(title)}</tei:head>{''.join(inner)}</tei:div>"
+        f"<tei:head>{_escape(title)}</tei:head>{inner}</tei:div>"
     )
     header = _header(title, f"Haftarah for {slug.replace('_', ' ').title()}", f"haftarah/{slug}")
     return f"haftarat_{slug}", _document(header, body)
@@ -497,10 +589,7 @@ def megillah_file(book: str, hebrew: str, holiday: str) -> tuple[str, str]:
     if repeat is not None:
         chapter, verse = repeat
         ref = VerseRef(book, chapter, verse)
-        parts.append(
-            f'<tei:note type="instruction" xml:lang="he">'
-            f"{_escape(REPEATED_VERSE_INSTRUCTION)}</tei:note>"
-        )
+        parts.append(_instruction(REPEATED_VERSE_INSTRUCTION))
         parts.append(_transclude(ref.range_urn(ref)))
 
     content = (
@@ -638,6 +727,7 @@ def build(
 
     parshiyot, pairs = parse_readings(sourcetexts_root)
     all_haftarot = haftarot(sourcetexts_root)
+    all_triennial_haftarot = triennial_haftarot(sourcetexts_root)
     all_triennial = triennial(sourcetexts_root)
     all_patterns = triennial_patterns(sourcetexts_root)
     festivals = festival_readings(sourcetexts_root)
@@ -665,8 +755,19 @@ def build(
 
     extra_urns: list[str] = []
     for slug, passages in sorted(all_haftarot.items()):
-        documents.append(haftarah_file(slug, passages))
+        documents.append(
+            haftarah_file(slug, passages, all_triennial_haftarot.get(slug, {}))
+        )
         extra_urns.append(f"{URN_PREFIX}:haftarah/{slug}")
+
+    unplaced = sorted(set(all_triennial_haftarot) - set(all_haftarot))
+    if unplaced:
+        # Nothing to hang them off: a parshah with a triennial haftarah but no annual one would
+        # have no file of its own, so say so rather than dropping it silently.
+        logger.warning(
+            "No haftarah file for %s, so their triennial haftarot were not emitted",
+            ", ".join(unplaced),
+        )
     for book, hebrew, holiday in MEGILLOT:
         documents.append(megillah_file(book, hebrew, holiday))
         extra_urns.append(f"{URN_PREFIX}:megillah/{book}")

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -27,6 +27,7 @@ from opensiddur.importer.humash.names import (
     PAIR_MEMBERS,
     SLUG_TO_HEBREW,
     slugify_reading_name,
+    vocalized_name,
 )
 from opensiddur.importer.humash.readings import (
     REPEATED_VERSE_INSTRUCTION,
@@ -42,7 +43,7 @@ from opensiddur.importer.humash.refs import (
     DIVERGENT_CHAPTER_VERSES,
     MEGILLOT,
     NUMBERINGS,
-    SLUG_TO_HEBREW_BOOK,
+    SLUG_TO_VOCALIZED_BOOK,
     TORAH_BOOKS,
     UNIT_ALIYAH,
     UNIT_ALIYAH_COMBINED,
@@ -126,10 +127,12 @@ def _header(title_he: str, title_en: str, urn_suffix: str) -> str:
 </tei:teiHeader>"""
 
 
-def _document(header: str, body: str, lang: str = "he") -> str:
+def _document(header: str, body: str, lang: str = "he", front: str = "") -> str:
+    front_element = f"<tei:front>{front}</tei:front>" if front else ""
     return (
         f'<tei:TEI xmlns:tei="{TEI_NS}" xmlns:j="{J_NS}" xml:lang="{lang}">'
-        f"{header}<tei:text xml:lang=\"{lang}\"><tei:body>{body}</tei:body></tei:text></tei:TEI>"
+        f'{header}<tei:text xml:lang="{lang}">{front_element}'
+        f"<tei:body>{body}</tei:body></tei:text></tei:TEI>"
     )
 
 
@@ -140,6 +143,9 @@ TRIENNIAL_YEARS = {1: "א׳", 2: "ב׳", 3: "ג׳"}
 # What the margin says of a division that belongs to the pair read together, so that it is not
 # mistaken for the same-numbered aliyah of either single, which is beside it in the same file.
 COMBINED_SUFFIX = "מְחֻבָּרוֹת"
+
+# What the prophetic reading of a festival or special Shabbat is headed.
+HAFTARAH_TITLE = "הַפְטָרָה"
 
 
 def _triennial_title(label: str) -> str:
@@ -171,7 +177,7 @@ def _milestone_title(span: ReadingSpan) -> str:
             return f"{ALIYAH_TITLES['maftir']} לְיוֹם {MAFTIR_DAY_LETTERS[day]}"
         return ALIYAH_TITLES["maftir"]
     if span.unit in (UNIT_PARSHA, UNIT_PARSHA_COMBINED):
-        return SLUG_TO_HEBREW.get(label, label)
+        return vocalized_name(label)
     if span.unit == UNIT_ALIYAH_COMBINED:
         return f"{ALIYAH_TITLES.get(label, label)} ({COMBINED_SUFFIX})"
     if span.unit == UNIT_WEEKDAY_COMBINED:
@@ -431,7 +437,7 @@ def parsha_file(
     spans = [parsha.parsha_span, *parsha.spans]
     for division in triennial_divisions.values():
         spans.extend(division)
-    hebrew = SLUG_TO_HEBREW.get(parsha.slug, parsha.hebrew_name)
+    hebrew = vocalized_name(parsha.slug)
     return _reading_document(
         parsha.slug, hebrew, spans, parsha.start, parsha.end, None, sourcetexts_root
     )
@@ -479,7 +485,7 @@ def pair_file(
         spans.extend(division)
 
     return _reading_document(
-        pair.slug, SLUG_TO_HEBREW.get(pair.slug, pair.hebrew_name), spans,
+        pair.slug, vocalized_name(pair.slug), spans,
         pair.start, pair.end, conditions, sourcetexts_root,
     )
 
@@ -537,7 +543,7 @@ def haftarah_file(
     printing four haftarot for it would be wrong however they were headed.
     """
     urn_base = f"{URN_PREFIX}:haftarah/{slug}"
-    hebrew = SLUG_TO_HEBREW.get(slug, slug)
+    hebrew = vocalized_name(slug)
     title = f"הַפְטָרַת {hebrew}"
 
     annual: list[str] = []
@@ -651,17 +657,30 @@ def festival_file(
             )
             parts.extend(_segment_xml(s, urn_base, sourcetexts_root) for s in segments)
 
+    # The haftarah gets a division of its own, headed, rather than following the maftir inside
+    # the reading's div: where a festival has one rite's haftarah and so no rite heading, the
+    # prophetic reading would otherwise begin with nothing at all to announce it, running on
+    # from the end of the Torah reading as though it were more of the same.
+    haftarah_parts: list[str] = []
     for passage in reading["haftarot"]:
         content = _passage_xml(passage, urn_base)
         if passage.rite is None:
-            parts.append(content)
+            haftarah_parts.append(content)
         else:
             variant = (
                 f'<tei:div corresp="{urn_base}/{passage.rite}" n="{passage.rite}">'
                 f"<tei:head>{_escape(passage.title or passage.rite)}</tei:head>"
                 f"{content}</tei:div>"
             )
-            parts.append(_conditional("opensiddur:rite", passage.rite, variant, "rite"))
+            haftarah_parts.append(
+                _conditional("opensiddur:rite", passage.rite, variant, "rite")
+            )
+    if haftarah_parts:
+        parts.append(
+            f'<tei:div corresp="{urn_base}/haftarah" n="haftarah">'
+            f"<tei:head>{_escape(HAFTARAH_TITLE)}</tei:head>"
+            f"{''.join(haftarah_parts)}</tei:div>"
+        )
 
     # hebcal names its readings in English; the heading is what the page shows, and everything
     # else in the volume is titled in Hebrew. The English name is kept in the header.
@@ -681,7 +700,7 @@ def book_file(book: str, parshiyot: list[Parsha]) -> tuple[str, str]:
     transcluding the members as well would print their text twice.
     """
     urn_base = f"{URN_PREFIX}:humash/{book}"
-    hebrew = SLUG_TO_HEBREW_BOOK[book]
+    hebrew = SLUG_TO_VOCALIZED_BOOK[book]
     targets: list[str] = []
     for parsha in parshiyot:
         slug = PAIR_FOR_MEMBER.get(parsha.slug, parsha.slug)
@@ -764,7 +783,13 @@ def index_file(extra_urns: list[str]) -> tuple[str, str]:
     </tei:sourceDesc>
   </tei:fileDesc>
 </tei:teiHeader>"""
-    return "index", _document(header, body)
+    front = (
+        "<tei:titlePage><tei:docTitle>"
+        '<tei:titlePart type="main" xml:lang="he">חֻמָּשׁ</tei:titlePart>'
+        '<tei:titlePart type="alt" xml:lang="en">Humash</tei:titlePart>'
+        "</tei:docTitle></tei:titlePage>"
+    )
+    return "index", _document(header, body, front=front)
 
 
 def build(

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -735,12 +735,31 @@ def haftarah_order(parshiyot: list[Parsha], available: dict[str, object]) -> lis
     return ordered
 
 
-def index_file(extra_urns: list[str]) -> tuple[str, str]:
+# The parts of the volume that are not the Torah itself. Each gathers its readings under one
+# heading, so that they stand to their readings as a book stands to its parshiyot rather than
+# lying beside the five books as 250 loose sections.
+SECTIONS: tuple[tuple[str, str], ...] = (
+    ("haftarot", "הַפְטָרוֹת"),
+    ("megillot", "מְגִלּוֹת"),
+    ("readings", "קְרִיאֵי מוֹעֵד"),
+)
+
+
+def index_file(sections: dict[str, list[str]]) -> tuple[str, str]:
     """The project entry point, holding the bibliography and transcluding everything."""
     urn = f"{URN_PREFIX}:humash"
     inner = "".join(
         _transclude(f"{URN_PREFIX}:humash/{slug}") for _, slug, _ in TORAH_BOOKS
-    ) + "".join(_transclude(target) for target in extra_urns)
+    )
+    for name, title in SECTIONS:
+        targets = sections.get(name) or []
+        if not targets:
+            continue
+        inner += (
+            f'<tei:div corresp="{urn}/{name}" n="{name}">'
+            f"<tei:head>{_escape(title)}</tei:head>"
+            f"{''.join(_transclude(target) for target in targets)}</tei:div>"
+        )
     body = (
         f'<tei:div corresp="{urn}" n="humash">'
         f"<tei:head>{_escape('חֻמָּשׁ')}</tei:head>{inner}</tei:div>"
@@ -829,12 +848,12 @@ def build(
     for _, book, _ in TORAH_BOOKS:
         documents.append(book_file(book, by_book.get(book, [])))
 
-    extra_urns: list[str] = []
+    sections: dict[str, list[str]] = {name: [] for name, _ in SECTIONS}
     for slug in haftarah_order(parshiyot, all_haftarot):
         documents.append(
             haftarah_file(slug, all_haftarot[slug], all_triennial_haftarot.get(slug, {}))
         )
-        extra_urns.append(f"{URN_PREFIX}:haftarah/{slug}")
+        sections["haftarot"].append(f"{URN_PREFIX}:haftarah/{slug}")
 
     unplaced = sorted(set(all_triennial_haftarot) - set(all_haftarot))
     if unplaced:
@@ -846,12 +865,12 @@ def build(
         )
     for book, hebrew, holiday in MEGILLOT:
         documents.append(megillah_file(book, hebrew, holiday, sourcetexts_root))
-        extra_urns.append(f"{URN_PREFIX}:megillah/{book}")
+        sections["megillot"].append(f"{URN_PREFIX}:megillah/{book}")
     for slug, reading in sorted(festivals.items()):
         documents.append(festival_file(slug, reading, sourcetexts_root))
-        extra_urns.append(f"{URN_PREFIX}:reading/{slug}")
+        sections["readings"].append(f"{URN_PREFIX}:reading/{slug}")
 
-    documents.append(index_file(extra_urns))
+    documents.append(index_file(sections))
 
     written: list[Path] = []
     for file_name, content in documents:

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -21,8 +21,10 @@ from pathlib import Path
 from opensiddur.importer.feinstein_haggadah.tei_builder import validate_and_write
 from opensiddur.importer.humash import model
 from opensiddur.importer.humash.aliyot import CombinedParsha, Parsha, parse_readings
+from opensiddur.importer.humash.festival_names import hebrew_name
 from opensiddur.importer.humash.names import (
     PAIR_FOR_MEMBER,
+    PAIR_MEMBERS,
     SLUG_TO_HEBREW,
     slugify_reading_name,
 )
@@ -54,6 +56,8 @@ from opensiddur.importer.humash.refs import (
     VARIATION_COMBINED,
     ReadingSpan,
     VerseRef,
+    chapters_in_book,
+    verses_in_chapter,
 )
 
 logger = logging.getLogger(__name__)
@@ -588,12 +592,27 @@ def haftarah_file(
     return f"haftarat_{slug}", _document(header, body)
 
 
-def megillah_file(book: str, hebrew: str, holiday: str) -> tuple[str, str]:
+def megillah_file(
+    book: str,
+    hebrew: str,
+    holiday: str,
+    sourcetexts_root: Path | None = None,
+) -> tuple[str, str]:
     """One of the five megillot, read whole on its festival."""
     from opensiddur.importer.humash.readings import REPEATED_CLOSING_VERSES
 
     urn_base = f"{URN_PREFIX}:megillah/{book}"
-    parts = [_transclude(f"{URN_PREFIX}:{book}")]
+    # Named as a range from the first verse to the last, not by the book's own URN. Every
+    # project holding a Tanakh book claims that URN, including one that carries only the
+    # book's title and no text — MAM has such a file for each of the megillot — and the book
+    # URN would resolve to the first project in priority order whether or not it has the
+    # words. A verse range asks for what is actually read, so it passes over an edition that
+    # does not have it, which is what every other reading the humash emits already does.
+    last_chapter = chapters_in_book(book, sourcetexts_root)
+    whole_book = VerseRef(book, 1, 1).range_urn(
+        VerseRef(book, last_chapter, verses_in_chapter(book, last_chapter, sourcetexts_root))
+    )
+    parts = [_transclude(whole_book)]
     repeat = REPEATED_CLOSING_VERSES.get((f"megillah:{book}", book))
     if repeat is not None:
         chapter, verse = repeat
@@ -644,11 +663,14 @@ def festival_file(
             )
             parts.append(_conditional("opensiddur:rite", passage.rite, variant, "rite"))
 
+    # hebcal names its readings in English; the heading is what the page shows, and everything
+    # else in the volume is titled in Hebrew. The English name is kept in the header.
+    hebrew = hebrew_name(name)
     body = (
         f'<tei:div corresp="{urn_base}" n="reading_{slug}">'
-        f'<tei:head xml:lang="en">{_escape(name)}</tei:head>{"".join(parts)}</tei:div>'
+        f'<tei:head>{_escape(hebrew)}</tei:head>{"".join(parts)}</tei:div>'
     )
-    header = _header(name, name, f"reading/{slug}")
+    header = _header(hebrew, name, f"reading/{slug}")
     return f"reading_{slug}", _document(header, body, lang="he")
 
 
@@ -672,6 +694,26 @@ def book_file(book: str, parshiyot: list[Parsha]) -> tuple[str, str]:
     )
     header = _header(hebrew, book.title(), f"humash/{book}")
     return book, _document(header, body)
+
+
+def haftarah_order(parshiyot: list[Parsha], available: dict[str, object]) -> list[str]:
+    """The haftarah slugs in the order their parshiyot are read.
+
+    Sorting by slug would file חיי שרה between בשלח and חֻקת. A pair's haftarah follows both
+    its members', since a pair is read on a week that would otherwise have read the second of
+    them. Anything with no parshah of that name — hebcal has none today — keeps a place at the
+    end rather than being dropped.
+    """
+    ordered: list[str] = []
+    for parsha in parshiyot:
+        if parsha.slug in available:
+            ordered.append(parsha.slug)
+        pair = PAIR_FOR_MEMBER.get(parsha.slug)
+        # The pair goes after its second member, which is the parshah that follows its first.
+        if pair is not None and pair in available and PAIR_MEMBERS[pair][1] == parsha.slug:
+            ordered.append(pair)
+    ordered.extend(sorted(set(available) - set(ordered)))
+    return ordered
 
 
 def index_file(extra_urns: list[str]) -> tuple[str, str]:
@@ -763,9 +805,9 @@ def build(
         documents.append(book_file(book, by_book.get(book, [])))
 
     extra_urns: list[str] = []
-    for slug, passages in sorted(all_haftarot.items()):
+    for slug in haftarah_order(parshiyot, all_haftarot):
         documents.append(
-            haftarah_file(slug, passages, all_triennial_haftarot.get(slug, {}))
+            haftarah_file(slug, all_haftarot[slug], all_triennial_haftarot.get(slug, {}))
         )
         extra_urns.append(f"{URN_PREFIX}:haftarah/{slug}")
 
@@ -778,7 +820,7 @@ def build(
             ", ".join(unplaced),
         )
     for book, hebrew, holiday in MEGILLOT:
-        documents.append(megillah_file(book, hebrew, holiday))
+        documents.append(megillah_file(book, hebrew, holiday, sourcetexts_root))
         extra_urns.append(f"{URN_PREFIX}:megillah/{book}")
     for slug, reading in sorted(festivals.items()):
         documents.append(festival_file(slug, reading, sourcetexts_root))

--- a/opensiddur/importer/humash/crosscheck.py
+++ b/opensiddur/importer/humash/crosscheck.py
@@ -1,0 +1,135 @@
+"""Check the MAM aliyah parse against hebcal's independent record of the same divisions.
+
+The humash takes its weekly aliyot from Miqra al pi ha-Masorah, whose divisions agree with the
+MAM text the reader is looking at. hebcal records the same divisions separately, so comparing
+the two catches parse errors in the MAM wikitext that no internal consistency check could.
+
+Where the two genuinely differ they differ for a reason — the sources disagree about where a
+few aliyot begin, and hebcal notes the alternative in a third element of the range. Those are
+listed in ``KNOWN_DIVERGENCES`` so that a new difference stands out from an expected one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from opensiddur.importer.humash.aliyot import parse_parshiyot
+from opensiddur.importer.humash.names import HEBCAL_TO_SLUG
+from opensiddur.importer.humash.refs import (
+    HEBCAL_BOOK_TO_SLUG,
+    UNIT_ALIYAH,
+    UNIT_MAFTIR,
+    UNIT_WEEKDAY,
+    parse_hebcal_ref,
+)
+from opensiddur.importer.util.pages import hebcal_leyning_data_directory
+
+logger = logging.getLogger(__name__)
+
+# hebcal numbers the books 1-5 in its aliyot.json.
+_HEBCAL_BOOK_NUMBERS = {1: "genesis", 2: "exodus", 3: "leviticus", 4: "numbers", 5: "deuteronomy"}
+
+# Aliyot where MAM and hebcal deliberately differ. hebcal's own note names MAM's division as
+# what "some sources use", so these are two live traditions, not an error in either.
+KNOWN_DIVERGENCES: frozenset[tuple[str, str, str]] = frozenset({
+    # (parshah slug, unit, label)
+    ("bereshit", UNIT_ALIYAH, "5"),   # hebcal 4:19-4:22; MAM 4:19-4:26
+    ("bereshit", UNIT_ALIYAH, "6"),   # hebcal 4:23-5:24; MAM 5:1-5:24
+    ("terumah", UNIT_ALIYAH, "2"),    # hebcal 25:16-25:30; MAM 25:17-25:30
+    ("terumah", UNIT_ALIYAH, "3"),    # hebcal 25:31-26:14; MAM 25:31-26:14
+})
+
+
+@dataclass(frozen=True)
+class Divergence:
+    parsha: str
+    unit: str
+    label: str
+    mam: str
+    hebcal: str
+    note: str | None = None
+
+    @property
+    def is_known(self) -> bool:
+        return (self.parsha, self.unit, self.label) in KNOWN_DIVERGENCES
+
+    def __str__(self) -> str:
+        marker = "known" if self.is_known else "NEW"
+        line = f"[{marker}] {self.parsha} {self.unit} {self.label}: MAM {self.mam} / hebcal {self.hebcal}"
+        return f"{line} ({self.note})" if self.note else line
+
+
+def _hebcal_spans(entry: dict) -> dict[tuple[str, str], tuple[str, str | None]]:
+    """Flatten one hebcal parshah entry to {(unit, label): (range, note)}."""
+    book = _HEBCAL_BOOK_NUMBERS[entry["book"]]
+    spans: dict[tuple[str, str], tuple[str, str | None]] = {}
+    for key, unit in (("fullkriyah", UNIT_ALIYAH), ("weekday", UNIT_WEEKDAY)):
+        for label, value in entry.get(key, {}).items():
+            note = value[2] if len(value) > 2 else None
+            start = parse_hebcal_ref(book, value[0])
+            end = parse_hebcal_ref(book, value[1])
+            target_unit = UNIT_MAFTIR if label == "M" else unit
+            target_label = "maftir" if label == "M" else label
+            spans[(target_unit, target_label)] = (f"{start.chapter}:{start.verse}-{end.chapter}:{end.verse}", note)
+    return spans
+
+
+def compare(sourcetexts_root: Path | None = None) -> list[Divergence]:
+    """Compare every MAM span against hebcal's, returning the differences."""
+    path = hebcal_leyning_data_directory(sourcetexts_root) / "aliyot.json"
+    hebcal = json.loads(path.read_text(encoding="utf-8"))
+    by_slug = {
+        HEBCAL_TO_SLUG[name]: entry
+        for name, entry in hebcal.items()
+        if not entry.get("combined") and name in HEBCAL_TO_SLUG
+    }
+
+    divergences: list[Divergence] = []
+    for parsha in parse_parshiyot(sourcetexts_root):
+        entry = by_slug.get(parsha.slug)
+        if entry is None:
+            logger.warning("hebcal has no entry for %s", parsha.slug)
+            continue
+        expected = _hebcal_spans(entry)
+        for span in parsha.spans:
+            label = "maftir" if span.unit == UNIT_MAFTIR else span.label
+            key = (span.unit, label)
+            if key not in expected:
+                divergences.append(Divergence(
+                    parsha.slug, span.unit, label,
+                    f"{span.start.chapter}:{span.start.verse}-{span.end.chapter}:{span.end.verse}",
+                    "absent",
+                ))
+                continue
+            hebcal_range, note = expected.pop(key)
+            mam_range = f"{span.start.chapter}:{span.start.verse}-{span.end.chapter}:{span.end.verse}"
+            if mam_range != hebcal_range:
+                divergences.append(
+                    Divergence(parsha.slug, span.unit, label, mam_range, hebcal_range, note)
+                )
+        for (unit, label), (hebcal_range, note) in expected.items():
+            divergences.append(Divergence(parsha.slug, unit, label, "absent", hebcal_range, note))
+    return divergences
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sourcetexts-root", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    divergences = compare(args.sourcetexts_root)
+    unexpected = [d for d in divergences if not d.is_known]
+    for divergence in divergences:
+        print(divergence)
+    print(f"\n{len(divergences)} divergences, {len(unexpected)} of them unexpected")
+    return 1 if unexpected else 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    sys.exit(main())

--- a/opensiddur/importer/humash/download.py
+++ b/opensiddur/importer/humash/download.py
@@ -1,0 +1,125 @@
+"""Download the hebcal leyning data that supplies haftarot and festival readings.
+
+The aliyah divisions of the weekly parshiyot come from Miqra al pi ha-Masorah instead (see
+``aliyot.py``); hebcal supplies what MAM does not encode at all — the haftarot, the festival
+and special-Shabbat readings, and the modern triennial cycle. hebcal's own weekly aliyot are
+downloaded too, not to be emitted, but so that the MAM parse can be checked against a second
+independent source (see ``crosscheck.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+from opensiddur.importer.util.pages import (
+    default_sourcetexts_root,
+    hebcal_leyning_data_directory,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+USER_AGENT = (
+    "OpenSiddur-AI/1.0 (https://github.com/opensiddur/opensiddur-ai; "
+    "opensiddur@example.com)"
+)
+
+RAW_BASE = "https://raw.githubusercontent.com/hebcal"
+
+# (repository, path within the repository, local file name).
+SOURCE_FILES: tuple[tuple[str, str, str], ...] = (
+    # Weekly parshiyot: aliyot 1-7 and maftir, the three weekday aliyot, and the Ashkenazi
+    # ("haft") and Sephardi ("seph") haftarot.
+    ("hebcal-leyning", "src/aliyot.json", "aliyot.json"),
+    # Torah readings and haftarot for festivals, the four parshiyot, Rosh Hodesh and the rest.
+    ("hebcal-leyning", "src/holiday-readings.json", "holiday-readings.json"),
+    # Verse counts per chapter, used to resolve a reading that runs to the end of a chapter.
+    ("hebcal-leyning", "src/numverses.json", "numverses.json"),
+    # Modern triennial cycle: which third of each parshah is read in each year of the cycle.
+    ("hebcal-triennial", "src/triennial.json", "triennial.json"),
+    ("hebcal-triennial", "src/triennial-haft.json", "triennial-haft.json"),
+)
+
+LICENSE_URL = "https://github.com/hebcal/hebcal-leyning/blob/main/LICENSE"
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def download(
+    sourcetexts_root: Path | None = None,
+    dry_run: bool = False,
+) -> Path:
+    """Fetch each source file and write it with a manifest. Returns the data directory."""
+    data_dir = hebcal_leyning_data_directory(sourcetexts_root)
+    if dry_run:
+        logger.info("Would write %d files to %s", len(SOURCE_FILES), data_dir)
+        return data_dir
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+    session = requests.Session()
+    session.headers.update({"User-Agent": USER_AGENT})
+
+    entries = []
+    for repository, remote_path, file_name in SOURCE_FILES:
+        url = f"{RAW_BASE}/{repository}/main/{remote_path}"
+        logger.info("Downloading %s", url)
+        response = session.get(url, timeout=60)
+        response.raise_for_status()
+        payload = response.content
+        # Parse before writing: a 200 carrying an error page would otherwise be stored as data.
+        parsed = json.loads(payload)
+        (data_dir / file_name).write_bytes(payload)
+        entries.append({
+            "repository": repository,
+            "url": url,
+            "path": file_name,
+            "bytes": len(payload),
+            "top_level_keys": len(parsed),
+            "sha256": _sha256_bytes(payload),
+        })
+
+    manifest = {
+        "source": "hebcal",
+        "license_url": LICENSE_URL,
+        "downloaded_at": datetime.now(timezone.utc).isoformat(),
+        "files": entries,
+    }
+    manifest_path = data_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    logger.info("Wrote %d files and a manifest to %s", len(entries), data_dir)
+    return data_dir
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sourcetexts-root",
+        type=Path,
+        default=None,
+        help=f"sourcetexts checkout root (default: {default_sourcetexts_root()})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be downloaded without writing anything.",
+    )
+    args = parser.parse_args(argv)
+    download(sourcetexts_root=args.sourcetexts_root, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/opensiddur/importer/humash/festival_names.py
+++ b/opensiddur/importer/humash/festival_names.py
@@ -16,7 +16,11 @@ from __future__ import annotations
 import logging
 import re
 
-from opensiddur.importer.humash.names import SLUG_TO_HEBREW, slugify_reading_name
+from opensiddur.importer.humash.names import (
+    SLUG_TO_HEBREW,
+    SLUG_TO_VOCALIZED,
+    slugify_reading_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +133,8 @@ def _occasion(name: str) -> str | None:
             return f"{OCCASION_NAMES['Rosh Chodesh']} {month}"
         return None
     # Several readings are a weekly parshah read on a particular year, named by the parshah.
-    return SLUG_TO_HEBREW.get(slugify_reading_name(name))
+    slug = slugify_reading_name(name)
+    return SLUG_TO_VOCALIZED.get(slug) or SLUG_TO_HEBREW.get(slug)
 
 
 def hebrew_name(name: str) -> str:
@@ -144,7 +149,8 @@ def hebrew_name(name: str) -> str:
         qualifier_he = QUALIFIERS.get(qualifier)
         if qualifier_he is None and qualifier.startswith("with "):
             # "(with Ha'azinu)" — which parshah Shabbat Shuva falls on that year.
-            parshah = SLUG_TO_HEBREW.get(slugify_reading_name(qualifier[len("with "):]))
+            slug = slugify_reading_name(qualifier[len("with "):])
+            parshah = SLUG_TO_VOCALIZED.get(slug) or SLUG_TO_HEBREW.get(slug)
             qualifier_he = f"עִם {parshah}" if parshah is not None else None
         if qualifier_he is None:
             logger.warning("No Hebrew for the qualifier %r of %r", qualifier, name)

--- a/opensiddur/importer/humash/festival_names.py
+++ b/opensiddur/importer/humash/festival_names.py
@@ -1,0 +1,178 @@
+"""Hebrew titles for the festival and special-Shabbat readings.
+
+hebcal names its readings in English — "Shabbat Shekalim", "Pesach VII (on Shabbat)" — and
+those names reached the page, which in a Hebrew volume is the one place the humash spoke
+English where everything else is Hebrew.
+
+The names are composed rather than listed one by one: 112 readings are built from about forty
+occasions and a handful of qualifiers, and a table with every combination spelled out would
+repeat פֶּסַח fourteen times and go stale the moment hebcal adds a day. An occasion with no
+Hebrew name keeps its English one and says so in the log, so a name hebcal adds later is
+visible rather than silently dropped.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from opensiddur.importer.humash.names import SLUG_TO_HEBREW, slugify_reading_name
+
+logger = logging.getLogger(__name__)
+
+# The occasions themselves. Longest match wins, so "Shabbat Rosh Chodesh Chanukah" is found
+# before "Shabbat Rosh Chodesh", and that before "Rosh Chodesh".
+OCCASION_NAMES: dict[str, str] = {
+    "Asara B'Tevet": "עֲשָׂרָה בְּטֵבֵת",
+    "Chanukah": "חֲנֻכָּה",
+    "Erev Purim": "עֶרֶב פּוּרִים",
+    "Erev Simchat Torah": "עֶרֶב שִׂמְחַת תּוֹרָה",
+    "Erev Tish'a B'Av": "עֶרֶב תִּשְׁעָה בְּאָב",
+    "Fast Day": "יוֹם תַּעֲנִית",
+    "Pesach": "פֶּסַח",
+    "Pesach Chol ha-Moed": "חֹל הַמּוֹעֵד פֶּסַח",
+    "Pesach Shabbat Chol ha-Moed": "שַׁבָּת חֹל הַמּוֹעֵד פֶּסַח",
+    "Purim": "פּוּרִים",
+    "Rosh Chodesh": "רֹאשׁ חֹדֶשׁ",
+    "Rosh Hashana": "רֹאשׁ הַשָּׁנָה",
+    "Shabbat HaChodesh": "שַׁבָּת הַחֹדֶשׁ",
+    "Shabbat HaGadol": "שַׁבָּת הַגָּדוֹל",
+    "Shabbat Machar Chodesh": "שַׁבָּת מָחָר חֹדֶשׁ",
+    "Shabbat Parah": "שַׁבָּת פָּרָה",
+    "Shabbat Rosh Chodesh": "שַׁבָּת רֹאשׁ חֹדֶשׁ",
+    "Shabbat Rosh Chodesh Chanukah": "שַׁבָּת רֹאשׁ חֹדֶשׁ חֲנֻכָּה",
+    "Shabbat Shekalim": "שַׁבָּת שְׁקָלִים",
+    "Shabbat Shuva": "שַׁבָּת שׁוּבָה",
+    "Shabbat Zachor": "שַׁבָּת זָכוֹר",
+    "Shavuot": "שָׁבוּעוֹת",
+    "Shmini Atzeret": "שְׁמִינִי עֲצֶרֶת",
+    "Shushan Purim": "שׁוּשַׁן פּוּרִים",
+    "Simchat Torah": "שִׂמְחַת תּוֹרָה",
+    "Sukkot": "סֻכּוֹת",
+    "Sukkot Chol ha-Moed": "חֹל הַמּוֹעֵד סֻכּוֹת",
+    "Sukkot Final Day": "יוֹם אַחֲרוֹן שֶׁל סֻכּוֹת",
+    "Sukkot Shabbat Chol ha-Moed": "שַׁבָּת חֹל הַמּוֹעֵד סֻכּוֹת",
+    "Ta'anit Esther": "תַּעֲנִית אֶסְתֵּר",
+    "Tish'a B'Av": "תִּשְׁעָה בְּאָב",
+    "Tzom Gedaliah": "צוֹם גְּדַלְיָה",
+    "Tzom Tammuz": "צוֹם תַּמּוּז",
+    "Yom HaAtzma'ut": "יוֹם הָעַצְמָאוּת",
+    "Yom Kippur": "יוֹם הַכִּפּוּרִים",
+    "Yom Yerushalayim": "יוֹם יְרוּשָׁלַיִם",
+}
+
+# The month a Rosh Chodesh reading belongs to, spelled as hebcal spells it.
+MONTH_NAMES: dict[str, str] = {
+    "Nisan": "נִיסָן",
+    "Iyyar": "אִיָּר",
+    "Sivan": "סִיוָן",
+    "Tamuz": "תַּמּוּז",
+    "Av": "אָב",
+    "Elul": "אֱלוּל",
+    "Tishrei": "תִּשְׁרֵי",
+    "Cheshvan": "חֶשְׁוָן",
+    "Kislev": "כִּסְלֵו",
+    "Tevet": "טֵבֵת",
+    "Sh'vat": "שְׁבָט",
+    "Adar": "אֲדָר",
+    "Adar I": "אֲדָר א׳",
+    "Adar II": "אֲדָר ב׳",
+}
+
+# What a parenthetical says. Anything else is passed through untranslated.
+QUALIFIERS: dict[str, str] = {
+    "on Shabbat": "בְּשַׁבָּת",
+    "on Rosh Chodesh": "בְּרֹאשׁ חֹדֶשׁ",
+    "Mincha": "מִנְחָה",
+    "Mincha, Alternate": "מִנְחָה, נֻסָּח אַחֵר",
+    "Mincha, Traditional": "מִנְחָה, מָסֹרֶת",
+    "Morning": "שַׁחֲרִית",
+    "Afternoon": "מִנְחָה",
+    "CH''M": "חֹל הַמּוֹעֵד",
+    "Hoshana Raba": "הוֹשַׁעְנָא רַבָּה",
+}
+
+# Phrases that follow a parshah's name and say which year's variant of its reading this is.
+TRAILERS: tuple[tuple[str, str], ...] = (
+    ("on Shabbat Rosh Chodesh", "בְּשַׁבָּת רֹאשׁ חֹדֶשׁ"),
+    ("following Special Shabbat", "אַחֲרֵי שַׁבָּת מְיֻחֶדֶת"),
+    ("with 3rd Haftarah of Consolation", "עִם הַהַפְטָרָה הַשְּׁלִישִׁית דְּנֶחָמְתָא"),
+    ("occurring after 17 Tammuz", "אַחַר י״ז בְּתַמּוּז"),
+    ("on Sunday", "בְּיוֹם רִאשׁוֹן"),
+    ("on Monday", "בְּיוֹם שֵׁנִי"),
+)
+
+# Roman numerals name the days of a festival; hebrew letters do the same job without being
+# reversed when set inside right-to-left text.
+ORDINALS: dict[str, str] = {
+    "I": "א׳", "II": "ב׳", "III": "ג׳", "IV": "ד׳", "V": "ה׳",
+    "VI": "ו׳", "VII": "ז׳", "VIII": "ח׳",
+}
+
+DAY_LETTERS: dict[int, str] = {
+    1: "א׳", 2: "ב׳", 3: "ג׳", 4: "ד׳", 5: "ה׳", 6: "ו׳", 7: "ז׳", 8: "ח׳",
+}
+
+_PARENTHETICAL = re.compile(r"^(?P<base>.*?)\s*\((?P<qualifier>[^)]*)\)\s*$")
+_DAY = re.compile(r"^(?P<base>.*?)\s+Day\s+(?P<day>\d+)$")
+_ORDINAL = re.compile(r"^(?P<base>.*?)\s+(?P<ordinal>I{1,3}|IV|VI{0,3})$")
+
+
+def _occasion(name: str) -> str | None:
+    """The Hebrew for a bare occasion, a Rosh Chodesh of a named month, or a parshah."""
+    known = OCCASION_NAMES.get(name)
+    if known is not None:
+        return known
+    if name.startswith("Rosh Chodesh "):
+        month = MONTH_NAMES.get(name[len("Rosh Chodesh "):])
+        if month is not None:
+            return f"{OCCASION_NAMES['Rosh Chodesh']} {month}"
+        return None
+    # Several readings are a weekly parshah read on a particular year, named by the parshah.
+    return SLUG_TO_HEBREW.get(slugify_reading_name(name))
+
+
+def hebrew_name(name: str) -> str:
+    """The Hebrew title for one of hebcal's reading names, or the name itself if unknown."""
+    qualifier_he: str | None = None
+    base = name
+
+    parenthetical = _PARENTHETICAL.match(base)
+    if parenthetical is not None:
+        base = parenthetical.group("base")
+        qualifier = parenthetical.group("qualifier")
+        qualifier_he = QUALIFIERS.get(qualifier)
+        if qualifier_he is None and qualifier.startswith("with "):
+            # "(with Ha'azinu)" — which parshah Shabbat Shuva falls on that year.
+            parshah = SLUG_TO_HEBREW.get(slugify_reading_name(qualifier[len("with "):]))
+            qualifier_he = f"עִם {parshah}" if parshah is not None else None
+        if qualifier_he is None:
+            logger.warning("No Hebrew for the qualifier %r of %r", qualifier, name)
+            qualifier_he = qualifier
+
+    for english, hebrew in TRAILERS:
+        if base.endswith(" " + english):
+            base = base[: -len(english) - 1]
+            qualifier_he = hebrew if qualifier_he is None else f"{hebrew}, {qualifier_he}"
+            break
+
+    suffix: str | None = None
+    day = _DAY.match(base)
+    ordinal = _ORDINAL.match(base) if day is None else None
+    if day is not None:
+        base, suffix = day.group("base"), f"יוֹם {DAY_LETTERS[int(day.group('day'))]}"
+    elif ordinal is not None and _occasion(ordinal.group("base")) is not None:
+        # Only when the stem without it is a known occasion: "Adar II" is a month, not an
+        # ordinal, and "Rosh Chodesh Adar II" must not be read as the second Rosh Chodesh Adar.
+        base, suffix = ordinal.group("base"), ORDINALS[ordinal.group("ordinal")]
+
+    hebrew = _occasion(base)
+    if hebrew is None:
+        logger.warning("No Hebrew name for the reading %r, so it stays in English", name)
+        return name
+
+    if suffix is not None:
+        hebrew = f"{hebrew} {suffix}"
+    if qualifier_he is not None:
+        hebrew = f"{hebrew} ({qualifier_he})"
+    return hebrew

--- a/opensiddur/importer/humash/model.py
+++ b/opensiddur/importer/humash/model.py
@@ -23,7 +23,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from opensiddur.importer.humash.refs import (
-    DEFAULT_NUMBERING,
     ReadingSpan,
     VerseRef,
     previous_verse,
@@ -50,10 +49,9 @@ class Segment:
 def next_verse(
     ref: VerseRef,
     sourcetexts_root: Path | None = None,
-    numbering: str = DEFAULT_NUMBERING,
 ) -> VerseRef:
     """The verse after `ref`, stepping into the next chapter at a chapter end."""
-    if ref.verse < verses_in_chapter(ref.book, ref.chapter, sourcetexts_root, numbering):
+    if ref.verse < verses_in_chapter(ref.book, ref.chapter, sourcetexts_root):
         return VerseRef(ref.book, ref.chapter, ref.verse + 1)
     return VerseRef(ref.book, ref.chapter + 1, 1)
 
@@ -76,7 +74,6 @@ def segment_by_union(
     start: VerseRef,
     end: VerseRef,
     sourcetexts_root: Path | None = None,
-    numbering: str = DEFAULT_NUMBERING,
 ) -> list[Segment]:
     """Cut `start`-`end` at every span boundary, emitting the text once.
 
@@ -91,13 +88,13 @@ def segment_by_union(
         if start <= span.start <= end:
             boundaries.add(span.start)
         if start <= span.end < end:
-            boundaries.add(next_verse(span.end, sourcetexts_root, numbering))
+            boundaries.add(next_verse(span.end, sourcetexts_root))
 
     ordered = sorted(boundaries)
     segments: list[Segment] = []
     for index, boundary in enumerate(ordered):
         segment_end = (
-            previous_verse(ordered[index + 1], sourcetexts_root, numbering)
+            previous_verse(ordered[index + 1], sourcetexts_root)
             if index + 1 < len(ordered)
             else end
         )
@@ -149,7 +146,6 @@ def segment_reading(
     start: VerseRef | None = None,
     end: VerseRef | None = None,
     sourcetexts_root: Path | None = None,
-    numbering: str = DEFAULT_NUMBERING,
     allow_duplication: bool = True,
 ) -> list[Segment]:
     """Segment a reading, choosing the strategy its spans call for.
@@ -170,4 +166,4 @@ def segment_reading(
         return segment_by_span(spans)
     start = start if start is not None else min(span.start for span in spans)
     end = end if end is not None else max(span.end for span in spans)
-    return segment_by_union(spans, start, end, sourcetexts_root, numbering)
+    return segment_by_union(spans, start, end, sourcetexts_root)

--- a/opensiddur/importer/humash/model.py
+++ b/opensiddur/importer/humash/model.py
@@ -1,0 +1,173 @@
+"""Turn overlapping reading divisions into a linear sequence of milestones and transclusions.
+
+The humash contributes structure over text it does not hold: every word is transcluded from
+the Tanakh projects by URN. The problem this module solves is that the divisions overlap, in
+two different ways, which need two different answers.
+
+**Between unit-spaces.** The maftir begins inside the seventh aliyah, the weekday aliyot
+subdivide the Shabbat ones, and the triennial breaks cut across the annual ones. Here the text
+is read once and marked several ways, so the spans are cut at the *union* of all their
+boundaries and the text emitted once, with every milestone that falls at a point placed
+before the segment starting there. A printed humash marks maftir in the margin of the seventh
+aliyah; it does not print those verses twice.
+
+**Within one unit-space.** On weekday Rosh Hodesh, Numbers 28:1-15 divides kohen 28:1-3, levi
+28:3-5, yisrael 28:6-10, revi'i 28:11-15 — 28:3 belongs to both kohen and levi and really is
+read twice. Cutting at the union cannot express that, so a unit-space whose own spans overlap
+is emitted span by span and the shared verses are transcluded twice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from opensiddur.importer.humash.refs import (
+    DEFAULT_NUMBERING,
+    ReadingSpan,
+    VerseRef,
+    previous_verse,
+    verses_in_chapter,
+)
+
+
+@dataclass
+class Segment:
+    """A stretch of text to transclude, and the milestones that open at its start."""
+
+    start: VerseRef
+    end: VerseRef
+    opening: list[ReadingSpan] = field(default_factory=list)
+    # Set when this segment repeats text already emitted, because two spans of one
+    # unit-space overlap.
+    duplicate: bool = False
+
+    @property
+    def target(self) -> str:
+        return self.start.range_urn(self.end)
+
+
+def next_verse(
+    ref: VerseRef,
+    sourcetexts_root: Path | None = None,
+    numbering: str = DEFAULT_NUMBERING,
+) -> VerseRef:
+    """The verse after `ref`, stepping into the next chapter at a chapter end."""
+    if ref.verse < verses_in_chapter(ref.book, ref.chapter, sourcetexts_root, numbering):
+        return VerseRef(ref.book, ref.chapter, ref.verse + 1)
+    return VerseRef(ref.book, ref.chapter + 1, 1)
+
+
+def has_internal_overlap(spans: list[ReadingSpan]) -> bool:
+    """Whether any two spans of the same unit-space overlap each other."""
+    by_unit: dict[str, list[ReadingSpan]] = {}
+    for span in spans:
+        by_unit.setdefault(span.unit, []).append(span)
+    for unit_spans in by_unit.values():
+        ordered = sorted(unit_spans, key=lambda span: (span.start, span.end))
+        for earlier, later in zip(ordered, ordered[1:]):
+            if later.start <= earlier.end:
+                return True
+    return False
+
+
+def segment_by_union(
+    spans: list[ReadingSpan],
+    start: VerseRef,
+    end: VerseRef,
+    sourcetexts_root: Path | None = None,
+    numbering: str = DEFAULT_NUMBERING,
+) -> list[Segment]:
+    """Cut `start`-`end` at every span boundary, emitting the text once.
+
+    Each span's start opens a segment; each span's end closes one, so that a span which ends
+    before the next one begins does not swallow the gap.
+    """
+    if end < start:
+        raise ValueError(f"Cannot segment an empty range: {start} to {end}")
+
+    boundaries: set[VerseRef] = {start}
+    for span in spans:
+        if start <= span.start <= end:
+            boundaries.add(span.start)
+        if start <= span.end < end:
+            boundaries.add(next_verse(span.end, sourcetexts_root, numbering))
+
+    ordered = sorted(boundaries)
+    segments: list[Segment] = []
+    for index, boundary in enumerate(ordered):
+        segment_end = (
+            previous_verse(ordered[index + 1], sourcetexts_root, numbering)
+            if index + 1 < len(ordered)
+            else end
+        )
+        if segment_end < boundary:
+            continue
+        segments.append(Segment(
+            start=boundary,
+            end=segment_end,
+            opening=[span for span in spans if span.start == boundary],
+        ))
+    return segments
+
+
+def segment_by_span(spans: list[ReadingSpan]) -> list[Segment]:
+    """Emit each span as its own segment, in reading order, duplicating shared text.
+
+    Used where a unit-space's own spans overlap and the shared verses genuinely are read
+    twice, so cutting at the union would lose a verse from the second reading.
+    """
+    segments: list[Segment] = []
+    covered: list[tuple[VerseRef, VerseRef]] = []
+    for span in spans:
+        duplicate = any(
+            span.start <= seen_end and seen_start <= span.end
+            for seen_start, seen_end in covered
+        )
+        segments.append(Segment(
+            start=span.start, end=span.end, opening=[span], duplicate=duplicate
+        ))
+        covered.append((span.start, span.end))
+    return segments
+
+
+def overlapping_units(spans: list[ReadingSpan]) -> list[str]:
+    """The unit-spaces whose own spans overlap each other."""
+    by_unit: dict[str, list[ReadingSpan]] = {}
+    for span in spans:
+        by_unit.setdefault(span.unit, []).append(span)
+    overlapping: list[str] = []
+    for unit, unit_spans in by_unit.items():
+        ordered = sorted(unit_spans, key=lambda span: (span.start, span.end))
+        if any(later.start <= earlier.end for earlier, later in zip(ordered, ordered[1:])):
+            overlapping.append(unit)
+    return overlapping
+
+
+def segment_reading(
+    spans: list[ReadingSpan],
+    start: VerseRef | None = None,
+    end: VerseRef | None = None,
+    sourcetexts_root: Path | None = None,
+    numbering: str = DEFAULT_NUMBERING,
+    allow_duplication: bool = True,
+) -> list[Segment]:
+    """Segment a reading, choosing the strategy its spans call for.
+
+    With `allow_duplication`, spans that overlap inside one unit-space are emitted one by one
+    so that the repeated verses survive — right for a short festival reading, where the whole
+    of it is a handful of verses and the kohen and levi of weekday Rosh Hodesh really do share
+    Numbers 28:3.
+
+    Without it the text is always emitted once. A continuous reading passes False: a single
+    overlapping pair anywhere would otherwise duplicate the entire parshah, and one triennial
+    aliyah whose marked scope stops early is a far smaller loss than a parshah printed three
+    times over.
+    """
+    if not spans:
+        return []
+    if allow_duplication and has_internal_overlap(spans):
+        return segment_by_span(spans)
+    start = start if start is not None else min(span.start for span in spans)
+    end = end if end is not None else max(span.end for span in spans)
+    return segment_by_union(spans, start, end, sourcetexts_root, numbering)

--- a/opensiddur/importer/humash/names.py
+++ b/opensiddur/importer/humash/names.py
@@ -1,0 +1,126 @@
+"""The names of the weekly parshiyot, in the three forms the importer needs.
+
+``JLPTEI-3.md`` asks for transliterated Hebrew in URN path segments, "unless the text has a
+common name (with a common spelling)". Every parshah does, so the table below is explicit
+rather than produced by running the transliteration rules over the Hebrew: mechanical
+transliteration would give forms nobody writes (``vzat_hbrkh``), and it would silently drop
+the maqaf in לך־לך the way the jps1917 importer does.
+
+The table is also the join between the two sources — MAM names the parshiyot in Hebrew, hebcal
+in English — so it must not depend on the two happening to be in the same order.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# (MAM Hebrew name, hebcal name, opensiddur slug)
+PARSHA_NAMES: tuple[tuple[str, str, str], ...] = (
+    ("בראשית", "Bereshit", "bereshit"),
+    ("נֹח", "Noach", "noach"),
+    ("לך־לך", "Lech-Lecha", "lech_lecha"),
+    ("וירא", "Vayera", "vayera"),
+    ("חיי שרה", "Chayei Sara", "chayei_sara"),
+    ("תולדֹת", "Toldot", "toldot"),
+    ("ויצא", "Vayetzei", "vayetzei"),
+    ("וישלח", "Vayishlach", "vayishlach"),
+    ("וישב", "Vayeshev", "vayeshev"),
+    ("מקץ", "Miketz", "miketz"),
+    ("ויגש", "Vayigash", "vayigash"),
+    ("ויחי", "Vayechi", "vayechi"),
+    ("שמות", "Shemot", "shemot"),
+    ("וארא", "Vaera", "vaera"),
+    ("בֹא", "Bo", "bo"),
+    ("בשלח", "Beshalach", "beshalach"),
+    ("יתרו", "Yitro", "yitro"),
+    ("משפטים", "Mishpatim", "mishpatim"),
+    ("תרומה", "Terumah", "terumah"),
+    ("תצוה", "Tetzaveh", "tetzaveh"),
+    ("כי תשא", "Ki Tisa", "ki_tisa"),
+    ("ויקהל", "Vayakhel", "vayakhel"),
+    ("פקודי", "Pekudei", "pekudei"),
+    ("ויקרא", "Vayikra", "vayikra"),
+    ("צו", "Tzav", "tzav"),
+    ("שמיני", "Shmini", "shmini"),
+    ("תזריע", "Tazria", "tazria"),
+    ("מצֹרע", "Metzora", "metzora"),
+    ("אחרי מות", "Achrei Mot", "achrei_mot"),
+    ("קדֹשים", "Kedoshim", "kedoshim"),
+    ("אמֹר", "Emor", "emor"),
+    ("בהר", "Behar", "behar"),
+    ("בחֻקֹתי", "Bechukotai", "bechukotai"),
+    ("במדבר", "Bamidbar", "bamidbar"),
+    ("נשֹא", "Nasso", "nasso"),
+    ("בהעלֹתך", "Beha'alotcha", "behaalotcha"),
+    ("שלח", "Sh'lach", "shlach"),
+    ("קֹרח", "Korach", "korach"),
+    ("חֻקת", "Chukat", "chukat"),
+    ("בלק", "Balak", "balak"),
+    ("פינחס", "Pinchas", "pinchas"),
+    ("מטות", "Matot", "matot"),
+    ("מסעי", "Masei", "masei"),
+    ("דברים", "Devarim", "devarim"),
+    ("ואתחנן", "Vaetchanan", "vaetchanan"),
+    ("עקב", "Eikev", "eikev"),
+    ("ראה", "Re'eh", "reeh"),
+    ("שֹפטים", "Shoftim", "shoftim"),
+    ("כי־תצא", "Ki Teitzei", "ki_teitzei"),
+    ("כי־תבוא", "Ki Tavo", "ki_tavo"),
+    ("נִצבים", "Nitzavim", "nitzavim"),
+    ("וילך", "Vayeilech", "vayeilech"),
+    ("האזינו", "Ha'azinu", "haazinu"),
+    ("וזאת הברכה", "Vezot Haberakhah", "vezot_haberakhah"),
+)
+
+# Weeks on which two parshiyot are read together. hebcal names these by joining the two.
+COMBINED_PARSHIYOT: tuple[tuple[str, str], ...] = (
+    ("Vayakhel-Pekudei", "vayakhel_pekudei"),
+    ("Tazria-Metzora", "tazria_metzora"),
+    ("Achrei Mot-Kedoshim", "achrei_mot_kedoshim"),
+    ("Behar-Bechukotai", "behar_bechukotai"),
+    ("Chukat-Balak", "chukat_balak"),
+    ("Matot-Masei", "matot_masei"),
+    ("Nitzavim-Vayeilech", "nitzavim_vayeilech"),
+)
+
+
+def _fold(hebrew: str) -> str:
+    """Strip pointing and cantillation so MAM's pointed names match the table's.
+
+    Only combining marks are removed. The maqaf in לך־לך is punctuation, not a mark, and is
+    deliberately kept: folding it away is what collapses the name to לךלך.
+    """
+    return "".join(
+        char for char in unicodedata.normalize("NFD", hebrew)
+        if unicodedata.category(char) != "Mn"
+    )
+
+
+_BY_FOLDED_HEBREW = {_fold(hebrew): (hebrew, hebcal, slug) for hebrew, hebcal, slug in PARSHA_NAMES}
+_BY_HEBCAL = {hebcal: (hebrew, hebcal, slug) for hebrew, hebcal, slug in PARSHA_NAMES}
+
+HEBCAL_TO_SLUG = {hebcal: slug for _, hebcal, slug in PARSHA_NAMES}
+HEBCAL_TO_SLUG.update(dict(COMBINED_PARSHIYOT))
+SLUG_TO_HEBREW = {slug: hebrew for hebrew, _, slug in PARSHA_NAMES}
+
+
+def slug_for_hebrew(hebrew: str) -> str:
+    """The slug for a parshah named in Hebrew, with or without pointing."""
+    entry = _BY_FOLDED_HEBREW.get(_fold(hebrew))
+    if entry is None:
+        raise KeyError(f"Unknown parshah name: {hebrew!r}")
+    return entry[2]
+
+
+def hebcal_for_hebrew(hebrew: str) -> str:
+    entry = _BY_FOLDED_HEBREW.get(_fold(hebrew))
+    if entry is None:
+        raise KeyError(f"Unknown parshah name: {hebrew!r}")
+    return entry[1]
+
+
+def slugify_reading_name(name: str) -> str:
+    """Slug for a reading hebcal names but the parshah table does not, e.g. a festival."""
+    folded = name.replace("'", "").replace("’", "")
+    return re.sub(r"[\s\-/]+", "_", folded.lower()).strip("_")

--- a/opensiddur/importer/humash/names.py
+++ b/opensiddur/importer/humash/names.py
@@ -28,6 +28,8 @@ __all__ = [
     "PAIR_MEMBERS",
     "PARSHA_NAMES",
     "SLUG_TO_HEBREW",
+    "SLUG_TO_VOCALIZED",
+    "vocalized_name",
     "hebcal_for_hebrew",
     "slug_for_combined_hebrew",
     "slug_for_hebrew",
@@ -82,3 +84,77 @@ def slug_for_combined_hebrew(hebrew: str) -> str:
     if slug is None:
         raise KeyError(f"Unknown combined parshah name: {hebrew!r}")
     return slug
+
+
+# The parshah names pointed, for headings and margin markers. The shared table carries the
+# names as MAM writes them in its own apparatus — consonants with only the occasional holam
+# haser — which is the form to match source text against, but not the form to set a title in.
+# The spelling (defective where MAM is defective: תולדֹת, בחֻקֹתי, נשֹא) is kept, so that these
+# differ from the shared table by vowels alone; test_names asserts exactly that.
+SLUG_TO_VOCALIZED: dict[str, str] = {
+    "bereshit": "בְּרֵאשִׁית",
+    "noach": "נֹחַ",
+    "lech_lecha": "לֶךְ־לְךָ",
+    "vayera": "וַיֵּרָא",
+    "chayei_sara": "חַיֵּי שָׂרָה",
+    "toldot": "תּוֹלְדֹת",
+    "vayetzei": "וַיֵּצֵא",
+    "vayishlach": "וַיִּשְׁלַח",
+    "vayeshev": "וַיֵּשֶׁב",
+    "miketz": "מִקֵּץ",
+    "vayigash": "וַיִּגַּשׁ",
+    "vayechi": "וַיְחִי",
+    "shemot": "שְׁמוֹת",
+    "vaera": "וָאֵרָא",
+    "bo": "בֹּא",
+    "beshalach": "בְּשַׁלַּח",
+    "yitro": "יִתְרוֹ",
+    "mishpatim": "מִשְׁפָּטִים",
+    "terumah": "תְּרוּמָה",
+    "tetzaveh": "תְּצַוֶּה",
+    "ki_tisa": "כִּי תִשָּׂא",
+    "vayakhel": "וַיַּקְהֵל",
+    "pekudei": "פְקוּדֵי",
+    "vayikra": "וַיִּקְרָא",
+    "tzav": "צַו",
+    "shmini": "שְׁמִינִי",
+    "tazria": "תַזְרִיעַ",
+    "metzora": "מְצֹרָע",
+    "achrei_mot": "אַחֲרֵי מוֹת",
+    "kedoshim": "קְדֹשִׁים",
+    "emor": "אֱמֹר",
+    "behar": "בְּהַר",
+    "bechukotai": "בְּחֻקֹּתַי",
+    "bamidbar": "בְּמִדְבַּר",
+    "nasso": "נָשֹׂא",
+    "behaalotcha": "בְּהַעֲלֹתְךָ",
+    "shlach": "שְׁלַח",
+    "korach": "קֹרַח",
+    "chukat": "חֻקַּת",
+    "balak": "בָּלָק",
+    "pinchas": "פִּינְחָס",
+    "matot": "מַטּוֹת",
+    "masei": "מַסְעֵי",
+    "devarim": "דְּבָרִים",
+    "vaetchanan": "וָאֶתְחַנַּן",
+    "eikev": "עֵקֶב",
+    "reeh": "רְאֵה",
+    "shoftim": "שֹׁפְטִים",
+    "ki_teitzei": "כִּי־תֵצֵא",
+    "ki_tavo": "כִּי־תָבוֹא",
+    "nitzavim": "נִצָּבִים",
+    "vayeilech": "וַיֵּלֶךְ",
+    "haazinu": "הַאֲזִינוּ",
+    "vezot_haberakhah": "וְזֹאת הַבְּרָכָה",
+}
+
+# A pair keeps each member's pointing, joined by the en-dash MAM writes.
+SLUG_TO_VOCALIZED.update({
+    pair: "–".join(SLUG_TO_VOCALIZED[member] for member in members)
+    for pair, members in PAIR_MEMBERS.items()
+})
+
+
+def vocalized_name(slug: str) -> str:
+    """The pointed name of a parshah, falling back to the unpointed one."""
+    return SLUG_TO_VOCALIZED.get(slug) or SLUG_TO_HEBREW.get(slug, slug)

--- a/opensiddur/importer/humash/names.py
+++ b/opensiddur/importer/humash/names.py
@@ -73,15 +73,18 @@ PARSHA_NAMES: tuple[tuple[str, str, str], ...] = (
     ("וזאת הברכה", "Vezot Haberakhah", "vezot_haberakhah"),
 )
 
-# Weeks on which two parshiyot are read together. hebcal names these by joining the two.
-COMBINED_PARSHIYOT: tuple[tuple[str, str], ...] = (
-    ("Vayakhel-Pekudei", "vayakhel_pekudei"),
-    ("Tazria-Metzora", "tazria_metzora"),
-    ("Achrei Mot-Kedoshim", "achrei_mot_kedoshim"),
-    ("Behar-Bechukotai", "behar_bechukotai"),
-    ("Chukat-Balak", "chukat_balak"),
-    ("Matot-Masei", "matot_masei"),
-    ("Nitzavim-Vayeilech", "nitzavim_vayeilech"),
+# Weeks on which two parshiyot are read together, each with the two it joins. MAM writes the
+# joined name with an en-dash — ויקהל–פקודי — which is not the maqaf of לך־לך and not the
+# hyphen hebcal joins with, so the Hebrew form is given here rather than composed.
+COMBINED_PARSHIYOT: tuple[tuple[str, str, str, str], ...] = (
+    # (MAM Hebrew name, hebcal name, opensiddur slug, first member slug)
+    ("ויקהל–פקודי", "Vayakhel-Pekudei", "vayakhel_pekudei", "vayakhel"),
+    ("תזריע–מצֹרע", "Tazria-Metzora", "tazria_metzora", "tazria"),
+    ("אחרי מות–קדֹשים", "Achrei Mot-Kedoshim", "achrei_mot_kedoshim", "achrei_mot"),
+    ("בהר–בחֻקֹתי", "Behar-Bechukotai", "behar_bechukotai", "behar"),
+    ("חֻקת–בלק", "Chukat-Balak", "chukat_balak", "chukat"),
+    ("מטות–מסעי", "Matot-Masei", "matot_masei", "matot"),
+    ("נִצבים–וילך", "Nitzavim-Vayeilech", "nitzavim_vayeilech", "nitzavim"),
 )
 
 
@@ -97,12 +100,29 @@ def _fold(hebrew: str) -> str:
     )
 
 
+_ORDER = [slug for _, _, slug in PARSHA_NAMES]
+
+# The two parshiyot each pair joins. They are always consecutive, so the second is read off the
+# order rather than listed again.
+PAIR_MEMBERS: dict[str, tuple[str, str]] = {
+    slug: (first, _ORDER[_ORDER.index(first) + 1])
+    for _, _, slug, first in COMBINED_PARSHIYOT
+}
+
+# The pair a parshah belongs to, for the twelve — fourteen, with Nitzavim-Vayeilech — that have
+# one. Every other parshah is absent.
+PAIR_FOR_MEMBER: dict[str, str] = {
+    member: pair for pair, members in PAIR_MEMBERS.items() for member in members
+}
+
 _BY_FOLDED_HEBREW = {_fold(hebrew): (hebrew, hebcal, slug) for hebrew, hebcal, slug in PARSHA_NAMES}
 _BY_HEBCAL = {hebcal: (hebrew, hebcal, slug) for hebrew, hebcal, slug in PARSHA_NAMES}
+_PAIR_BY_FOLDED_HEBREW = {_fold(hebrew): slug for hebrew, _, slug, _ in COMBINED_PARSHIYOT}
 
 HEBCAL_TO_SLUG = {hebcal: slug for _, hebcal, slug in PARSHA_NAMES}
-HEBCAL_TO_SLUG.update(dict(COMBINED_PARSHIYOT))
+HEBCAL_TO_SLUG.update({hebcal: slug for _, hebcal, slug, _ in COMBINED_PARSHIYOT})
 SLUG_TO_HEBREW = {slug: hebrew for hebrew, _, slug in PARSHA_NAMES}
+SLUG_TO_HEBREW.update({slug: hebrew for hebrew, _, slug, _ in COMBINED_PARSHIYOT})
 
 
 def slug_for_hebrew(hebrew: str) -> str:
@@ -111,6 +131,14 @@ def slug_for_hebrew(hebrew: str) -> str:
     if entry is None:
         raise KeyError(f"Unknown parshah name: {hebrew!r}")
     return entry[2]
+
+
+def slug_for_combined_hebrew(hebrew: str) -> str:
+    """The slug for a *pair* named in Hebrew, e.g. ויקהל–פקודי."""
+    slug = _PAIR_BY_FOLDED_HEBREW.get(_fold(hebrew))
+    if slug is None:
+        raise KeyError(f"Unknown combined parshah name: {hebrew!r}")
+    return slug
 
 
 def hebcal_for_hebrew(hebrew: str) -> str:

--- a/opensiddur/importer/humash/names.py
+++ b/opensiddur/importer/humash/names.py
@@ -1,154 +1,84 @@
-"""The names of the weekly parshiyot, in the three forms the importer needs.
+"""The parshah names the humash needs beyond the shared table.
 
-``JLPTEI-3.md`` asks for transliterated Hebrew in URN path segments, "unless the text has a
-common name (with a common spelling)". Every parshah does, so the table below is explicit
-rather than produced by running the transliteration rules over the Hebrew: mechanical
-transliteration would give forms nobody writes (``vzat_hbrkh``), and it would silently drop
-the maqaf in לך־לך the way the jps1917 importer does.
-
-The table is also the join between the two sources — MAM names the parshiyot in Hebrew, hebcal
-in English — so it must not depend on the two happening to be in the same order.
+The 54 weekly names, and lookups by Hebrew or hebcal name, live in
+:mod:`opensiddur.importer.util.parshiyot` and are re-exported here. What is local to the
+humash is the *pairs*: the weeks on which two parshiyot are read together. The shared table
+knows a pair's hebcal name because hebcal names one, but the humash also needs the Hebrew
+form to match MAM, and needs to know which two parshiyot each pair joins so that a combined
+week's aliyot can be scoped to the pair rather than to either member.
 """
 
 from __future__ import annotations
 
-import re
-import unicodedata
-
-# (MAM Hebrew name, hebcal name, opensiddur slug)
-PARSHA_NAMES: tuple[tuple[str, str, str], ...] = (
-    ("בראשית", "Bereshit", "bereshit"),
-    ("נֹח", "Noach", "noach"),
-    ("לך־לך", "Lech-Lecha", "lech_lecha"),
-    ("וירא", "Vayera", "vayera"),
-    ("חיי שרה", "Chayei Sara", "chayei_sara"),
-    ("תולדֹת", "Toldot", "toldot"),
-    ("ויצא", "Vayetzei", "vayetzei"),
-    ("וישלח", "Vayishlach", "vayishlach"),
-    ("וישב", "Vayeshev", "vayeshev"),
-    ("מקץ", "Miketz", "miketz"),
-    ("ויגש", "Vayigash", "vayigash"),
-    ("ויחי", "Vayechi", "vayechi"),
-    ("שמות", "Shemot", "shemot"),
-    ("וארא", "Vaera", "vaera"),
-    ("בֹא", "Bo", "bo"),
-    ("בשלח", "Beshalach", "beshalach"),
-    ("יתרו", "Yitro", "yitro"),
-    ("משפטים", "Mishpatim", "mishpatim"),
-    ("תרומה", "Terumah", "terumah"),
-    ("תצוה", "Tetzaveh", "tetzaveh"),
-    ("כי תשא", "Ki Tisa", "ki_tisa"),
-    ("ויקהל", "Vayakhel", "vayakhel"),
-    ("פקודי", "Pekudei", "pekudei"),
-    ("ויקרא", "Vayikra", "vayikra"),
-    ("צו", "Tzav", "tzav"),
-    ("שמיני", "Shmini", "shmini"),
-    ("תזריע", "Tazria", "tazria"),
-    ("מצֹרע", "Metzora", "metzora"),
-    ("אחרי מות", "Achrei Mot", "achrei_mot"),
-    ("קדֹשים", "Kedoshim", "kedoshim"),
-    ("אמֹר", "Emor", "emor"),
-    ("בהר", "Behar", "behar"),
-    ("בחֻקֹתי", "Bechukotai", "bechukotai"),
-    ("במדבר", "Bamidbar", "bamidbar"),
-    ("נשֹא", "Nasso", "nasso"),
-    ("בהעלֹתך", "Beha'alotcha", "behaalotcha"),
-    ("שלח", "Sh'lach", "shlach"),
-    ("קֹרח", "Korach", "korach"),
-    ("חֻקת", "Chukat", "chukat"),
-    ("בלק", "Balak", "balak"),
-    ("פינחס", "Pinchas", "pinchas"),
-    ("מטות", "Matot", "matot"),
-    ("מסעי", "Masei", "masei"),
-    ("דברים", "Devarim", "devarim"),
-    ("ואתחנן", "Vaetchanan", "vaetchanan"),
-    ("עקב", "Eikev", "eikev"),
-    ("ראה", "Re'eh", "reeh"),
-    ("שֹפטים", "Shoftim", "shoftim"),
-    ("כי־תצא", "Ki Teitzei", "ki_teitzei"),
-    ("כי־תבוא", "Ki Tavo", "ki_tavo"),
-    ("נִצבים", "Nitzavim", "nitzavim"),
-    ("וילך", "Vayeilech", "vayeilech"),
-    ("האזינו", "Ha'azinu", "haazinu"),
-    ("וזאת הברכה", "Vezot Haberakhah", "vezot_haberakhah"),
+from opensiddur.importer.util.parshiyot import (
+    COMBINED_PARSHIYOT as _COMBINED_HEBCAL,
+    HEBCAL_TO_SLUG,
+    PARSHA_NAMES,
+    SLUG_TO_HEBREW,
+    hebcal_for_hebrew,
+    slug_for_hebrew,
+    slugify_reading_name,
 )
+from opensiddur.importer.util.hebrew import normalize_hebrew
 
-# Weeks on which two parshiyot are read together, each with the two it joins. MAM writes the
-# joined name with an en-dash — ויקהל–פקודי — which is not the maqaf of לך־לך and not the
-# hyphen hebcal joins with, so the Hebrew form is given here rather than composed.
-COMBINED_PARSHIYOT: tuple[tuple[str, str, str, str], ...] = (
-    # (MAM Hebrew name, hebcal name, opensiddur slug, first member slug)
-    ("ויקהל–פקודי", "Vayakhel-Pekudei", "vayakhel_pekudei", "vayakhel"),
-    ("תזריע–מצֹרע", "Tazria-Metzora", "tazria_metzora", "tazria"),
-    ("אחרי מות–קדֹשים", "Achrei Mot-Kedoshim", "achrei_mot_kedoshim", "achrei_mot"),
-    ("בהר–בחֻקֹתי", "Behar-Bechukotai", "behar_bechukotai", "behar"),
-    ("חֻקת–בלק", "Chukat-Balak", "chukat_balak", "chukat"),
-    ("מטות–מסעי", "Matot-Masei", "matot_masei", "matot"),
-    ("נִצבים–וילך", "Nitzavim-Vayeilech", "nitzavim_vayeilech", "nitzavim"),
+__all__ = [
+    "COMBINED_PARSHIYOT",
+    "HEBCAL_TO_SLUG",
+    "PAIR_FOR_MEMBER",
+    "PAIR_MEMBERS",
+    "PARSHA_NAMES",
+    "SLUG_TO_HEBREW",
+    "hebcal_for_hebrew",
+    "slug_for_combined_hebrew",
+    "slug_for_hebrew",
+    "slugify_reading_name",
+]
+
+# MAM writes a joined name with an en-dash — ויקהל–פקודי — which is neither the maqaf of
+# לך־לך nor the hyphen hebcal joins with, so the Hebrew form is given here rather than
+# composed from the two members.
+_COMBINED_HEBREW: dict[str, str] = {
+    "vayakhel_pekudei": "ויקהל–פקודי",
+    "tazria_metzora": "תזריע–מצֹרע",
+    "achrei_mot_kedoshim": "אחרי מות–קדֹשים",
+    "behar_bechukotai": "בהר–בחֻקֹתי",
+    "chukat_balak": "חֻקת–בלק",
+    "matot_masei": "מטות–מסעי",
+    "nitzavim_vayeilech": "נִצבים–וילך",
+}
+
+# (MAM Hebrew name, hebcal name, opensiddur slug) for each pair, in the shared table's order.
+COMBINED_PARSHIYOT: tuple[tuple[str, str, str], ...] = tuple(
+    (_COMBINED_HEBREW[slug], hebcal, slug) for hebcal, slug in _COMBINED_HEBCAL
 )
-
-
-def _fold(hebrew: str) -> str:
-    """Strip pointing and cantillation so MAM's pointed names match the table's.
-
-    Only combining marks are removed. The maqaf in לך־לך is punctuation, not a mark, and is
-    deliberately kept: folding it away is what collapses the name to לךלך.
-    """
-    return "".join(
-        char for char in unicodedata.normalize("NFD", hebrew)
-        if unicodedata.category(char) != "Mn"
-    )
-
 
 _ORDER = [slug for _, _, slug in PARSHA_NAMES]
 
-# The two parshiyot each pair joins. They are always consecutive, so the second is read off the
-# order rather than listed again.
-PAIR_MEMBERS: dict[str, tuple[str, str]] = {
-    slug: (first, _ORDER[_ORDER.index(first) + 1])
-    for _, _, slug, first in COMBINED_PARSHIYOT
-}
+# The two parshiyot each pair joins. The first is the earlier of the two in the annual order
+# and the second follows it directly, so only the pair's slug has to be given: both members
+# are read off it. Nothing else in the table is composed from a slug, but here the slugs are
+# the join of the two members by construction.
+PAIR_MEMBERS: dict[str, tuple[str, str]] = {}
+for _hebrew, _hebcal, _slug in COMBINED_PARSHIYOT:
+    _first = HEBCAL_TO_SLUG[_hebcal.split("-", 1)[0]]
+    PAIR_MEMBERS[_slug] = (_first, _ORDER[_ORDER.index(_first) + 1])
 
-# The pair a parshah belongs to, for the twelve — fourteen, with Nitzavim-Vayeilech — that have
-# one. Every other parshah is absent.
+# The pair a parshah belongs to, for the fourteen that have one. Every other parshah is absent.
 PAIR_FOR_MEMBER: dict[str, str] = {
     member: pair for pair, members in PAIR_MEMBERS.items() for member in members
 }
 
-_BY_FOLDED_HEBREW = {_fold(hebrew): (hebrew, hebcal, slug) for hebrew, hebcal, slug in PARSHA_NAMES}
-_BY_HEBCAL = {hebcal: (hebrew, hebcal, slug) for hebrew, hebcal, slug in PARSHA_NAMES}
-_PAIR_BY_FOLDED_HEBREW = {_fold(hebrew): slug for hebrew, _, slug, _ in COMBINED_PARSHIYOT}
+SLUG_TO_HEBREW = dict(SLUG_TO_HEBREW)
+SLUG_TO_HEBREW.update({slug: hebrew for hebrew, _, slug in COMBINED_PARSHIYOT})
 
-HEBCAL_TO_SLUG = {hebcal: slug for _, hebcal, slug in PARSHA_NAMES}
-HEBCAL_TO_SLUG.update({hebcal: slug for _, hebcal, slug, _ in COMBINED_PARSHIYOT})
-SLUG_TO_HEBREW = {slug: hebrew for hebrew, _, slug in PARSHA_NAMES}
-SLUG_TO_HEBREW.update({slug: hebrew for hebrew, _, slug, _ in COMBINED_PARSHIYOT})
-
-
-def slug_for_hebrew(hebrew: str) -> str:
-    """The slug for a parshah named in Hebrew, with or without pointing."""
-    entry = _BY_FOLDED_HEBREW.get(_fold(hebrew))
-    if entry is None:
-        raise KeyError(f"Unknown parshah name: {hebrew!r}")
-    return entry[2]
+_PAIR_BY_SKELETON = {
+    normalize_hebrew(hebrew): slug for hebrew, _, slug in COMBINED_PARSHIYOT
+}
 
 
 def slug_for_combined_hebrew(hebrew: str) -> str:
     """The slug for a *pair* named in Hebrew, e.g. ויקהל–פקודי."""
-    slug = _PAIR_BY_FOLDED_HEBREW.get(_fold(hebrew))
+    slug = _PAIR_BY_SKELETON.get(normalize_hebrew(hebrew))
     if slug is None:
         raise KeyError(f"Unknown combined parshah name: {hebrew!r}")
     return slug
-
-
-def hebcal_for_hebrew(hebrew: str) -> str:
-    entry = _BY_FOLDED_HEBREW.get(_fold(hebrew))
-    if entry is None:
-        raise KeyError(f"Unknown parshah name: {hebrew!r}")
-    return entry[1]
-
-
-def slugify_reading_name(name: str) -> str:
-    """Slug for a reading hebcal names but the parshah table does not, e.g. a festival."""
-    folded = name.replace("'", "").replace("’", "")
-    return re.sub(r"[\s\-/]+", "_", folded.lower()).strip("_")

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -22,7 +22,6 @@ from opensiddur.importer.humash.names import (
 )
 from opensiddur.importer.humash.refs import (
     BOOK_NUMBER_TO_SLUG,
-    NUMBERING_COMMON,
     HEBCAL_BOOK_TO_SLUG,
     UNIT_ALIYAH,
     UNIT_MAFTIR,
@@ -30,6 +29,8 @@ from opensiddur.importer.humash.refs import (
     triennial_unit,
     ReadingSpan,
     VerseRef,
+    NUMBERING_COMMON,
+    canonical_ref,
     hebcal_ref_half,
     parse_hebcal_ref,
 )
@@ -142,9 +143,8 @@ def _haftarah_spans(raw, unit: str = "haftarah") -> list[ReadingSpan]:
             unit=unit,
             label=str(index),
             start=parse_hebcal_ref(book, part["b"]),
-            end=parse_hebcal_ref(book, part["e"]),
+            end=parse_hebcal_ref(book, part["e"], at_end=True),
             note=part.get("note"),
-            numbering=NUMBERING_COMMON,
             start_half=hebcal_ref_half(part["b"]),
             end_half=hebcal_ref_half(part["e"]),
         ))
@@ -189,7 +189,8 @@ def _repeated_span(key: str, spans: list[ReadingSpan]) -> ReadingSpan | None:
     if repeat is None:
         return None
     chapter, verse = repeat
-    ref = VerseRef(book, chapter, verse)
+    # Stated the way the printed editions number, like everything else taken from hebcal.
+    ref = canonical_ref(NUMBERING_COMMON, VerseRef(book, chapter, verse))
     return ReadingSpan(unit="haftarah.repeated", label="repeated", start=ref, end=ref)
 
 
@@ -259,8 +260,7 @@ def festival_readings(sourcetexts_root: Path | None = None) -> dict[str, dict]:
                 unit=unit,
                 label=normalized_label,
                 start=parse_hebcal_ref(book, value["b"]),
-                end=parse_hebcal_ref(book, value["e"]),
-                numbering=NUMBERING_COMMON,
+                end=parse_hebcal_ref(book, value["e"], at_end=True),
             ))
         passages: list[Passage] = []
         for hebcal_key, rite in HEBCAL_RITE_KEYS.items():
@@ -303,8 +303,7 @@ def _division_spans(
             unit=triennial_unit(year, maftir=maftir, variation=variation, owner=owner),
             label=f"{year}.{name}" if variation is None else f"{variation}.{year}.{name}",
             start=parse_hebcal_ref(book, value[0]),
-            end=parse_hebcal_ref(book, value[1]),
-            numbering=NUMBERING_COMMON,
+            end=parse_hebcal_ref(book, value[1], at_end=True),
             owner=owner,
         ))
     return spans

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -88,10 +88,48 @@ class Passage:
         return seen
 
 
+# Verses hebcal names that do not exist. Corrected on the way in rather than in sourcetexts,
+# which is kept a faithful copy of upstream. Each entry gives the path to the value, what
+# upstream says, and what it should say, so that a fix upstream is noticed rather than
+# silently overwritten.
+HEBCAL_CORRECTIONS: dict[str, dict[tuple, tuple[str, str]]] = {
+    "triennial-haft.json": {
+        # Ki Teitzei year 3 reads Isaiah 48:12-21 and then repeats 48:20, so that the haftarah
+        # does not end on 48:22, אין שלום אמר ה׳ לרשעים. Upstream writes chapter 4, which has
+        # six verses.
+        ("Ki Teitzei", "3", 1, "b"): ("4:20", "48:20"),
+        ("Ki Teitzei", "3", 1, "e"): ("4:20", "48:20"),
+    },
+}
+
+
+def _apply_corrections(name: str, data: dict) -> dict:
+    """Replace the known bad references in one hebcal file, in place."""
+    for path, (wrong, right) in HEBCAL_CORRECTIONS.get(name, {}).items():
+        node = data
+        try:
+            for step in path[:-1]:
+                node = node[step]
+            found = node[path[-1]]
+        except (KeyError, IndexError, TypeError):
+            logger.warning("%s: %s is gone, so its correction no longer applies", name, path)
+            continue
+        if found == right:
+            continue
+        if found != wrong:
+            logger.warning(
+                "%s: %s reads %r, neither the %r this corrects nor the %r it corrects it to; "
+                "leaving it alone", name, path, found, wrong, right,
+            )
+            continue
+        node[path[-1]] = right
+    return data
+
+
 @functools.cache
 def _load(name: str, sourcetexts_root: Path | None = None) -> dict:
     path = hebcal_leyning_data_directory(sourcetexts_root) / name
-    return json.loads(path.read_text(encoding="utf-8"))
+    return _apply_corrections(name, json.loads(path.read_text(encoding="utf-8")))
 
 
 def _haftarah_spans(raw, unit: str = "haftarah") -> list[ReadingSpan]:

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -197,10 +197,19 @@ def festival_readings(sourcetexts_root: Path | None = None) -> dict[str, dict]:
         aliyot_spans: list[ReadingSpan] = []
         for label, value in entry.get("fullkriyah", {}).items():
             book = BOOK_NUMBER_TO_SLUG[value["k"]]
-            unit = UNIT_MAFTIR if label == "M" else UNIT_ALIYAH
+            # Most festivals have one maftir, keyed "M". Sukkot's Chol HaMoed Shabbat has a
+            # different maftir per weekday of the intermediate days, keyed "M-day1".."M-day5".
+            is_maftir = label == "M" or label.startswith("M-day")
+            unit = UNIT_MAFTIR if is_maftir else UNIT_ALIYAH
+            if label == "M":
+                normalized_label = "maftir"
+            elif is_maftir:
+                normalized_label = f"maftir_{label[len('M-'):]}"
+            else:
+                normalized_label = label
             aliyot_spans.append(ReadingSpan(
                 unit=unit,
-                label="maftir" if label == "M" else label,
+                label=normalized_label,
                 start=parse_hebcal_ref(book, value["b"]),
                 end=parse_hebcal_ref(book, value["e"]),
                 numbering=NUMBERING_COMMON,

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import functools
 import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -29,9 +30,12 @@ from opensiddur.importer.humash.refs import (
     triennial_unit,
     ReadingSpan,
     VerseRef,
+    hebcal_ref_half,
     parse_hebcal_ref,
 )
 from opensiddur.importer.util.pages import hebcal_leyning_data_directory
+
+logger = logging.getLogger(__name__)
 
 # The rites hebcal distinguishes. "haft" is what it gives without qualification, which is the
 # Ashkenazi reading; "seph" is the Sephardi one. Other rites are not in this data.
@@ -103,8 +107,39 @@ def _haftarah_spans(raw, unit: str = "haftarah") -> list[ReadingSpan]:
             end=parse_hebcal_ref(book, part["e"]),
             note=part.get("note"),
             numbering=NUMBERING_COMMON,
+            start_half=hebcal_ref_half(part["b"]),
+            end_half=hebcal_ref_half(part["e"]),
         ))
     return spans
+
+
+def _without_anchor_verses(key: str, spans: list[ReadingSpan]) -> list[ReadingSpan]:
+    """The spans actually read, dropping any that an earlier span already covers.
+
+    Eight of the triennial haftarot end with a piece inside one already listed — Nasso
+    year 1 is Joshua 6:5-14 and then 6:12, Emor year 3 is Nachum 2:1-3 and then 2:2b-3a. That
+    is the verse the pairing with the parshah turns on, recorded beside the reading rather than
+    appended to it: taking it as a continuation would read those verses a second time.
+
+    A piece that merely runs backwards is left alone. The haftarot really do that — Mishpatim
+    reads Jeremiah 34:12-22 and then 33:25-26 — and only containment marks an anchor.
+    """
+    kept: list[ReadingSpan] = []
+    for span in spans:
+        anchor = any(
+            earlier.book == span.book
+            and earlier.start <= span.start
+            and span.end <= earlier.end
+            for earlier in kept
+        )
+        if anchor:
+            logger.debug(
+                "%s: %s-%s lies inside an earlier span, so it is the verse the pairing turns "
+                "on rather than part of the reading", key, span.start, span.end,
+            )
+            continue
+        kept.append(span)
+    return kept
 
 
 def _repeated_span(key: str, spans: list[ReadingSpan]) -> ReadingSpan | None:
@@ -301,7 +336,23 @@ def triennial_patterns(sourcetexts_root: Path | None = None) -> dict[str, dict[s
 
 
 def triennial_haftarot(sourcetexts_root: Path | None = None) -> dict[str, dict[int, Passage]]:
-    """The triennial haftarah of each parshah, by slug then cycle year."""
+    """The triennial haftarah of each parshah, by slug then cycle year.
+
+    These are alternatives to the annual haftarah, not additions to it, and unlike the Torah
+    divisions they are keyed by plain cycle year: the reading follows the year alone, so none
+    of the variation machinery of ``triennial`` applies.
+
+    Coverage is not uniform, and the caller has to allow for it.
+
+    * Only 51 parshiyot have any. Devarim and Vaetchanan always fall on Shabbat Hazon and
+      Shabbat Nahamu, whose haftarot are fixed, and Vezot Haberakhah is read on Simhat Torah;
+      those three keep their annual haftarah in every year.
+    * Tazria, Achrei Mot and Behar carry years 1 and 2 only, being read alone only in those
+      years, and the pairs have no triennial haftarah of their own — so on a year a pair is
+      read together the annual haftarah of that week stands.
+    * ``Tish'a B'Av`` is in the file but is not a parshah, and is dropped here with everything
+      else the parshah table does not name.
+    """
     data = _load("triennial-haft.json", sourcetexts_root)
     result: dict[str, dict[int, Passage]] = {}
     for name, entry in data.items():
@@ -310,12 +361,18 @@ def triennial_haftarot(sourcetexts_root: Path | None = None) -> dict[str, dict[i
             continue
         years: dict[int, Passage] = {}
         for year_key, value in entry.items():
-            if not year_key.isdigit() or not isinstance(value, dict) or "k" not in value:
+            # A year is one reading object, or a list of them where the reading is
+            # discontinuous — Toldot's third year is Judges 3:15-27 and then 3:30. The
+            # mnemonic hebcal notes against each piece rides along on the span.
+            parts = value if isinstance(value, list) else [value]
+            if not year_key.isdigit() or not parts or not all(
+                isinstance(part, dict) and "k" in part for part in parts
+            ):
                 continue
+            passage_key = f"{name}:triennial:{year_key}"
             years[int(year_key)] = Passage(
-                key=f"{name}:triennial:{year_key}",
-                spans=_haftarah_spans(value),
-                note=value.get("note"),
+                key=passage_key,
+                spans=_without_anchor_verses(passage_key, _haftarah_spans(value)),
             )
         if years:
             result[slug] = years

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -232,6 +232,16 @@ def festival_readings(sourcetexts_root: Path | None = None) -> dict[str, dict]:
     data = _load("holiday-readings.json", sourcetexts_root)
     result: dict[str, dict] = {}
     for name, entry in data.items():
+        if entry.get("alias"):
+            # A pointer, not a reading: hebcal names the occasion and says which reading it
+            # takes. Rosh Chodesh Nisan is the Rosh Chodesh reading, Tzom Gedaliah the Fast
+            # Day (Morning) one, Pesach III (CH"M) is what Israel calls Pesach Chol ha-Moed
+            # Day 1. The reading itself is emitted under the name hebcal points at, so
+            # following the pointer here would print the same text under thirty-one more
+            # headings; which occasions fall on which day is the calendar's business, not a
+            # division of the text.
+            logger.debug("%s reads %s, so it is not a reading of its own", name, entry["key"])
+            continue
         aliyot_spans: list[ReadingSpan] = []
         for label, value in entry.get("fullkriyah", {}).items():
             book = BOOK_NUMBER_TO_SLUG[value["k"]]

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -1,0 +1,246 @@
+"""Haftarot, festival readings and the modern triennial cycle, read from the hebcal data.
+
+MAM records no haftarot and no festival readings at all, so these come from hebcal. Each is
+modelled as a *passage*: an ordered list of spans, because a haftarah is frequently
+discontinuous and occasionally moves backwards through its book — Mishpatim reads Jeremiah
+34:8-22 and then 33:25-26 — and because two of them bridge books.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from opensiddur.importer.humash.names import HEBCAL_TO_SLUG, slugify_reading_name
+from opensiddur.importer.humash.refs import (
+    BOOK_NUMBER_TO_SLUG,
+    NUMBERING_COMMON,
+    HEBCAL_BOOK_TO_SLUG,
+    UNIT_ALIYAH,
+    UNIT_MAFTIR,
+    triennial_unit,
+    ReadingSpan,
+    VerseRef,
+    parse_hebcal_ref,
+)
+from opensiddur.importer.util.pages import hebcal_leyning_data_directory
+
+# The rites hebcal distinguishes. "haft" is what it gives without qualification, which is the
+# Ashkenazi reading; "seph" is the Sephardi one. Other rites are not in this data.
+RITE_ASHKENAZ = "ashkenaz"
+RITE_SEPHARAD = "sepharad"
+HEBCAL_RITE_KEYS = {"haft": RITE_ASHKENAZ, "seph": RITE_SEPHARAD}
+
+RITE_TITLES = {
+    RITE_ASHKENAZ: "מִנְהַג אַשְׁכְּנַז",
+    RITE_SEPHARAD: "מִנְהַג סְפָרַד",
+}
+
+# Readings that repeat an earlier verse after the last one, so as not to end on a verse of
+# rebuke or calamity. hebcal does not record this, and it is invisible in the output if
+# forgotten, so it is listed here explicitly.
+#
+# Keyed by (reading key, book slug) -> the verse to repeat at the end.
+REPEATED_CLOSING_VERSES: dict[tuple[str, str], tuple[int, int]] = {
+    # Isaiah 66:24 ends "their worm shall not die"; 66:23 is read again after it.
+    ("Shabbat Rosh Chodesh", "isaiah"): (66, 23),
+    # Malachi 3:24 ends with a curse, so 3:23 is repeated after it.
+    ("Shabbat HaGadol", "malachi"): (3, 23),
+    # The last verse of Lamentations is a lament; 5:21 is repeated after 5:22.
+    ("megillah:lamentations", "lamentations"): (5, 21),
+    # Ecclesiastes 12:13 is repeated after 12:14.
+    ("megillah:ecclesiastes", "ecclesiastes"): (12, 13),
+}
+
+REPEATED_VERSE_INSTRUCTION = "חוזרים ואומרים את הפסוק הקודם"
+
+
+@dataclass
+class Passage:
+    """One reading: an ordered list of spans, possibly discontinuous or across books."""
+
+    key: str
+    spans: list[ReadingSpan] = field(default_factory=list)
+    rite: str | None = None
+    title: str | None = None
+    note: str | None = None
+    # A verse repeated after the end so the reading does not close on a hard verse.
+    repeated: ReadingSpan | None = None
+
+    @property
+    def books(self) -> list[str]:
+        seen: list[str] = []
+        for span in self.spans:
+            if span.book not in seen:
+                seen.append(span.book)
+        return seen
+
+
+@functools.cache
+def _load(name: str, sourcetexts_root: Path | None = None) -> dict:
+    path = hebcal_leyning_data_directory(sourcetexts_root) / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _haftarah_spans(raw, unit: str = "haftarah") -> list[ReadingSpan]:
+    """Turn hebcal's haftarah value — one object or a list of them — into spans."""
+    parts = raw if isinstance(raw, list) else [raw]
+    spans: list[ReadingSpan] = []
+    for index, part in enumerate(parts, start=1):
+        book = HEBCAL_BOOK_TO_SLUG[part["k"]]
+        spans.append(ReadingSpan(
+            unit=unit,
+            label=str(index),
+            start=parse_hebcal_ref(book, part["b"]),
+            end=parse_hebcal_ref(book, part["e"]),
+            note=part.get("note"),
+            numbering=NUMBERING_COMMON,
+        ))
+    return spans
+
+
+def _repeated_span(key: str, spans: list[ReadingSpan]) -> ReadingSpan | None:
+    """The closing verse to repeat, if this reading has one."""
+    if not spans:
+        return None
+    book = spans[-1].end.book
+    repeat = REPEATED_CLOSING_VERSES.get((key, book))
+    if repeat is None:
+        return None
+    chapter, verse = repeat
+    ref = VerseRef(book, chapter, verse)
+    return ReadingSpan(unit="haftarah.repeated", label="repeated", start=ref, end=ref)
+
+
+def haftarot(sourcetexts_root: Path | None = None) -> dict[str, list[Passage]]:
+    """The haftarah of each weekly parshah, by slug, one Passage per rite."""
+    data = _load("aliyot.json", sourcetexts_root)
+    result: dict[str, list[Passage]] = {}
+    for name, entry in data.items():
+        slug = HEBCAL_TO_SLUG.get(name)
+        if slug is None:
+            continue
+        passages: list[Passage] = []
+        for hebcal_key, rite in HEBCAL_RITE_KEYS.items():
+            if hebcal_key not in entry:
+                continue
+            spans = _haftarah_spans(entry[hebcal_key])
+            passages.append(Passage(
+                key=name,
+                spans=spans,
+                rite=rite,
+                title=RITE_TITLES[rite],
+                repeated=_repeated_span(name, spans),
+            ))
+        if passages:
+            # A parshah with only one recorded haftarah has no rite variation to show.
+            if len(passages) == 1:
+                passages[0].rite = None
+                passages[0].title = None
+            result[slug] = passages
+    return result
+
+
+def festival_readings(sourcetexts_root: Path | None = None) -> dict[str, dict]:
+    """Every festival and special-Shabbat reading, keyed by hebcal's name for the occasion.
+
+    Each value holds the Torah spans (``aliyot``) and one Passage per rite (``haftarot``).
+    The Torah reading of a festival is drawn from wherever in the Torah it belongs, so unlike
+    the weekly parshiyot these spans may come from any book.
+    """
+    data = _load("holiday-readings.json", sourcetexts_root)
+    result: dict[str, dict] = {}
+    for name, entry in data.items():
+        aliyot_spans: list[ReadingSpan] = []
+        for label, value in entry.get("fullkriyah", {}).items():
+            book = BOOK_NUMBER_TO_SLUG[value["k"]]
+            unit = UNIT_MAFTIR if label == "M" else UNIT_ALIYAH
+            aliyot_spans.append(ReadingSpan(
+                unit=unit,
+                label="maftir" if label == "M" else label,
+                start=parse_hebcal_ref(book, value["b"]),
+                end=parse_hebcal_ref(book, value["e"]),
+                numbering=NUMBERING_COMMON,
+            ))
+        passages: list[Passage] = []
+        for hebcal_key, rite in HEBCAL_RITE_KEYS.items():
+            if hebcal_key not in entry:
+                continue
+            spans = _haftarah_spans(entry[hebcal_key])
+            passages.append(Passage(
+                key=name, spans=spans, rite=rite, title=RITE_TITLES[rite],
+                repeated=_repeated_span(name, spans),
+            ))
+        if len(passages) == 1:
+            passages[0].rite = None
+            passages[0].title = None
+        result[slugify_reading_name(name)] = {
+            "name": name,
+            "aliyot": sorted(aliyot_spans, key=lambda span: (span.unit, span.label)),
+            "haftarot": passages,
+        }
+    return result
+
+
+def triennial(sourcetexts_root: Path | None = None) -> dict[str, dict[int, list[ReadingSpan]]]:
+    """The modern triennial division of each parshah, by slug then cycle year (1-3)."""
+    data = _load("triennial.json", sourcetexts_root)
+    result: dict[str, dict[int, list[ReadingSpan]]] = {}
+    for name, entry in data.items():
+        slug = HEBCAL_TO_SLUG.get(name)
+        if slug is None:
+            continue
+        book = BOOK_NUMBER_TO_SLUG[entry["book"]]
+        years: dict[int, list[ReadingSpan]] = {}
+        # Most entries hold the three years under "years". Those whose division depends on
+        # whether the parshah is read alone or combined that year use "variations" instead,
+        # keyed either "Y.n" — the same fixed three years — or by a year-pattern name such as
+        # "C.2", which cannot be reduced to a cycle year and is skipped.
+        divisions = entry.get("years") or entry.get("variations") or {}
+        for year_key, aliyot in divisions.items():
+            if not year_key.startswith("Y.") or not isinstance(aliyot, dict):
+                continue
+            year = int(year_key.split(".", 1)[1])
+            spans: list[ReadingSpan] = []
+            for label, value in (aliyot or {}).items():
+                if not isinstance(value, list) or len(value) < 2:
+                    continue
+                # The maftir re-reads the close of that year's seventh aliyah, so like the
+                # annual maftir it needs a unit-space of its own or it would cut the aliyah
+                # short; and each cycle year needs one because the years overlap each other.
+                spans.append(ReadingSpan(
+                    unit=triennial_unit(year, maftir=label == "M"),
+                    label=f"{year}.{'maftir' if label == 'M' else label}",
+                    start=parse_hebcal_ref(book, value[0]),
+                    end=parse_hebcal_ref(book, value[1]),
+                    numbering=NUMBERING_COMMON,
+                ))
+            if spans:
+                years[year] = spans
+        if years:
+            result[slug] = years
+    return result
+
+
+def triennial_haftarot(sourcetexts_root: Path | None = None) -> dict[str, dict[int, Passage]]:
+    """The triennial haftarah of each parshah, by slug then cycle year."""
+    data = _load("triennial-haft.json", sourcetexts_root)
+    result: dict[str, dict[int, Passage]] = {}
+    for name, entry in data.items():
+        slug = HEBCAL_TO_SLUG.get(name)
+        if slug is None:
+            continue
+        years: dict[int, Passage] = {}
+        for year_key, value in entry.items():
+            if not year_key.isdigit() or not isinstance(value, dict) or "k" not in value:
+                continue
+            years[int(year_key)] = Passage(
+                key=f"{name}:triennial:{year_key}",
+                spans=_haftarah_spans(value),
+                note=value.get("note"),
+            )
+        if years:
+            result[slug] = years
+    return result

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -13,13 +13,19 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from opensiddur.importer.humash.names import HEBCAL_TO_SLUG, slugify_reading_name
+from opensiddur.importer.humash.names import (
+    HEBCAL_TO_SLUG,
+    PAIR_FOR_MEMBER,
+    PAIR_MEMBERS,
+    slugify_reading_name,
+)
 from opensiddur.importer.humash.refs import (
     BOOK_NUMBER_TO_SLUG,
     NUMBERING_COMMON,
     HEBCAL_BOOK_TO_SLUG,
     UNIT_ALIYAH,
     UNIT_MAFTIR,
+    VARIATION_COMBINED,
     triennial_unit,
     ReadingSpan,
     VerseRef,
@@ -184,43 +190,113 @@ def festival_readings(sourcetexts_root: Path | None = None) -> dict[str, dict]:
     return result
 
 
-def triennial(sourcetexts_root: Path | None = None) -> dict[str, dict[int, list[ReadingSpan]]]:
-    """The modern triennial division of each parshah, by slug then cycle year (1-3)."""
+def _division_spans(
+    aliyot: dict,
+    book: str,
+    year: int,
+    variation: str | None,
+    owner: str | None,
+) -> list[ReadingSpan]:
+    """One year's aliyot, as spans of the unit-space that year and variation own."""
+    spans: list[ReadingSpan] = []
+    for label, value in (aliyot or {}).items():
+        if not isinstance(value, list) or len(value) < 2:
+            continue
+        maftir = label == "M"
+        name = "maftir" if maftir else label
+        # The maftir re-reads the close of that year's seventh aliyah, so like the annual
+        # maftir it needs a unit-space of its own or it would cut the aliyah short; and each
+        # cycle year needs one because the years overlap each other.
+        spans.append(ReadingSpan(
+            unit=triennial_unit(year, maftir=maftir, variation=variation, owner=owner),
+            label=f"{year}.{name}" if variation is None else f"{variation}.{year}.{name}",
+            start=parse_hebcal_ref(book, value[0]),
+            end=parse_hebcal_ref(book, value[1]),
+            numbering=NUMBERING_COMMON,
+            owner=owner,
+        ))
+    return spans
+
+
+def triennial(
+    sourcetexts_root: Path | None = None,
+) -> dict[str, dict[tuple[str | None, int], list[ReadingSpan]]]:
+    """The modern triennial division of each reading, by slug then (variation, cycle year).
+
+    Most parshiyot hold the three years under "years" and have no variation, so their key is
+    ``(None, year)``. The twelve that may be read combined with their partner divide
+    differently depending on whether they were read alone in each year of the cycle, and hold
+    a "variations" object keyed ``"<variation>.<year>"`` — ``"C.2"`` is year 2 of variation C.
+    Which variation a cycle uses follows from its combine/separate pattern; see
+    ``triennial_patterns``. A variation may be an alias for another, written as a string
+    rather than an object, and is followed here so that every key yields real aliyot.
+
+    The seven combined readings are keyed by the pair's own slug, with variation
+    ``VARIATION_COMBINED``: they are what is read on a year the pair is read together.
+    """
     data = _load("triennial.json", sourcetexts_root)
-    result: dict[str, dict[int, list[ReadingSpan]]] = {}
+    result: dict[str, dict[tuple[str | None, int], list[ReadingSpan]]] = {}
     for name, entry in data.items():
         slug = HEBCAL_TO_SLUG.get(name)
         if slug is None:
             continue
         book = BOOK_NUMBER_TO_SLUG[entry["book"]]
-        years: dict[int, list[ReadingSpan]] = {}
-        # Most entries hold the three years under "years". Those whose division depends on
-        # whether the parshah is read alone or combined that year use "variations" instead,
-        # keyed either "Y.n" — the same fixed three years — or by a year-pattern name such as
-        # "C.2", which cannot be reduced to a cycle year and is skipped.
-        divisions = entry.get("years") or entry.get("variations") or {}
-        for year_key, aliyot in divisions.items():
+        combined = slug in PAIR_MEMBERS
+        # A parshah with a partner shares that pair's file, so its variations carry its slug.
+        # The combined reading and the 42 that stand alone own their file and do not.
+        owner = slug if slug in PAIR_FOR_MEMBER else None
+        divisions: dict[tuple[str | None, int], list[ReadingSpan]] = {}
+
+        for year_key, aliyot in (entry.get("years") or {}).items():
             if not year_key.startswith("Y.") or not isinstance(aliyot, dict):
                 continue
             year = int(year_key.split(".", 1)[1])
-            spans: list[ReadingSpan] = []
-            for label, value in (aliyot or {}).items():
-                if not isinstance(value, list) or len(value) < 2:
-                    continue
-                # The maftir re-reads the close of that year's seventh aliyah, so like the
-                # annual maftir it needs a unit-space of its own or it would cut the aliyah
-                # short; and each cycle year needs one because the years overlap each other.
-                spans.append(ReadingSpan(
-                    unit=triennial_unit(year, maftir=label == "M"),
-                    label=f"{year}.{'maftir' if label == 'M' else label}",
-                    start=parse_hebcal_ref(book, value[0]),
-                    end=parse_hebcal_ref(book, value[1]),
-                    numbering=NUMBERING_COMMON,
-                ))
+            variation = VARIATION_COMBINED if combined else None
+            spans = _division_spans(aliyot, book, year, variation, owner)
             if spans:
-                years[year] = spans
-        if years:
-            result[slug] = years
+                divisions[(variation, year)] = spans
+
+        variations = entry.get("variations") or {}
+        for variation_key, aliyot in variations.items():
+            # An alias names another variation whose division is identical.
+            while isinstance(aliyot, str):
+                aliyot = variations.get(aliyot)
+            if not isinstance(aliyot, dict):
+                continue
+            variation, _, year_part = variation_key.rpartition(".")
+            if not year_part.isdigit():
+                continue
+            year = int(year_part)
+            # "Y" is hebcal's name for "no variation": the fixed three years.
+            variation = None if variation == "Y" else variation
+            spans = _division_spans(aliyot, book, year, variation, owner)
+            if spans:
+                divisions[(variation, year)] = spans
+
+        if divisions:
+            result[slug] = divisions
+    return result
+
+
+def triennial_patterns(sourcetexts_root: Path | None = None) -> dict[str, dict[str, str]]:
+    """Which variation each combine/separate pattern selects, by pair slug.
+
+    The pattern is one character per year of the cycle — ``T`` where the pair was read
+    together that year, ``S`` where apart — so ``{"TSS": "C"}`` says that a cycle which read
+    the pair together only in its first year divides the two singles as variation C. The
+    patterns that resolve to an Israel variation are disjoint from the diaspora ones, so the
+    pattern alone identifies the variation and no separate Israel test is needed.
+    """
+    data = _load("triennial.json", sourcetexts_root)
+    result: dict[str, dict[str, str]] = {}
+    for name, entry in data.items():
+        slug = HEBCAL_TO_SLUG.get(name)
+        # Lech-Lecha is hyphenated but is one parshah, so the pair table decides, not the name.
+        if slug not in PAIR_MEMBERS:
+            continue
+        patterns = entry.get("patterns")
+        if patterns:
+            result[slug] = dict(patterns)
     return result
 
 

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -22,7 +22,16 @@ UNIT_PARSHA = "parsha.annual"
 UNIT_ALIYAH = "aliyah.annual"
 UNIT_WEEKDAY = "aliyah.weekday"
 UNIT_MAFTIR = "maftir.annual"
+# Each year of the triennial cycle is its own division of the same text, and consecutive
+# years deliberately overlap — in Beshalach, year 1's fifth aliyah and year 2's first are the
+# same verses — so each year needs a unit-space of its own.
 UNIT_TRIENNIAL = "aliyah.triennial"
+UNIT_TRIENNIAL_MAFTIR = "maftir.triennial"
+
+
+def triennial_unit(year: int, maftir: bool = False) -> str:
+    base = UNIT_TRIENNIAL_MAFTIR if maftir else UNIT_TRIENNIAL
+    return f"{base}.{year}"
 
 # The five books, in order, as MAM names them in Hebrew.
 TORAH_BOOKS: tuple[tuple[str, str, str], ...] = (
@@ -34,10 +43,87 @@ TORAH_BOOKS: tuple[tuple[str, str, str], ...] = (
     ("דברים", "deuteronomy", "Deuteronomy"),
 )
 
+# The prophetic books the haftarot draw on, plus the five megillot. hebcal names them the way
+# the left column does; the projects file them under the slug in the right.
+OTHER_BOOKS: tuple[tuple[str, str], ...] = (
+    ("Joshua", "joshua"),
+    ("Judges", "judges"),
+    ("I Samuel", "samuel_1"),
+    ("II Samuel", "samuel_2"),
+    ("I Kings", "kings_1"),
+    ("II Kings", "kings_2"),
+    ("Isaiah", "isaiah"),
+    ("Jeremiah", "jeremiah"),
+    ("Ezekiel", "ezekiel"),
+    ("Hosea", "hosea"),
+    ("Joel", "joel"),
+    ("Amos", "amos"),
+    ("Obadiah", "obadiah"),
+    ("Jonah", "jonah"),
+    ("Micah", "micah"),
+    ("Nachum", "nahum"),
+    ("Habakkuk", "habakkuk"),
+    ("Zephaniah", "zephaniah"),
+    ("Haggai", "haggai"),
+    ("Zechariah", "zechariah"),
+    ("Malachi", "malachi"),
+    ("Song of Songs", "song_of_songs"),
+    ("Ruth", "ruth"),
+    ("Lamentations", "lamentations"),
+    ("Ecclesiastes", "ecclesiastes"),
+    ("Esther", "esther"),
+)
+
+# The five megillot, each with the occasion it is read on and its Hebrew title. The occasion
+# names are features of the existing opensiddur:holiday feature structure.
+MEGILLOT: tuple[tuple[str, str, str], ...] = (
+    # (book slug, Hebrew title, opensiddur:holiday feature)
+    ("song_of_songs", "שִׁיר הַשִּׁירִים", "pesah"),
+    ("ruth", "רוּת", "shavuot"),
+    ("lamentations", "אֵיכָה", "tisha-bav"),
+    ("ecclesiastes", "קֹהֶלֶת", "sukkot"),
+    ("esther", "אֶסְתֵּר", "purim"),
+)
+
 HEBREW_BOOK_TO_SLUG = {hebrew: slug for hebrew, slug, _ in TORAH_BOOKS}
 SLUG_TO_HEBREW_BOOK = {slug: hebrew for hebrew, slug, _ in TORAH_BOOKS}
 SLUG_TO_HEBCAL_BOOK = {slug: english for _, slug, english in TORAH_BOOKS}
 HEBCAL_BOOK_TO_SLUG = {english: slug for _, slug, english in TORAH_BOOKS}
+HEBCAL_BOOK_TO_SLUG.update(dict(OTHER_BOOKS))
+
+# hebcal numbers the Torah books 1-5 in the festival readings.
+BOOK_NUMBER_TO_SLUG = {number: slug for number, (_, slug, _) in enumerate(TORAH_BOOKS, start=1)}
+
+
+# Verse numbering conventions, and the project that follows each.
+#
+# Four Torah chapters are divided into verses differently by different editions, because the
+# Decalogue and a few other passages can be grouped by the upper cantillation (ta'am elyon) or
+# the lower (ta'am tachton). The humash therefore emits a variant range per numbering, under
+# conditional control; see model.py. MAM's division is the default, since the aliyah
+# boundaries come from MAM.
+NUMBERING_MASORAH = "masorah"       # Miqra al pi ha-Masorah
+NUMBERING_LENINGRAD = "leningrad"   # Westminster Leningrad Codex
+NUMBERING_COMMON = "common"         # common printed editions, which hebcal and jps1917 follow
+
+NUMBERINGS = (NUMBERING_MASORAH, NUMBERING_LENINGRAD, NUMBERING_COMMON)
+DEFAULT_NUMBERING = NUMBERING_MASORAH
+
+NUMBERING_PROJECT = {
+    NUMBERING_MASORAH: "miqra_al_pi_hamasorah",
+    NUMBERING_LENINGRAD: "wlc",
+    NUMBERING_COMMON: "jps1917",
+}
+
+# Chapters whose verse count depends on the numbering. Everywhere else the three agree, so
+# hebcal's counts are used directly. Verified against each edition's own source rather than
+# against the generated projects: miqra_al_pi_hamasorah's Numbers 10 is short two verses in
+# the project but not in MAM itself, and encoding that would bake a defect into the humash.
+DIVERGENT_CHAPTER_VERSES: dict[tuple[str, int], dict[str, int]] = {
+    ("exodus", 20): {NUMBERING_MASORAH: 22, NUMBERING_LENINGRAD: 26, NUMBERING_COMMON: 23},
+    ("numbers", 25): {NUMBERING_MASORAH: 18, NUMBERING_LENINGRAD: 19, NUMBERING_COMMON: 19},
+    ("deuteronomy", 5): {NUMBERING_MASORAH: 29, NUMBERING_LENINGRAD: 33, NUMBERING_COMMON: 30},
+}
 
 
 @dataclass(frozen=True, order=True)
@@ -77,42 +163,33 @@ class ReadingSpan:
     end: VerseRef
     # Free text from the source noting that other traditions divide differently.
     note: str | None = None
+    # Which edition's verse division the references are stated in. It matters only in the
+    # four chapters of DIVERGENT_CHAPTER_VERSES: MAM supplies the weekly aliyot in its own
+    # numbering, while everything taken from hebcal follows the common printed editions.
+    numbering: str = "masorah"
+
+    @property
+    def book(self) -> str:
+        """The book this span lies in. Both ends are always in the same one."""
+        return self.start.book
+
+    @property
+    def crosses_divergent_chapter(self) -> bool:
+        """Whether either end lies in a chapter the editions divide differently.
+
+        Only these spans need a per-numbering variant; everywhere else one range serves
+        every edition.
+        """
+        return any(
+            (ref.book, ref.chapter) in DIVERGENT_CHAPTER_VERSES
+            for ref in (self.start, self.end)
+        )
 
     def __post_init__(self):
         if self.start.book != self.end.book:
             raise ValueError(f"{self.unit} {self.label} crosses books: {self.start}-{self.end}")
         if self.end < self.start:
             raise ValueError(f"{self.unit} {self.label} ends before it starts: {self.start}-{self.end}")
-
-
-# Verse numbering conventions, and the project that follows each.
-#
-# Four Torah chapters are divided into verses differently by different editions, because the
-# Decalogue and a few other passages can be grouped by the upper cantillation (ta'am elyon) or
-# the lower (ta'am tachton). The humash therefore emits a variant range per numbering, under
-# conditional control; see model.py. MAM's division is the default, since the aliyah
-# boundaries come from MAM.
-NUMBERING_MASORAH = "masorah"       # Miqra al pi ha-Masorah
-NUMBERING_LENINGRAD = "leningrad"   # Westminster Leningrad Codex
-NUMBERING_COMMON = "common"         # common printed editions, which hebcal and jps1917 follow
-
-NUMBERINGS = (NUMBERING_MASORAH, NUMBERING_LENINGRAD, NUMBERING_COMMON)
-DEFAULT_NUMBERING = NUMBERING_MASORAH
-
-NUMBERING_PROJECT = {
-    NUMBERING_MASORAH: "miqra_al_pi_hamasorah",
-    NUMBERING_LENINGRAD: "wlc",
-    NUMBERING_COMMON: "jps1917",
-}
-
-# Chapters whose verse count depends on the numbering. Everywhere else the three agree, so
-# hebcal's counts are used directly. Verified against the three projects' own milestones.
-DIVERGENT_CHAPTER_VERSES: dict[tuple[str, int], dict[str, int]] = {
-    ("exodus", 20): {NUMBERING_MASORAH: 22, NUMBERING_LENINGRAD: 26, NUMBERING_COMMON: 23},
-    ("numbers", 10): {NUMBERING_MASORAH: 34, NUMBERING_LENINGRAD: 36, NUMBERING_COMMON: 36},
-    ("numbers", 25): {NUMBERING_MASORAH: 18, NUMBERING_LENINGRAD: 19, NUMBERING_COMMON: 19},
-    ("deuteronomy", 5): {NUMBERING_MASORAH: 29, NUMBERING_LENINGRAD: 33, NUMBERING_COMMON: 30},
-}
 
 
 @functools.cache

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import functools
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -200,6 +201,12 @@ class ReadingSpan:
     # for the two parshiyot of a pair, which share a file but keep their own URN spaces:
     # without it their identically numbered aliyot would both be .../vayakhel_pekudei/1.
     owner: str | None = None
+    # Where the span really begins or ends, when that is inside a verse rather than at its
+    # edge: "b" on `start_half` means it begins at the second half of `start`, and "a" on
+    # `end_half` that it ends at the first half of `end`. The whole verse is transcluded either
+    # way — a URN addresses no less than a verse — and the reading says where to stop.
+    start_half: str | None = None
+    end_half: str | None = None
 
     @property
     def book(self) -> str:
@@ -277,7 +284,27 @@ def previous_verse(
     )
 
 
+# hebcal writes a boundary that falls inside a verse as a letter after the verse number: the
+# triennial haftarah of Emor in year 3 runs from Nachum 2:2b to 2:3a, the second half of one
+# verse to the first half of the next. Three references in the data are of this form.
+_HEBCAL_REF = re.compile(r"\s*(\d+)\s*:\s*(\d+)\s*([ab]?)\s*\Z")
+
+
 def parse_hebcal_ref(book: str, spec: str) -> VerseRef:
-    """Parse hebcal's ``"chapter:verse"`` form against an opensiddur book slug."""
-    chapter, _, verse = spec.partition(":")
-    return VerseRef(book, int(chapter), int(verse))
+    """Parse hebcal's ``"chapter:verse"`` form against an opensiddur book slug.
+
+    A half-verse marker is read as the whole verse containing it, since a URN addresses whole
+    verses; ``hebcal_ref_half`` recovers which half was meant so the reading can say so.
+    """
+    match = _HEBCAL_REF.match(spec)
+    if match is None:
+        raise ValueError(f"Unparseable hebcal reference {spec!r} in {book}")
+    return VerseRef(book, int(match.group(1)), int(match.group(2)))
+
+
+def hebcal_ref_half(spec: str) -> str | None:
+    """Which half of the verse a reference names — ``"a"``, ``"b"``, or None for the whole."""
+    match = _HEBCAL_REF.match(spec)
+    if match is None:
+        raise ValueError(f"Unparseable hebcal reference {spec!r}")
+    return match.group(3) or None

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -1,0 +1,173 @@
+"""Verse references and reading spans — the vocabulary the whole humash importer shares.
+
+A *reading span* is a named, explicitly bounded stretch of text belonging to one *unit-space*.
+Ends are always stored, never inferred from the next span, because reading divisions overlap:
+the maftir re-reads the close of the seventh aliyah, and the weekday aliyot subdivide the
+Shabbat ones. See ``model.py`` for how overlapping spans are emitted.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from opensiddur.importer.util.pages import hebcal_leyning_data_directory
+
+# Unit-spaces. These become tei:milestone/@unit, and refdb.UNIT_CONTAINED_BY decides which of
+# them may terminate which; they are deliberately distinct so that they do not truncate one
+# another.
+UNIT_PARSHA = "parsha.annual"
+UNIT_ALIYAH = "aliyah.annual"
+UNIT_WEEKDAY = "aliyah.weekday"
+UNIT_MAFTIR = "maftir.annual"
+UNIT_TRIENNIAL = "aliyah.triennial"
+
+# The five books, in order, as MAM names them in Hebrew.
+TORAH_BOOKS: tuple[tuple[str, str, str], ...] = (
+    # (MAM Hebrew name, opensiddur slug, hebcal English name)
+    ("בראשית", "genesis", "Genesis"),
+    ("שמות", "exodus", "Exodus"),
+    ("ויקרא", "leviticus", "Leviticus"),
+    ("במדבר", "numbers", "Numbers"),
+    ("דברים", "deuteronomy", "Deuteronomy"),
+)
+
+HEBREW_BOOK_TO_SLUG = {hebrew: slug for hebrew, slug, _ in TORAH_BOOKS}
+SLUG_TO_HEBREW_BOOK = {slug: hebrew for hebrew, slug, _ in TORAH_BOOKS}
+SLUG_TO_HEBCAL_BOOK = {slug: english for _, slug, english in TORAH_BOOKS}
+HEBCAL_BOOK_TO_SLUG = {english: slug for _, slug, english in TORAH_BOOKS}
+
+
+@dataclass(frozen=True, order=True)
+class VerseRef:
+    """One verse, identified the way the Tanakh projects' URNs identify it."""
+
+    book: str  # opensiddur slug, e.g. "genesis"
+    chapter: int
+    verse: int
+
+    def __str__(self) -> str:
+        return f"{self.book} {self.chapter}:{self.verse}"
+
+    @property
+    def urn(self) -> str:
+        """The unsuffixed verse URN, which resolves in whichever project has priority."""
+        return f"urn:x-opensiddur:text:bible:{self.book}/{self.chapter}/{self.verse}"
+
+    def range_urn(self, end: "VerseRef") -> str:
+        """A ranged transclusion target from this verse to `end`.
+
+        The range syntax replaces the trailing components of the start, so the end is written
+        as ``chapter/verse`` — see UrnResolver.resolve_range.
+        """
+        if end.book != self.book:
+            raise ValueError(f"A range may not cross books: {self} to {end}")
+        return f"{self.urn}-{end.chapter}/{end.verse}"
+
+
+@dataclass(frozen=True)
+class ReadingSpan:
+    """A named span of one unit-space, with both ends given explicitly."""
+
+    unit: str
+    label: str
+    start: VerseRef
+    end: VerseRef
+    # Free text from the source noting that other traditions divide differently.
+    note: str | None = None
+
+    def __post_init__(self):
+        if self.start.book != self.end.book:
+            raise ValueError(f"{self.unit} {self.label} crosses books: {self.start}-{self.end}")
+        if self.end < self.start:
+            raise ValueError(f"{self.unit} {self.label} ends before it starts: {self.start}-{self.end}")
+
+
+# Verse numbering conventions, and the project that follows each.
+#
+# Four Torah chapters are divided into verses differently by different editions, because the
+# Decalogue and a few other passages can be grouped by the upper cantillation (ta'am elyon) or
+# the lower (ta'am tachton). The humash therefore emits a variant range per numbering, under
+# conditional control; see model.py. MAM's division is the default, since the aliyah
+# boundaries come from MAM.
+NUMBERING_MASORAH = "masorah"       # Miqra al pi ha-Masorah
+NUMBERING_LENINGRAD = "leningrad"   # Westminster Leningrad Codex
+NUMBERING_COMMON = "common"         # common printed editions, which hebcal and jps1917 follow
+
+NUMBERINGS = (NUMBERING_MASORAH, NUMBERING_LENINGRAD, NUMBERING_COMMON)
+DEFAULT_NUMBERING = NUMBERING_MASORAH
+
+NUMBERING_PROJECT = {
+    NUMBERING_MASORAH: "miqra_al_pi_hamasorah",
+    NUMBERING_LENINGRAD: "wlc",
+    NUMBERING_COMMON: "jps1917",
+}
+
+# Chapters whose verse count depends on the numbering. Everywhere else the three agree, so
+# hebcal's counts are used directly. Verified against the three projects' own milestones.
+DIVERGENT_CHAPTER_VERSES: dict[tuple[str, int], dict[str, int]] = {
+    ("exodus", 20): {NUMBERING_MASORAH: 22, NUMBERING_LENINGRAD: 26, NUMBERING_COMMON: 23},
+    ("numbers", 10): {NUMBERING_MASORAH: 34, NUMBERING_LENINGRAD: 36, NUMBERING_COMMON: 36},
+    ("numbers", 25): {NUMBERING_MASORAH: 18, NUMBERING_LENINGRAD: 19, NUMBERING_COMMON: 19},
+    ("deuteronomy", 5): {NUMBERING_MASORAH: 29, NUMBERING_LENINGRAD: 33, NUMBERING_COMMON: 30},
+}
+
+
+@functools.cache
+def _verse_counts(sourcetexts_root: Path | None = None) -> dict[str, list[int]]:
+    """Verses per chapter, by hebcal book name. Index 0 is a placeholder, so chapters are 1-based."""
+    path = hebcal_leyning_data_directory(sourcetexts_root) / "numverses.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def verses_in_chapter(
+    book: str,
+    chapter: int,
+    sourcetexts_root: Path | None = None,
+    numbering: str = DEFAULT_NUMBERING,
+) -> int:
+    """How many verses chapter `chapter` of `book` (an opensiddur slug) has.
+
+    hebcal's counts follow the common printed editions, so the four chapters where the
+    editions disagree are looked up separately — using hebcal's count for a MAM-numbered span
+    would run the span past the end of the chapter as MAM divides it.
+    """
+    divergent = DIVERGENT_CHAPTER_VERSES.get((book, chapter))
+    if divergent is not None:
+        return divergent[numbering]
+    counts = _verse_counts(sourcetexts_root)[SLUG_TO_HEBCAL_BOOK[book]]
+    if not 1 <= chapter < len(counts):
+        raise ValueError(f"{book} has no chapter {chapter}")
+    return counts[chapter]
+
+
+def chapters_in_book(book: str, sourcetexts_root: Path | None = None) -> int:
+    return len(_verse_counts(sourcetexts_root)[SLUG_TO_HEBCAL_BOOK[book]]) - 1
+
+
+def previous_verse(
+    ref: VerseRef,
+    sourcetexts_root: Path | None = None,
+    numbering: str = DEFAULT_NUMBERING,
+) -> VerseRef:
+    """The verse before `ref`, stepping back over a chapter boundary when needed.
+
+    Used to close a span at the verse before the next span begins, since the sources mark
+    where each reading starts and leave the end implied.
+    """
+    if ref.verse > 1:
+        return VerseRef(ref.book, ref.chapter, ref.verse - 1)
+    if ref.chapter <= 1:
+        raise ValueError(f"No verse precedes {ref}")
+    chapter = ref.chapter - 1
+    return VerseRef(
+        ref.book, chapter, verses_in_chapter(ref.book, chapter, sourcetexts_root, numbering)
+    )
+
+
+def parse_hebcal_ref(book: str, spec: str) -> VerseRef:
+    """Parse hebcal's ``"chapter:verse"`` form against an opensiddur book slug."""
+    chapter, _, verse = spec.partition(":")
+    return VerseRef(book, int(chapter), int(verse))

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -115,6 +115,17 @@ MEGILLOT: tuple[tuple[str, str, str], ...] = (
     ("esther", "אֶסְתֵּר", "purim"),
 )
 
+# The book names pointed, for headings. As with the parshah names, the table above holds the
+# form to match MAM's text against; a title on the page wants vowels. test_build asserts these
+# differ from it by vowels alone.
+SLUG_TO_VOCALIZED_BOOK: dict[str, str] = {
+    "genesis": "בְּרֵאשִׁית",
+    "exodus": "שְׁמוֹת",
+    "leviticus": "וַיִּקְרָא",
+    "numbers": "בְּמִדְבַּר",
+    "deuteronomy": "דְּבָרִים",
+}
+
 HEBREW_BOOK_TO_SLUG = {hebrew: slug for hebrew, slug, _ in TORAH_BOOKS}
 SLUG_TO_HEBREW_BOOK = {slug: hebrew for hebrew, slug, _ in TORAH_BOOKS}
 SLUG_TO_HEBCAL_BOOK = {slug: english for _, slug, english in TORAH_BOOKS}

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -22,16 +22,45 @@ UNIT_PARSHA = "parsha.annual"
 UNIT_ALIYAH = "aliyah.annual"
 UNIT_WEEKDAY = "aliyah.weekday"
 UNIT_MAFTIR = "maftir.annual"
+
+# The divisions of a week on which two parshiyot are read together. They are a separate
+# division of the same text, not a subdivision of either single: the fourth aliyah of the
+# combined Vayakhel-Pekudei is Exodus 38:1-39:1, which runs straight through the point where
+# Pekudei begins. So they are contained by parsha.combined and not by parsha.annual, which
+# would cut them at that boundary.
+UNIT_PARSHA_COMBINED = "parsha.combined"
+UNIT_ALIYAH_COMBINED = "aliyah.combined"
+UNIT_WEEKDAY_COMBINED = "aliyah.weekday.combined"
+UNIT_MAFTIR_COMBINED = "maftir.combined"
+
 # Each year of the triennial cycle is its own division of the same text, and consecutive
 # years deliberately overlap — in Beshalach, year 1's fifth aliyah and year 2's first are the
 # same verses — so each year needs a unit-space of its own.
 UNIT_TRIENNIAL = "aliyah.triennial"
 UNIT_TRIENNIAL_MAFTIR = "maftir.triennial"
 
+# The variation of a parshah that is sometimes read combined: how it divides depends on
+# whether it was read alone or with its partner in each year of the cycle, so its unit-space
+# carries the variation as well as the year. See readings.triennial.
+VARIATION_COMBINED = "combined"
 
-def triennial_unit(year: int, maftir: bool = False) -> str:
+
+def triennial_unit(
+    year: int,
+    maftir: bool = False,
+    variation: str | None = None,
+    owner: str | None = None,
+) -> str:
+    """The unit-space of one year of one triennial division.
+
+    A parshah that shares a file with its partner names itself as the owner, because the two
+    divide the same file and may cover the same verses: in the cycle hebcal calls IL3, Behar
+    read alone in year 2 is Leviticus 25:39-26:46, which runs well into Bechukotai. Sharing a
+    unit-space would cut one of them short at the other's first marker.
+    """
     base = UNIT_TRIENNIAL_MAFTIR if maftir else UNIT_TRIENNIAL
-    return f"{base}.{year}"
+    parts = [base, owner, variation, str(year)]
+    return ".".join(part for part in parts if part)
 
 # The five books, in order, as MAM names them in Hebrew.
 TORAH_BOOKS: tuple[tuple[str, str, str], ...] = (
@@ -167,6 +196,10 @@ class ReadingSpan:
     # four chapters of DIVERGENT_CHAPTER_VERSES: MAM supplies the weekly aliyot in its own
     # numbering, while everything taken from hebcal follows the common printed editions.
     numbering: str = "masorah"
+    # The reading this span's URN hangs off, where that is not the file it is emitted in. Set
+    # for the two parshiyot of a pair, which share a file but keep their own URN spaces:
+    # without it their identically numbered aliyot would both be .../vayakhel_pekudei/1.
+    owner: str | None = None
 
     @property
     def book(self) -> str:

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -120,6 +120,9 @@ SLUG_TO_HEBREW_BOOK = {slug: hebrew for hebrew, slug, _ in TORAH_BOOKS}
 SLUG_TO_HEBCAL_BOOK = {slug: english for _, slug, english in TORAH_BOOKS}
 HEBCAL_BOOK_TO_SLUG = {english: slug for _, slug, english in TORAH_BOOKS}
 HEBCAL_BOOK_TO_SLUG.update(dict(OTHER_BOOKS))
+# Every book the humash reads from, not only the Torah: a megillah is transcluded as a range
+# over its whole book, which needs that book's verse counts.
+SLUG_TO_HEBCAL_BOOK.update({slug: english for english, slug in OTHER_BOOKS})
 
 # hebcal numbers the Torah books 1-5 in the festival readings.
 BOOK_NUMBER_TO_SLUG = {number: slug for number, (_, slug, _) in enumerate(TORAH_BOOKS, start=1)}

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -14,6 +14,8 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from opensiddur.common import versification
+from opensiddur.common.versification import NUMBERING_COMMON, NUMBERING_MASORAH
 from opensiddur.importer.util.pages import hebcal_leyning_data_directory
 
 # Unit-spaces. These become tei:milestone/@unit, and refdb.UNIT_CONTAINED_BY decides which of
@@ -139,35 +141,12 @@ SLUG_TO_HEBCAL_BOOK.update({slug: english for english, slug in OTHER_BOOKS})
 BOOK_NUMBER_TO_SLUG = {number: slug for number, (_, slug, _) in enumerate(TORAH_BOOKS, start=1)}
 
 
-# Verse numbering conventions, and the project that follows each.
-#
-# Four Torah chapters are divided into verses differently by different editions, because the
-# Decalogue and a few other passages can be grouped by the upper cantillation (ta'am elyon) or
-# the lower (ta'am tachton). The humash therefore emits a variant range per numbering, under
-# conditional control; see model.py. MAM's division is the default, since the aliyah
-# boundaries come from MAM.
-NUMBERING_MASORAH = "masorah"       # Miqra al pi ha-Masorah
-NUMBERING_LENINGRAD = "leningrad"   # Westminster Leningrad Codex
-NUMBERING_COMMON = "common"         # common printed editions, which hebcal and jps1917 follow
-
-NUMBERINGS = (NUMBERING_MASORAH, NUMBERING_LENINGRAD, NUMBERING_COMMON)
-DEFAULT_NUMBERING = NUMBERING_MASORAH
-
-NUMBERING_PROJECT = {
-    NUMBERING_MASORAH: "miqra_al_pi_hamasorah",
-    NUMBERING_LENINGRAD: "wlc",
-    NUMBERING_COMMON: "jps1917",
-}
-
-# Chapters whose verse count depends on the numbering. Everywhere else the three agree, so
-# hebcal's counts are used directly. Verified against each edition's own source rather than
-# against the generated projects: miqra_al_pi_hamasorah's Numbers 10 is short two verses in
-# the project but not in MAM itself, and encoding that would bake a defect into the humash.
-DIVERGENT_CHAPTER_VERSES: dict[tuple[str, int], dict[str, int]] = {
-    ("exodus", 20): {NUMBERING_MASORAH: 22, NUMBERING_LENINGRAD: 26, NUMBERING_COMMON: 23},
-    ("numbers", 25): {NUMBERING_MASORAH: 18, NUMBERING_LENINGRAD: 19, NUMBERING_COMMON: 19},
-    ("deuteronomy", 5): {NUMBERING_MASORAH: 29, NUMBERING_LENINGRAD: 33, NUMBERING_COMMON: 30},
-}
+# The bible URN space has one canonical verse division (opensiddur.common.versification), so
+# every range here is stated in it. The sources are not: MAM gives the weekly aliyot in its own
+# numbering and hebcal gives everything else in the common printed editions', and in the
+# Decalogue and a handful of other chapters those differ from canonical. Each reference is
+# converted where it is read, by _parse_verse_position for MAM and parse_hebcal_ref for hebcal,
+# so that nothing downstream has to carry a numbering at all.
 
 
 @dataclass(frozen=True, order=True)
@@ -207,10 +186,6 @@ class ReadingSpan:
     end: VerseRef
     # Free text from the source noting that other traditions divide differently.
     note: str | None = None
-    # Which edition's verse division the references are stated in. It matters only in the
-    # four chapters of DIVERGENT_CHAPTER_VERSES: MAM supplies the weekly aliyot in its own
-    # numbering, while everything taken from hebcal follows the common printed editions.
-    numbering: str = "masorah"
     # The reading this span's URN hangs off, where that is not the file it is emitted in. Set
     # for the two parshiyot of a pair, which share a file but keep their own URN spaces:
     # without it their identically numbered aliyot would both be .../vayakhel_pekudei/1.
@@ -227,18 +202,6 @@ class ReadingSpan:
         """The book this span lies in. Both ends are always in the same one."""
         return self.start.book
 
-    @property
-    def crosses_divergent_chapter(self) -> bool:
-        """Whether either end lies in a chapter the editions divide differently.
-
-        Only these spans need a per-numbering variant; everywhere else one range serves
-        every edition.
-        """
-        return any(
-            (ref.book, ref.chapter) in DIVERGENT_CHAPTER_VERSES
-            for ref in (self.start, self.end)
-        )
-
     def __post_init__(self):
         if self.start.book != self.end.book:
             raise ValueError(f"{self.unit} {self.label} crosses books: {self.start}-{self.end}")
@@ -253,21 +216,32 @@ def _verse_counts(sourcetexts_root: Path | None = None) -> dict[str, list[int]]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def canonical_ref(numbering: str, ref: VerseRef, at_end: bool = False) -> VerseRef:
+    """`ref`, stated in `numbering`, as a verse of the canonical division.
+
+    An edition verse may cover several canonical ones — MAM reads the four short commandments
+    as a single verse where the canonical division has four — so a reference that opens a
+    reading takes the first of them and one that closes it takes the last.
+    """
+    first, last = versification.to_canonical(numbering, ref.book, ref.chapter, ref.verse)
+    chosen = last if at_end else first
+    return VerseRef(ref.book, chosen.chapter, chosen.verse)
+
+
 def verses_in_chapter(
     book: str,
     chapter: int,
     sourcetexts_root: Path | None = None,
-    numbering: str = DEFAULT_NUMBERING,
 ) -> int:
-    """How many verses chapter `chapter` of `book` (an opensiddur slug) has.
+    """How many verses chapter `chapter` of `book` (an opensiddur slug) has, canonically.
 
-    hebcal's counts follow the common printed editions, so the four chapters where the
-    editions disagree are looked up separately — using hebcal's count for a MAM-numbered span
-    would run the span past the end of the chapter as MAM divides it.
+    hebcal's counts follow the common printed editions, which in a few chapters are coarser
+    than the canonical division: taking hebcal's count for canonical Exodus 20 would end the
+    chapter three verses early.
     """
-    divergent = DIVERGENT_CHAPTER_VERSES.get((book, chapter))
-    if divergent is not None:
-        return divergent[numbering]
+    canonical = versification.CANONICAL_VERSE_COUNTS.get((book, chapter))
+    if canonical is not None:
+        return canonical
     counts = _verse_counts(sourcetexts_root)[SLUG_TO_HEBCAL_BOOK[book]]
     if not 1 <= chapter < len(counts):
         raise ValueError(f"{book} has no chapter {chapter}")
@@ -281,7 +255,6 @@ def chapters_in_book(book: str, sourcetexts_root: Path | None = None) -> int:
 def previous_verse(
     ref: VerseRef,
     sourcetexts_root: Path | None = None,
-    numbering: str = DEFAULT_NUMBERING,
 ) -> VerseRef:
     """The verse before `ref`, stepping back over a chapter boundary when needed.
 
@@ -294,7 +267,7 @@ def previous_verse(
         raise ValueError(f"No verse precedes {ref}")
     chapter = ref.chapter - 1
     return VerseRef(
-        ref.book, chapter, verses_in_chapter(ref.book, chapter, sourcetexts_root, numbering)
+        ref.book, chapter, verses_in_chapter(ref.book, chapter, sourcetexts_root)
     )
 
 
@@ -304,16 +277,20 @@ def previous_verse(
 _HEBCAL_REF = re.compile(r"\s*(\d+)\s*:\s*(\d+)\s*([ab]?)\s*\Z")
 
 
-def parse_hebcal_ref(book: str, spec: str) -> VerseRef:
+def parse_hebcal_ref(book: str, spec: str, at_end: bool = False) -> VerseRef:
     """Parse hebcal's ``"chapter:verse"`` form against an opensiddur book slug.
 
-    A half-verse marker is read as the whole verse containing it, since a URN addresses whole
-    verses; ``hebcal_ref_half`` recovers which half was meant so the reading can say so.
+    hebcal numbers by the common printed editions, so the result is converted to the canonical
+    division the URN space uses. A half-verse marker is read as the whole verse containing it,
+    since a URN addresses whole verses; ``hebcal_ref_half`` recovers which half was meant so
+    the reading can say so.
     """
     match = _HEBCAL_REF.match(spec)
     if match is None:
         raise ValueError(f"Unparseable hebcal reference {spec!r} in {book}")
-    return VerseRef(book, int(match.group(1)), int(match.group(2)))
+    return canonical_ref(
+        NUMBERING_COMMON, VerseRef(book, int(match.group(1)), int(match.group(2))), at_end
+    )
 
 
 def hebcal_ref_half(spec: str) -> str | None:

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -106,6 +106,37 @@ OTHER_BOOKS: tuple[tuple[str, str], ...] = (
     ("Esther", "esther"),
 )
 
+# Unvocalized Hebrew names for the books a haftarah or megillah is drawn from, for citations.
+# Matches the forms miqra_al_pi_hamasorah.convert_tsv.TANAKH_INDEX uses for the same books.
+SLUG_TO_HEBREW_OTHER_BOOK: dict[str, str] = {
+    "joshua": "יהושע",
+    "judges": "שופטים",
+    "samuel_1": "שמואל א",
+    "samuel_2": "שמואל ב",
+    "kings_1": "מלכים א",
+    "kings_2": "מלכים ב",
+    "isaiah": "ישעיהו",
+    "jeremiah": "ירמיהו",
+    "ezekiel": "יחזקאל",
+    "hosea": "הושע",
+    "joel": "יואל",
+    "amos": "עמוס",
+    "obadiah": "עבדיה",
+    "jonah": "יונה",
+    "micah": "מיכה",
+    "nahum": "נחום",
+    "habakkuk": "חבקוק",
+    "zephaniah": "צפניה",
+    "haggai": "חגי",
+    "zechariah": "זכריה",
+    "malachi": "מלאכי",
+    "song_of_songs": "שיר השירים",
+    "ruth": "רות",
+    "lamentations": "איכה",
+    "ecclesiastes": "קהלת",
+    "esther": "אסתר",
+}
+
 # The five megillot, each with the occasion it is read on and its Hebrew title. The occasion
 # names are features of the existing opensiddur:holiday feature structure.
 MEGILLOT: tuple[tuple[str, str, str], ...] = (
@@ -130,6 +161,10 @@ SLUG_TO_VOCALIZED_BOOK: dict[str, str] = {
 
 HEBREW_BOOK_TO_SLUG = {hebrew: slug for hebrew, slug, _ in TORAH_BOOKS}
 SLUG_TO_HEBREW_BOOK = {slug: hebrew for hebrew, slug, _ in TORAH_BOOKS}
+
+# Every book the humash reads from, Torah or not, for citations (build._citation).
+SLUG_TO_HEBREW_ANY_BOOK: dict[str, str] = {**SLUG_TO_HEBREW_BOOK, **SLUG_TO_HEBREW_OTHER_BOOK}
+
 SLUG_TO_HEBCAL_BOOK = {slug: english for _, slug, english in TORAH_BOOKS}
 HEBCAL_BOOK_TO_SLUG = {english: slug for _, slug, english in TORAH_BOOKS}
 HEBCAL_BOOK_TO_SLUG.update(dict(OTHER_BOOKS))
@@ -269,6 +304,22 @@ def previous_verse(
     return VerseRef(
         ref.book, chapter, verses_in_chapter(ref.book, chapter, sourcetexts_root)
     )
+
+
+def next_verse(
+    ref: VerseRef,
+    sourcetexts_root: Path | None = None,
+) -> VerseRef:
+    """The verse after `ref`, stepping over a chapter boundary when needed.
+
+    Used to tell whether one reading span continues directly into the next, or whether the
+    reading skips or backtracks between them.
+    """
+    if ref.verse < verses_in_chapter(ref.book, ref.chapter, sourcetexts_root):
+        return VerseRef(ref.book, ref.chapter, ref.verse + 1)
+    if ref.chapter >= chapters_in_book(ref.book, sourcetexts_root):
+        raise ValueError(f"No verse follows {ref}")
+    return VerseRef(ref.book, ref.chapter + 1, 1)
 
 
 # hebcal writes a boundary that falls inside a verse as a letter after the verse number: the

--- a/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/miqra_to_tei.xslt
@@ -103,6 +103,14 @@
     <xsl:variable name="editionVerse" select="string(@editionVerse)"/>
     <xsl:variable name="editionVerseStart" select="string(@editionVerseStart)"/>
     <xsl:variable name="fileName" select="string(ancestor::miqra:book/@fileName)"/>
+    <!-- Whether this row opens a new chapter, decided here against the real source tree
+         (preceding-sibling::miqra:row) rather than downstream against the constructed
+         miqra:verse elements: those are built by independent element constructors inside
+         the $blocks variable in the calling template, so they are not one tree and
+         preceding:: cannot see across them there. -->
+    <xsl:variable name="opens-chapter" select="
+        not(preceding-sibling::miqra:row[1])
+        or preceding-sibling::miqra:row[1]/normalize-space(@chapter) != $chapter"/>
     <!-- The rest of the column C/D notes annotate the row — a break another witness has
          but MAM does not, a seder marker, a free {{מ:הערה}} — rather than a point in the
          verse, so they anchor at the head of the verse. Without this the standOff note
@@ -140,7 +148,8 @@
             <miqra:verse chapter="{$chapter}" verse="{$verse}" fileName="{$fileName}"
                          editionVerse="{$editionVerse}"
                          editionVerseStart="{$editionVerseStart}"
-                         opensVerse="{if ($position = $first-group) then 'true' else 'false'}">
+                         opensVerse="{if ($position = $first-group) then 'true' else 'false'}"
+                         opensChapter="{if ($opens-chapter) then 'true' else 'false'}">
               <xsl:copy-of select="$content"/>
             </miqra:verse>
           </xsl:if>
@@ -150,7 +159,8 @@
         <miqra:verse chapter="{$chapter}" verse="{$verse}" fileName="{$fileName}"
                      editionVerse="{$editionVerse}"
                      editionVerseStart="{$editionVerseStart}"
-                     opensVerse="true">
+                     opensVerse="true"
+                     opensChapter="{if ($opens-chapter) then 'true' else 'false'}">
           <xsl:copy-of select="$text-nodes[not(self::miqra:note)]"/>
         </miqra:verse>
       </xsl:otherwise>
@@ -207,6 +217,22 @@
     <xsl:variable name="verse" select="normalize-space(@verse)"/>
     <xsl:variable name="editionVerse" select="normalize-space(@editionVerse)"/>
     <xsl:if test="miqra:has-verse-ref($chapter, $verse)">
+      <xsl:if test="@opensVerse = 'true' and @opensChapter = 'true'">
+        <!-- A chapter milestone has no representation of its own in MAM's source; @opensChapter
+             is computed in mode="flatten", against the real miqra:row source tree, because by
+             the time verses reach this template they are independent nodes built by separate
+             element constructors and so cannot be compared by document order (preceding::)
+             against one another. wlc emits the same unit from its own explicit c/@n; see
+             transform_book.xslt. -->
+        <tei:milestone unit="chapter" n="{$chapter}">
+          <xsl:attribute name="corresp">
+            <xsl:text>urn:x-opensiddur:text:bible:</xsl:text>
+            <xsl:value-of select="@fileName"/>
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="$chapter"/>
+          </xsl:attribute>
+        </tei:milestone>
+      </xsl:if>
       <xsl:if test="@editionVerseStart = 'true' and @opensVerse = 'true'
                     and $editionVerse != '' and $editionVerse != $verse">
         <tei:milestone unit="edition-verse" n="{$editionVerse}"/>

--- a/opensiddur/importer/util/pages.py
+++ b/opensiddur/importer/util/pages.py
@@ -29,6 +29,16 @@ def jps1917_credits_directory(sourcetexts_root: Path | None = None) -> Path:
     return jps1917_data_directory(sourcetexts_root) / "credits"
 
 
+def hebcal_leyning_data_directory(sourcetexts_root: Path | None = None) -> Path:
+    """hebcal leyning raw data: <sourcetexts-root>/hebcal_leyning."""
+    root = (
+        sourcetexts_root.resolve()
+        if sourcetexts_root is not None
+        else default_sourcetexts_root()
+    )
+    return root / "hebcal_leyning"
+
+
 def miqra_al_pi_hamasorah_data_directory(sourcetexts_root: Path | None = None) -> Path:
     """Miqra al pi ha-Masorah raw dumps: <sourcetexts-root>/miqra_al_pi_hamasorah."""
     root = (

--- a/opensiddur/tests/exporter/test_calendar_compute.py
+++ b/opensiddur/tests/exporter/test_calendar_compute.py
@@ -229,6 +229,34 @@ class TestComputeFunctions(unittest.TestCase):
         self.assertIn("diaspora-parsha", result)
         self.assertIn("shabbat-shuva", result)
 
+    def test_triennial_pattern_describes_the_whole_cycle(self):
+        """One character per year of the cycle: T where the pair was read together, S apart."""
+        snap = _snapshot({
+            (FS_GREGORIAN, "year"): 2025,
+            (FS_GREGORIAN, "month"): 11,
+            (FS_GREGORIAN, "day"): 1,
+        })
+        result = compute_torah_reading(snap)
+        # 5786 opens a cycle. Vayakhel and Pekudei are read together in its first and third
+        # years and apart in its second, so only that year's variation of each is read.
+        self.assertEqual(result["triennial-pattern-vayakhel-pekudei"], "TST")
+        # A pair that always falls together over a cycle needs no variation at all.
+        self.assertEqual(result["triennial-pattern-matot-masei"], "TTT")
+        self.assertEqual(len(result["triennial-pattern-behar-bechukotai"]), 3)
+
+    def test_triennial_pattern_follows_the_israel_reckoning(self):
+        """Israel and the diaspora fall a week apart after a festival on Shabbat."""
+        date = {
+            (FS_GREGORIAN, "year"): 2025,
+            (FS_GREGORIAN, "month"): 11,
+            (FS_GREGORIAN, "day"): 1,
+        }
+        diaspora = compute_torah_reading(_snapshot({**date, (FS_ISRAEL, "is-israel"): False}))
+        israel = compute_torah_reading(_snapshot({**date, (FS_ISRAEL, "is-israel"): True}))
+        self.assertEqual(diaspora["triennial-pattern-chukat-balak"], "TTS")
+        # Chukat and Balak are never combined in Israel.
+        self.assertEqual(israel["triennial-pattern-chukat-balak"], "SSS")
+
     def test_holiday_multiday_pesach_and_sukkot(self):
         pesach_ii = _snapshot({
             (FS_GREGORIAN, "year"): 2024,

--- a/opensiddur/tests/exporter/test_derived_settings.py
+++ b/opensiddur/tests/exporter/test_derived_settings.py
@@ -5,8 +5,14 @@ import unittest
 from pathlib import Path
 
 import yaml
+from lxml import etree
 
 from opensiddur.exporter.compiler import CompilerProcessor
+from opensiddur.exporter.condition_eval import (
+    TriState,
+    evaluate_condition,
+    parse_condition_element,
+)
 from opensiddur.exporter.conditional_settings import (
     INIT_DECLARE_ID,
     yaml_to_declaration_entries,
@@ -287,6 +293,39 @@ class TestGoldenCalendarDates(unittest.TestCase):
         )
         self.assertEqual(
             get_active_setting_entry(self.linear_data, "opensiddur:holiday", "pesah").value, 1
+        )
+
+    def test_a_triennial_variation_condition_selects_on_the_declared_date(self):
+        """The condition the humash puts on the twelve doubled parshiyot, end to end.
+
+        A parshah that is sometimes read with its partner divides differently depending on how
+        the pair fell across the cycle, so each division is conditioned on the patterns that
+        select it. With a date declared, only the live one survives.
+        """
+        def condition(*patterns: str):
+            alternatives = "".join(
+                f'<tei:fs type="opensiddur:torah-reading">'
+                f'<tei:f name="triennial-pattern-vayakhel-pekudei">'
+                f"<tei:string>{pattern}</tei:string></tei:f></tei:fs>"
+                for pattern in patterns
+            )
+            element = etree.fromstring(
+                f'<j:conditional xmlns:j="{J}" xmlns:tei="{TEI}" xml:id="c">'
+                f"<j:any>{alternatives}</j:any></j:conditional>".encode()
+            )
+            return parse_condition_element(element)
+
+        processor = CompilerProcessor.__new__(CompilerProcessor)
+        processor.linear_data = self.linear_data
+
+        # Undeclared, every variation is kept, the way an undeclared rite keeps every rite.
+        self.assertEqual(evaluate_condition(condition("TSS"), processor), TriState.UNDEFINED)
+
+        # 5786 opens a cycle in which the pair falls together, apart, together.
+        self._load({"opensiddur:gregorian-date": {"year": 2025, "month": 11, "day": 1}})
+        self.assertEqual(evaluate_condition(condition("TST"), processor), TriState.TRUE)
+        self.assertEqual(
+            evaluate_condition(condition("TSS", "SSS"), processor), TriState.FALSE
         )
 
     def test_torah_reading_parsha(self):

--- a/opensiddur/tests/exporter/test_derived_settings.py
+++ b/opensiddur/tests/exporter/test_derived_settings.py
@@ -75,6 +75,107 @@ class TestDerivedSettingsFramework(unittest.TestCase):
         self.assertTrue(entry.value)
         self.assertEqual(entry.source, "init")
 
+    CYCLE = "opensiddur:reading-cycle"
+
+    def _cycle(self) -> dict[str, object]:
+        """Which readings the volume carries, as a plain dict."""
+        return {
+            feature: get_active_setting_entry(self.linear_data, self.CYCLE, feature).value
+            for feature in
+            ("annual", "triennial-year-1", "triennial-year-2", "triennial-year-3")
+        }
+
+    def test_reading_cycle_defaults_to_the_annual_reading_alone(self):
+        """These cannot be left undefined the way opensiddur:rite is.
+
+        The annual haftarah and the three triennial ones are read on the same Shabbat, and an
+        undefined condition keeps its text, so an open feature here would print all four.
+        """
+        recalculate_derived_settings(self.linear_data, trigger=SettingChangeTrigger.INIT)
+        self.assertEqual(self._cycle(), {
+            "annual": True,
+            "triennial-year-1": False,
+            "triennial-year-2": False,
+            "triennial-year-3": False,
+        })
+
+    def test_a_date_alone_selects_no_triennial_year(self):
+        """Every date falls in some year of the cycle, including an annual volume's."""
+        CompilerProcessor.load_init_settings(
+            self.linear_data,
+            yaml_to_declaration_entries({
+                "opensiddur:gregorian-date": {"year": 2026, "month": 1, "day": 3},
+            }),
+        )
+        self.assertEqual(self._cycle()["annual"], True)
+        self.assertEqual(self._cycle()["triennial-year-1"], False)
+
+    def test_a_triennial_volume_takes_its_year_from_the_date(self):
+        """5788 is the third year of the cycle, and the annual reading gives way to it."""
+        CompilerProcessor.load_init_settings(
+            self.linear_data,
+            yaml_to_declaration_entries({
+                "opensiddur:gregorian-date": {"year": 2028, "month": 1, "day": 8},
+                "opensiddur:reading-cycle": {"triennial": True},
+            }),
+        )
+        self.assertEqual(self._cycle(), {
+            "annual": False,
+            "triennial-year-1": False,
+            "triennial-year-2": False,
+            "triennial-year-3": True,
+        })
+
+    def test_a_volume_for_a_whole_cycle_keeps_all_three_years(self):
+        """A printed humash covering a cycle turns on every year; a date would allow only one."""
+        CompilerProcessor.load_init_settings(
+            self.linear_data,
+            yaml_to_declaration_entries({
+                "opensiddur:reading-cycle": {
+                    "annual": False,
+                    "triennial-year-1": True,
+                    "triennial-year-2": True,
+                    "triennial-year-3": True,
+                },
+            }),
+        )
+        self.assertEqual(self._cycle(), {
+            "annual": False,
+            "triennial-year-1": True,
+            "triennial-year-2": True,
+            "triennial-year-3": True,
+        })
+
+    def test_a_declared_year_wins_over_the_date(self):
+        CompilerProcessor.load_init_settings(
+            self.linear_data,
+            yaml_to_declaration_entries({
+                "opensiddur:gregorian-date": {"year": 2026, "month": 1, "day": 3},
+                "opensiddur:reading-cycle": {"triennial": True, "triennial-year-2": True},
+            }),
+        )
+        self.assertEqual(self._cycle()["triennial-year-2"], True)
+
+    def test_triennial_year_is_derived_from_the_date(self):
+        """The cycle is counted from 5756, so 5786 opens one and 5788 closes it."""
+        for gregorian, expected in (((2026, 1, 3), 1), ((2028, 1, 8), 3)):
+            with self.subTest(date=gregorian):
+                reset_linear_data()
+                linear_data = get_linear_data()
+                year, month, day = gregorian
+                CompilerProcessor.load_init_settings(
+                    linear_data,
+                    yaml_to_declaration_entries({
+                        "opensiddur:gregorian-date": {
+                            "year": year, "month": month, "day": day
+                        },
+                    }),
+                )
+                entry = get_active_setting_entry(
+                    linear_data, "opensiddur:torah-reading", "triennial-year"
+                )
+                self.assertEqual(entry.value, expected)
+
     def test_secular_day_from_gregorian_init(self):
         CompilerProcessor.load_init_settings(
             self.linear_data,

--- a/opensiddur/tests/exporter/test_external_compiler.py
+++ b/opensiddur/tests/exporter/test_external_compiler.py
@@ -1592,6 +1592,68 @@ class TestExternalCompilerProcessor(unittest.TestCase):
             self.assertTrue(len(paragraph) or (paragraph.text or "").strip(),
                             "No empty paragraph shells")
 
+    # A chapter milestone sits immediately before the verse-1 milestone that opens a new
+    # chapter, the way miqra_to_tei.xslt emits it. @unit (not @type, as MULTI_PARAGRAPH_SOURCE
+    # above uses) is what refdb.UNIT_CONTAINED_BY and the boundary check key off of.
+    CHAPTER_BOUNDARY_SOURCE = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="he">
+    <tei:text>
+        <tei:body>
+            <tei:div type="book">
+                <tei:p><tei:milestone unit="verse" n="10" corresp="urn:x-opensiddur:text:bible:book/1/10"/> Chapter 1 verse 10
+                    <tei:milestone unit="chapter" n="2" corresp="urn:x-opensiddur:text:bible:book/2"/>
+                    <tei:milestone unit="verse" n="1" corresp="urn:x-opensiddur:text:bible:book/2/1"/> Chapter 2 verse 1
+                    <tei:milestone unit="verse" n="2" corresp="urn:x-opensiddur:text:bible:book/2/2"/> Chapter 2 verse 2</tei:p>
+            </tei:div>
+        </tei:body>
+    </tei:text>
+</tei:TEI>'''
+
+    def test_a_chapter_milestone_opening_the_range_start_is_included(self):
+        """A range beginning exactly at a new chapter's first verse must still carry the
+        chapter milestone that announces it, even though it is a preceding sibling."""
+        xml_bytes = self.CHAPTER_BOUNDARY_SOURCE.encode('utf-8')
+        project, file_name = self._create_test_file("chapter_boundary.xml", xml_bytes)
+
+        root = etree.fromstring(xml_bytes)
+        tree = root.getroottree()
+        start_milestone = root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/2/1']")[0]
+        end_milestone = root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/2/2']")[0]
+        from_start = tree.getpath(start_milestone)
+        end_path, include_tail = find_end_of_mapping(end_milestone)
+
+        processor = ExternalCompilerProcessor(
+            project, file_name, from_start, end_path, include_tail_after_end=include_tail)
+        result = processor.process()
+        result_str = ''.join(etree.tostring(elem, encoding='unicode') for elem in result)
+
+        self.assertIn('unit="chapter" n="2" corresp="urn:x-opensiddur:text:bible:book/2"',
+                       result_str)
+        self.assertIn("Chapter 2 verse 1", result_str)
+        self.assertNotIn("Chapter 1 verse 10", result_str)
+
+    def test_a_verse_milestone_before_the_range_start_is_still_excluded(self):
+        """The chapter-boundary exception must not reopen #51: an ordinary preceding verse
+        milestone (not a container of the start's unit) still gets no empty shell."""
+        xml_bytes = self.CHAPTER_BOUNDARY_SOURCE.encode('utf-8')
+        project, file_name = self._create_test_file("chapter_boundary2.xml", xml_bytes)
+
+        root = etree.fromstring(xml_bytes)
+        tree = root.getroottree()
+        # Start at chapter 2 verse 2: verse 1's milestone immediately precedes it, but a
+        # verse does not contain another verse, so it must still be excluded.
+        start_milestone = root.xpath("//*[@corresp='urn:x-opensiddur:text:bible:book/2/2']")[0]
+        from_start = tree.getpath(start_milestone)
+        end_path, include_tail = find_end_of_mapping(start_milestone)
+
+        processor = ExternalCompilerProcessor(
+            project, file_name, from_start, end_path, include_tail_after_end=include_tail)
+        result = processor.process()
+        result_str = ''.join(etree.tostring(elem, encoding='unicode') for elem in result)
+
+        self.assertNotIn('corresp="urn:x-opensiddur:text:bible:book/2/1"', result_str)
+        self.assertNotIn("Chapter 2 verse 1", result_str)
+        self.assertIn("Chapter 2 verse 2", result_str)
+
     def test_range_keeps_declarations_made_before_the_start(self):
         """A j:declare preceding the range inside the DCA is still in scope in the range."""
         xml_bytes = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:j="http://jewishliturgy.org/ns/jlptei/2" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="he">

--- a/opensiddur/tests/exporter/test_latex.py
+++ b/opensiddur/tests/exporter/test_latex.py
@@ -102,6 +102,14 @@ class TestLicensesToTex(unittest.TestCase):
         self.assertIn("CC", out)
         self.assertIn(r"\url{http://creativecommons.org/cc}", out)
 
+    def test_no_licences_emits_nothing(self):
+        """An itemize with no items is a LaTeX error and kills the run before any PDF.
+
+        A document can genuinely have no licences to list — one built entirely of public
+        domain text, or compiled without annotations.
+        """
+        self.assertEqual(licenses_to_tex([]), "")
+
 
 class TestExtractCredits(unittest.TestCase):
 

--- a/opensiddur/tests/exporter/test_marker_reconstruct.py
+++ b/opensiddur/tests/exporter/test_marker_reconstruct.py
@@ -109,6 +109,40 @@ class TestMarkerReconstruct(unittest.TestCase):
         p = root.find(f".//{{{TEI_NS}}}p")
         self.assertTrue(substantive_content(p))
 
+    def test_substantive_content_bare_milestone(self):
+        """A milestone with no text of its own (e.g. a chapter marker) still counts: it
+        is a deliberate marker, never filler, even though it carries no text."""
+        xml = f"""<tei:TEI xmlns:tei="{TEI_NS}">
+          <tei:p><tei:milestone unit="chapter" n="5"/></tei:p>
+        </tei:TEI>"""
+        root = etree.fromstring(xml.encode())
+        p = root.find(f".//{{{TEI_NS}}}p")
+        self.assertTrue(substantive_content(p))
+
+    def test_a_bare_milestone_fragment_is_not_pruned(self):
+        """A source tei:p that a chapter-boundary milestone splits into three parallel-row
+        fragments (verses before, the bare milestone alone, verses after) reconstructs into
+        three same-logical-id fragments. The middle one carries no text of its own — this
+        is what silently erased chapter numbers from the compiled humash, wherever one
+        landed alone between two verse-aligned parallel segments like this."""
+        ns = {"tei": TEI_NS, "p": P_NS}
+        xml = f"""<tei:TEI xmlns:tei="{TEI_NS}" xmlns:p="{P_NS}">
+          <tei:text><tei:body>
+            <tei:p p:logical-id="a" p:part="first">before</tei:p>
+            <tei:p p:logical-id="a" p:part="middle"><tei:milestone unit="chapter" n="6"/></tei:p>
+            <tei:p p:logical-id="a" p:part="last">after</tei:p>
+          </tei:body></tei:text></tei:TEI>"""
+        root = etree.fromstring(xml.encode())
+        from opensiddur.exporter.marker_reconstruct import normalize_segment_parts
+        normalize_segment_parts(root)
+        ps = root.xpath("//tei:p", namespaces=ns)
+        self.assertEqual(len(ps), 3, "the milestone-only fragment must survive")
+        milestones = root.xpath("//tei:milestone[@unit='chapter']", namespaces=ns)
+        self.assertEqual(len(milestones), 1)
+        self.assertEqual(milestones[0].get("n"), "6")
+        # Still ordered first/middle/last across all three surviving fragments.
+        self.assertEqual([p.get(f"{{{P_NS}}}part") for p in ps], ["first", "middle", "last"])
+
     def test_substantive_content_nested_child_text(self):
         xml = f"""<tei:TEI xmlns:tei="{TEI_NS}">
           <tei:p><tei:hi><tei:seg>deep</tei:seg></tei:hi></tei:p>

--- a/opensiddur/tests/exporter/test_refdb.py
+++ b/opensiddur/tests/exporter/test_refdb.py
@@ -1121,6 +1121,38 @@ class TestMilestoneScoping(unittest.TestCase):
         )
         self.assertTrue(self._scope_end(aliyah7).endswith("seg[1]"))
 
+    def test_a_combined_aliyah_crosses_the_parsha_it_runs_into(self):
+        """Two parshiyot read together divide as one reading, across the boundary between them."""
+        combined1, _second_parsha, _combined2 = self._document(
+            ("aliyah.combined", "4",
+             "urn:x-opensiddur:text:bible:parsha/vayakhel_pekudei/aliyah_combined/4"),
+            ("parsha.annual", "pekudei", "urn:x-opensiddur:text:bible:parsha/pekudei"),
+            ("aliyah.combined", "5",
+             "urn:x-opensiddur:text:bible:parsha/vayakhel_pekudei/aliyah_combined/5"),
+        )
+        # Runs past where Pekudei begins, to the next combined aliyah.
+        self.assertTrue(self._scope_end(combined1).endswith("seg[2]"))
+
+    def test_a_combined_reading_ends_the_divisions_it_contains(self):
+        combined_aliyah, _pair = self._document(
+            ("aliyah.combined", "7",
+             "urn:x-opensiddur:text:bible:parsha/vayakhel_pekudei/aliyah_combined/7"),
+            ("parsha.combined", "chukat_balak",
+             "urn:x-opensiddur:text:bible:parsha/chukat_balak"),
+        )
+        self.assertTrue(self._scope_end(combined_aliyah).endswith("seg[1]"))
+
+    def test_a_triennial_variation_is_scoped_by_the_pair_not_by_either_parshah(self):
+        """Behar read alone in one cycle runs into Bechukotai, so the pair is what ends it."""
+        variation, _second_parsha, _pair = self._document(
+            ("aliyah.triennial.behar.IL3.2", "IL3.2.7",
+             "urn:x-opensiddur:text:bible:parsha/behar/aliyah_triennial_behar_IL3_2/il3.2.7"),
+            ("parsha.annual", "bechukotai", "urn:x-opensiddur:text:bible:parsha/bechukotai"),
+            ("parsha.combined", "behar_bechukotai",
+             "urn:x-opensiddur:text:bible:parsha/behar_bechukotai"),
+        )
+        self.assertTrue(self._scope_end(variation).endswith("seg[2]"))
+
     def test_falls_back_to_urn_depth_without_units(self):
         """Milestones with no @unit keep the original URN-depth heuristic."""
         verse, _chapter = self._document(

--- a/opensiddur/tests/exporter/test_refdb.py
+++ b/opensiddur/tests/exporter/test_refdb.py
@@ -1024,6 +1024,127 @@ class TestReferenceDatabaseReferences(unittest.TestCase):
         self.assertEqual(element_tags, {"{http://www.tei-c.org/ns/1.0}ptr", "{http://www.tei-c.org/ns/1.0}note"})
 
 
+class TestMilestoneScoping(unittest.TestCase):
+    """Test that a milestone's URN scope ends at the right following milestone.
+
+    A milestone scopes to the next milestone of the same unit, or of a unit that contains it.
+    Reading divisions overlap on purpose, so they must not terminate each other.
+    """
+
+    TEI = "http://www.tei-c.org/ns/1.0"
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.db = ReferenceDatabase(Path(self.temp_dir.name) / 'test_urn.db')
+        self.addCleanup(self.db.close)
+
+    def _document(self, *milestones: tuple[str, str, str]) -> list[ElementBase]:
+        """Build a doc of `(unit, n, corresp)` milestones separated by text-bearing segs.
+
+        Returns the milestone elements in document order.
+        """
+        root = etree.Element(f"{{{self.TEI}}}TEI")
+        text = etree.SubElement(root, f"{{{self.TEI}}}text")
+        body = etree.SubElement(text, f"{{{self.TEI}}}body")
+        created = []
+        for index, (unit, n, corresp) in enumerate(milestones):
+            milestone = etree.SubElement(body, f"{{{self.TEI}}}milestone")
+            if unit is not None:
+                milestone.set("unit", unit)
+            milestone.set("n", n)
+            milestone.set("corresp", corresp)
+            created.append(milestone)
+            seg = etree.SubElement(body, f"{{{self.TEI}}}seg")
+            seg.set("{http://www.w3.org/XML/1998/namespace}id", f"seg{index}")
+            seg.text = f"text {index}"
+        return created
+
+    def _scope_end(self, milestone: ElementBase) -> str:
+        end_path, _ = self.db._find_end_of_mapping(milestone)
+        return end_path
+
+    def test_verse_ends_at_next_verse(self):
+        verse1, _verse2 = self._document(
+            ("verse", "1", "urn:x-opensiddur:text:bible:genesis/1/1"),
+            ("verse", "2", "urn:x-opensiddur:text:bible:genesis/1/2"),
+        )
+        self.assertTrue(self._scope_end(verse1).endswith("seg[1]"))
+
+    def test_verse_ends_at_next_chapter(self):
+        """A chapter contains verses, so it closes the last verse of the previous chapter.
+
+        Without this, a range ending on a chapter boundary would swallow the following
+        chapter milestone and render a spurious chapter number.
+        """
+        verse, _chapter = self._document(
+            ("verse", "31", "urn:x-opensiddur:text:bible:genesis/1/31"),
+            ("chapter", "2", "urn:x-opensiddur:text:bible:genesis/2"),
+        )
+        self.assertTrue(self._scope_end(verse).endswith("seg[1]"))
+
+    def test_chapter_does_not_end_at_verse(self):
+        """Containment is one-directional: a verse must not close the chapter holding it."""
+        chapter, _verse, _next_chapter = self._document(
+            ("chapter", "1", "urn:x-opensiddur:text:bible:genesis/1"),
+            ("verse", "1", "urn:x-opensiddur:text:bible:genesis/1/1"),
+            ("chapter", "2", "urn:x-opensiddur:text:bible:genesis/2"),
+        )
+        # Ends just before chapter 2, i.e. after the second seg, not the first.
+        self.assertTrue(self._scope_end(chapter).endswith("seg[2]"))
+
+    def test_maftir_does_not_end_the_seventh_aliyah(self):
+        """Maftir re-reads the close of aliyah 7; it opens inside it rather than ending it."""
+        aliyah7, _maftir, _parsha = self._document(
+            ("aliyah.annual", "7", "urn:x-opensiddur:text:bible:parsha/bereshit/aliyah/7"),
+            ("maftir.annual", "maftir", "urn:x-opensiddur:text:bible:parsha/bereshit/maftir"),
+            ("parsha.annual", "noach", "urn:x-opensiddur:text:bible:parsha/noach"),
+        )
+        # Runs past the maftir milestone to the end of the parsha.
+        self.assertTrue(self._scope_end(aliyah7).endswith("seg[2]"))
+
+    def test_overlapping_reading_schemes_do_not_terminate_each_other(self):
+        """Weekday and triennial aliyot subdivide/cut across the annual ones."""
+        annual1, _weekday2, _triennial1, _annual2 = self._document(
+            ("aliyah.annual", "1", "urn:x-opensiddur:text:bible:parsha/bereshit/aliyah/1"),
+            ("aliyah.weekday", "2", "urn:x-opensiddur:text:bible:parsha/bereshit/weekday/2"),
+            ("aliyah.triennial", "1", "urn:x-opensiddur:text:bible:parsha/bereshit/triennial/1/1"),
+            ("aliyah.annual", "2", "urn:x-opensiddur:text:bible:parsha/bereshit/aliyah/2"),
+        )
+        self.assertTrue(self._scope_end(annual1).endswith("seg[3]"))
+
+    def test_parsha_ends_an_aliyah(self):
+        """Aliyot do not cross parsha boundaries."""
+        aliyah7, _parsha = self._document(
+            ("aliyah.annual", "7", "urn:x-opensiddur:text:bible:parsha/bereshit/aliyah/7"),
+            ("parsha.annual", "noach", "urn:x-opensiddur:text:bible:parsha/noach"),
+        )
+        self.assertTrue(self._scope_end(aliyah7).endswith("seg[1]"))
+
+    def test_falls_back_to_urn_depth_without_units(self):
+        """Milestones with no @unit keep the original URN-depth heuristic."""
+        verse, _chapter = self._document(
+            (None, "1", "urn:x-opensiddur:text:prayer:ashrei/1/1"),
+            (None, "2", "urn:x-opensiddur:text:prayer:ashrei/2"),
+        )
+        self.assertTrue(self._scope_end(verse).endswith("seg[1]"))
+
+    def test_unknown_unit_falls_back_to_urn_depth(self):
+        """A unit absent from the containment table still terminates by URN depth."""
+        first, _second = self._document(
+            ("stanza", "1", "urn:x-opensiddur:text:poem:example/1"),
+            ("stanza", "2", "urn:x-opensiddur:text:poem:example/2"),
+        )
+        self.assertTrue(self._scope_end(first).endswith("seg[1]"))
+
+    def test_scope_runs_to_end_of_file_when_nothing_terminates(self):
+        only, = self._document(
+            ("aliyah.annual", "1", "urn:x-opensiddur:text:bible:parsha/bereshit/aliyah/1"),
+        )
+        # A lone seg carries no positional predicate in the lxml path.
+        self.assertTrue(self._scope_end(only).endswith("seg"))
+
+
 class TestReferenceDatabaseContextManager(unittest.TestCase):
     """Test Reference Database context manager functionality."""
 

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -1012,9 +1012,12 @@ class TestStructuralElements(unittest.TestCase):
           </tei:body></tei:text>
         </tei:TEI>"""
         out = _transform(xml)
+        # "42" and "5" must wrap as a single LTR run, not two side by side: two separate
+        # embeds with only a colon between them can have their *relative* order swapped by
+        # the bidi algorithm (this is what previously rendered "42:5" as "43:10-42:5" in a
+        # citation — see TestCitationMilestone.test_a_multi_number_range_stays_in_order).
         self.assertIn(
-            r"\OSheadA{ישעיהו {{\textdir TLT\selectlanguage{english}42}}:"
-            r"{{\textdir TLT\selectlanguage{english}5}}}",
+            r"\OSheadA{ישעיהו {{\textdir TLT\selectlanguage{english}42:5}}}",
             out,
         )
 
@@ -1382,11 +1385,32 @@ class TestCitationMilestone(unittest.TestCase):
                <tei:p><tei:milestone unit="verse" n="1"/>text</tei:p>"""
         )
         body = self._body(out)
-        self.assertIn(r"{\textdir TLT\selectlanguage{english}42}", body)
-        # A hyphen joins adjacent digit runs into one LTR-wrapped group, the same way
-        # f:emit-bidi-text already treats a hyphenated siglum like "EVR-II-B-8".
-        self.assertIn(r"{\textdir TLT\selectlanguage{english}5-43}", body)
-        self.assertIn(r"{\textdir TLT\selectlanguage{english}10}", body)
+        self.assertIn(r"{\textdir TLT\selectlanguage{english}42:5-43:10}", body)
+
+    def test_a_multi_number_range_stays_in_order(self):
+        """Two colon/dash-joined number groups sitting side by side in RTL text, with no
+        strong character between them to anchor on, do not reliably keep their relative
+        order if wrapped as separate LTR embeds: "42:5-43:10" can come out as "43:10-42:5".
+        The whole range must go in one embedding instead — see f:emit-bidi-text."""
+        out = self._transform_body(
+            """<tei:milestone unit="citation" n="ירמיהו 34:8–34:22; 33:25–33:26"/>
+               <tei:p><tei:milestone unit="verse" n="1"/>text</tei:p>"""
+        )
+        body = self._body(out)
+        self.assertIn(
+            r"{\textdir TLT\selectlanguage{english}34:8–34:22; 33:25–33:26}", body,
+        )
+
+    def test_a_book_change_still_gets_its_own_wrap(self):
+        """A Hebrew book name between two ranges is a strong character, so it is safe to
+        end one LTR run and start a fresh one there rather than merging across it."""
+        out = self._transform_body(
+            """<tei:milestone unit="citation" n="מלכים א 18:46; מלאכי 3:4–3:24"/>
+               <tei:p><tei:milestone unit="verse" n="1"/>text</tei:p>"""
+        )
+        body = self._body(out)
+        self.assertIn(r"{\textdir TLT\selectlanguage{english}18:46}", body)
+        self.assertIn(r"{\textdir TLT\selectlanguage{english}3:4–3:24}", body)
 
     def test_a_citation_does_not_break_the_reading(self):
         """The reading's own transcluded text still follows in the numbered stream."""

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -999,6 +999,25 @@ class TestStructuralElements(unittest.TestCase):
             out,
         )
 
+    def test_digits_embedded_in_a_hebrew_head_are_forced_ltr(self):
+        """A Hebrew heading was never expected to carry a number before, so digits in it
+        went out unwrapped and would render reversed (e.g. "42:5" as "5:24")."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="he">
+          <tei:text><tei:body>
+            <tei:div type="book">
+              <tei:head>ישעיהו 42:5</tei:head>
+              <tei:p><tei:milestone unit="verse" n="1"/>בְּרֵאשִׁית</tei:p>
+            </tei:div>
+          </tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml)
+        self.assertIn(
+            r"\OSheadA{ישעיהו {{\textdir TLT\selectlanguage{english}42}}:"
+            r"{{\textdir TLT\selectlanguage{english}5}}}",
+            out,
+        )
+
 
 class TestFrontMatter(unittest.TestCase):
     """``tei:front`` is set before the body, with title pages on pages of their own
@@ -1322,6 +1341,100 @@ class TestReadingDivisions(unittest.TestCase):
     def test_the_aliyah_macro_is_defined_in_the_preamble(self):
         out = self._transform_body("""<tei:p>text</tei:p>""")
         self.assertIn(r"\newcommand{\OSaliyah}", out.split(r"\begin{document}", 1)[0])
+
+
+class TestCitationMilestone(unittest.TestCase):
+    """A tei:milestone[@unit='citation'] is how the humash states a haftarah/festival
+    reading's scriptural source, or where it resumes after a jump (build._citation)."""
+
+    @staticmethod
+    def _body(tex: str) -> str:
+        return tex.split(r"\begin{document}", 1)[1]
+
+    def _transform_body(self, body: str, **params) -> str:
+        return _transform(
+            f"""<?xml version="1.0" encoding="UTF-8"?>
+            <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0"
+                     xmlns:p="http://jewishliturgy.org/ns/processing">
+              <tei:text><tei:body>{body}</tei:body></tei:text>
+            </tei:TEI>""",
+            **params,
+        )
+
+    def test_citation_is_rendered_in_its_own_pstart(self):
+        out = self._transform_body(
+            """<tei:head>הַפְטָרַת בְּרֵאשִׁית</tei:head>
+               <tei:milestone unit="citation" n="ישעיהו מב:ה–מג:י"/>
+               <tei:p><tei:milestone unit="verse" n="1"/>text</tei:p>"""
+        )
+        body = self._body(out)
+        self.assertIn(r"\OScitation{", body)
+        before = body.split(r"\OScitation{", 1)[0]
+        self.assertTrue(before.rstrip().endswith(r"\pstart \skipnumbering"))
+
+    def test_the_citation_macro_is_defined_in_the_preamble(self):
+        out = self._transform_body("""<tei:p>text</tei:p>""")
+        self.assertIn(r"\newcommand{\OScitation}", out.split(r"\begin{document}", 1)[0])
+
+    def test_digits_in_the_citation_are_forced_ltr(self):
+        out = self._transform_body(
+            """<tei:milestone unit="citation" n="ישעיהו 42:5-43:10"/>
+               <tei:p><tei:milestone unit="verse" n="1"/>text</tei:p>"""
+        )
+        body = self._body(out)
+        self.assertIn(r"{\textdir TLT\selectlanguage{english}42}", body)
+        # A hyphen joins adjacent digit runs into one LTR-wrapped group, the same way
+        # f:emit-bidi-text already treats a hyphenated siglum like "EVR-II-B-8".
+        self.assertIn(r"{\textdir TLT\selectlanguage{english}5-43}", body)
+        self.assertIn(r"{\textdir TLT\selectlanguage{english}10}", body)
+
+    def test_a_citation_does_not_break_the_reading(self):
+        """The reading's own transcluded text still follows in the numbered stream."""
+        out = self._transform_body(
+            """<tei:milestone unit="citation" n="ישעיהו 42:5-43:10"/>
+               <tei:p><tei:milestone unit="verse" n="1"/>text</tei:p>"""
+        )
+        self.assertIn(r"\vno{1}", self._body(out))
+
+    def test_markers_keep_pstart_counts_equal_for_parallel_text(self):
+        """A citation exists only on the Hebrew source's milestones, so it must not add or
+        remove a \\pstart on either side, or reledpar's column-pairing desyncs."""
+        without = _transform(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0"
+                     xmlns:p="http://jewishliturgy.org/ns/processing" xml:lang="he">
+              <tei:text><tei:body>
+                <p:parallel column-order="primary_first">
+                  <p:parallelItem role="primary" xml:lang="he">
+                    <tei:p><tei:milestone unit="verse" n="1"/>שלום</tei:p>
+                  </p:parallelItem>
+                  <p:parallelItem role="parallel" xml:lang="en">
+                    <tei:p><tei:milestone unit="verse" n="1"/>Hello</tei:p>
+                  </p:parallelItem>
+                </p:parallel>
+              </tei:body></tei:text>
+            </tei:TEI>"""
+        )
+        with_citation = _transform(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0"
+                     xmlns:p="http://jewishliturgy.org/ns/processing" xml:lang="he">
+              <tei:text><tei:body>
+                <p:parallel column-order="primary_first">
+                  <p:parallelItem role="primary" xml:lang="he">
+                    <tei:p><tei:milestone unit="citation" n="ישעיהו א:א"/>
+                      <tei:milestone unit="verse" n="1"/>שלום</tei:p>
+                  </p:parallelItem>
+                  <p:parallelItem role="parallel" xml:lang="en">
+                    <tei:p><tei:milestone unit="verse" n="1"/>Hello</tei:p>
+                  </p:parallelItem>
+                </p:parallel>
+              </tei:body></tei:text>
+            </tei:TEI>"""
+        )
+        self.assertEqual(without.count(r"\pstart"), with_citation.count(r"\pstart"))
+        self.assertEqual(without.count(r"\pend"), with_citation.count(r"\pend"))
+
 
 class TestUnrenderedMilestones(unittest.TestCase):
     """A milestone the stylesheet does not set must not open a paragraph of its own.

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -91,19 +91,55 @@ class TestPreamble(unittest.TestCase):
         self.assertIn("Ezra SIL", out)
         self.assertIn("TeX Gyre Pagella", out)
 
-    def test_preamble_bookmarks_three_levels_deep(self):
-        """The third heading level (index > book > parshah) must reach the PDF outline.
-
-        The book class stops the table of contents at subsection and hyperref follows it,
-        which silently drops the deepest \addcontentsline.
+    def test_preamble_bookmarks_four_levels_deep(self):
+        """The deeper heading levels (index > section > haftarah > rite) must reach the PDF
+        outline. The book class stops the table of contents at subsection and hyperref
+        follows it, which silently drops anything deeper.
         """
         xml = """<?xml version="1.0" encoding="UTF-8"?>
         <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
           <tei:text><tei:body><tei:p>Hi</tei:p></tei:body></tei:text>
         </tei:TEI>"""
         out = _transform(xml)
-        self.assertIn(r"\setcounter{tocdepth}{3}", out)
-        self.assertIn("bookmarksdepth=3", out)
+        self.assertIn(r"\setcounter{tocdepth}{4}", out)
+        self.assertIn("bookmarksdepth=4", out)
+
+    def test_a_fourth_level_head_gets_its_own_macro_and_outline_entry(self):
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body>
+            <tei:div><tei:head>Humash</tei:head>
+              <tei:div><tei:head>Haftarot</tei:head>
+                <tei:div><tei:head>Bereshit</tei:head>
+                  <tei:div><tei:head>Ashkenaz</tei:head><tei:p>Hi</tei:p></tei:div>
+                </tei:div>
+              </tei:div>
+            </tei:div>
+          </tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml)
+        self.assertIn(r"\OSheadD{", out)
+        self.assertIn(r"\addcontentsline{toc}{paragraph}", out)
+
+    def test_a_fifth_level_head_stays_at_the_fourth(self):
+        """Nesting deeper than the macros go must not fall off the end of the sequence."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body>
+            <tei:div><tei:head>One</tei:head>
+              <tei:div><tei:head>Two</tei:head>
+                <tei:div><tei:head>Three</tei:head>
+                  <tei:div><tei:head>Four</tei:head>
+                    <tei:div><tei:head>Five</tei:head><tei:p>Hi</tei:p></tei:div>
+                  </tei:div>
+                </tei:div>
+              </tei:div>
+            </tei:div>
+          </tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml)
+        self.assertIn("english}Five}", out)
+        self.assertNotIn("OSheadE", out)
 
     def test_a_third_level_head_is_added_to_the_outline(self):
         xml = """<?xml version="1.0" encoding="UTF-8"?>

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -1322,3 +1322,34 @@ class TestReadingDivisions(unittest.TestCase):
     def test_the_aliyah_macro_is_defined_in_the_preamble(self):
         out = self._transform_body("""<tei:p>text</tei:p>""")
         self.assertIn(r"\newcommand{\OSaliyah}", out.split(r"\begin{document}", 1)[0])
+
+class TestUnrenderedMilestones(unittest.TestCase):
+    """A milestone the stylesheet does not set must not open a paragraph of its own.
+
+    reledmac cannot typeset an empty \pstart: it fails with "You can't use \lastbox in
+    vertical mode" and produces no PDF at all. A paragraph holding only such a milestone —
+    which is what a range boundary falling inside an edition's own verse produces — used to
+    make exactly that.
+    """
+
+    XML = """<?xml version="1.0" encoding="UTF-8"?>
+    <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="he">
+      <tei:text><tei:body>
+        <tei:p><tei:milestone unit="verse" n="17"/>text</tei:p>
+        <tei:p><tei:milestone unit="edition-verse" n="14"/></tei:p>
+      </tei:body></tei:text>
+    </tei:TEI>"""
+
+    def test_no_empty_paragraph_is_emitted(self):
+        out = _transform(self.XML)
+        self.assertNotIn(r"\pstart \pend", out)
+        self.assertNotIn("\\pstart\n\\pend", out)
+
+    def test_the_verse_before_it_is_still_set(self):
+        out = _transform(self.XML)
+        self.assertIn(r"\vno{17}", out)
+        self.assertIn("text", out)
+
+    def test_an_edition_verse_prints_nothing(self):
+        self.assertNotIn("14", _transform(self.XML).split("begin{document}")[1])
+

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -1019,3 +1019,100 @@ class TestFrontMatter(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestReadingDivisions(unittest.TestCase):
+    """Aliyah, maftir and parshah markers, as the humash emits them.
+
+    These divisions overlap on purpose, so their markers are inline rather than breaks: a
+    maftir opens inside the seventh aliyah, and a marker that ended a paragraph would assert
+    a break that is not there — besides desynchronising a reledpar pairing, which counts
+    \\pstart markers on each side.
+    """
+
+    @staticmethod
+    def _body(tex: str) -> str:
+        return tex.split(r"\begin{document}", 1)[1]
+
+    def _transform_body(self, body: str, **params) -> str:
+        return _transform(
+            f"""<?xml version="1.0" encoding="UTF-8"?>
+            <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0"
+                     xmlns:j="http://jewishliturgy.org/ns/jlptei/2">
+              <tei:text><tei:body>{body}</tei:body></tei:text>
+            </tei:TEI>""",
+            **params,
+        )
+
+    def test_aliyah_marker_is_emitted_inline(self):
+        out = self._transform_body(
+            """<tei:p><tei:milestone unit="verse" n="1"/>text one
+               <tei:milestone unit="aliyah.annual" n="שני"/>text two</tei:p>"""
+        )
+        body = self._body(out)
+        self.assertIn(r"\OSaliyah{", body)
+        for word in ("text one", "text two"):
+            with self.subTest(word):
+                self.assertIn(word, body)
+
+    def test_maftir_and_weekday_and_triennial_all_get_markers(self):
+        for unit in ("maftir.annual", "aliyah.weekday", "aliyah.triennial.2"):
+            with self.subTest(unit=unit):
+                out = self._transform_body(
+                    f"""<tei:p><tei:milestone unit="verse" n="1"/>text
+                        <tei:milestone unit="{unit}" n="X"/>more</tei:p>"""
+                )
+                self.assertIn(r"\OSaliyah{X}", self._body(out))
+
+    def test_a_marker_does_not_break_the_paragraph(self):
+        """The maftir begins inside the seventh aliyah, so it must not close its pstart."""
+        out = self._transform_body(
+            """<tei:p><tei:milestone unit="verse" n="1"/>before
+               <tei:milestone unit="maftir.annual" n="מפטיר"/>after</tei:p>"""
+        )
+        body = self._body(out)
+        marker = body.index(r"\OSaliyah{")
+        # No paragraph is closed and reopened around the marker.
+        self.assertNotIn(r"\pend", body[max(0, marker - 120):marker])
+
+    def test_markers_keep_pstart_counts_equal_for_parallel_text(self):
+        """reledpar pairs columns by \\pstart count, so a marker on one side only must not
+        add or remove one."""
+        without = self._transform_body(
+            """<tei:p><tei:milestone unit="verse" n="1"/>a</tei:p>"""
+        )
+        with_marker = self._transform_body(
+            """<tei:p><tei:milestone unit="verse" n="1"/><tei:milestone
+               unit="aliyah.annual" n="ראשון"/>a</tei:p>"""
+        )
+        self.assertEqual(
+            self._body(without).count(r"\pstart"), self._body(with_marker).count(r"\pstart")
+        )
+        self.assertEqual(
+            self._body(without).count(r"\pend"), self._body(with_marker).count(r"\pend")
+        )
+
+    def test_a_qualified_parsha_unit_is_left_to_the_heading(self):
+        """The humash gives every parshah a tei:head, so printing the milestone too would
+        name it twice."""
+        out = self._transform_body(
+            """<tei:div><tei:head>בראשית</tei:head>
+               <tei:p><tei:milestone unit="verse" n="1"/><tei:milestone
+                 unit="parsha.annual" n="בראשית"/>text</tei:p></tei:div>"""
+        )
+        body = self._body(out)
+        self.assertNotIn("Parsha:", body)
+        self.assertIn("text", body)
+
+    def test_an_unqualified_parsha_unit_still_gets_its_footnote(self):
+        """wlc and jps1917 mark parshiyot inside a book with no heading of their own."""
+        out = self._transform_body(
+            """<tei:div type="book"><tei:head>Genesis</tei:head>
+               <tei:p><tei:milestone unit="verse" n="1"/>text
+               <tei:milestone unit="parsha" n="נח"/>more</tei:p></tei:div>"""
+        )
+        self.assertIn("Parsha:", self._body(out))
+
+    def test_the_aliyah_macro_is_defined_in_the_preamble(self):
+        out = self._transform_body("""<tei:p>text</tei:p>""")
+        self.assertIn(r"\newcommand{\OSaliyah}", out.split(r"\begin{document}", 1)[0])

--- a/opensiddur/tests/importer/humash/test_aliyot.py
+++ b/opensiddur/tests/importer/humash/test_aliyot.py
@@ -13,8 +13,11 @@ from opensiddur.importer.humash import aliyot
 from opensiddur.importer.humash.names import slug_for_hebrew
 from opensiddur.importer.humash.refs import (
     UNIT_ALIYAH,
+    UNIT_ALIYAH_COMBINED,
     UNIT_MAFTIR,
+    UNIT_MAFTIR_COMBINED,
     UNIT_WEEKDAY,
+    UNIT_WEEKDAY_COMBINED,
     ReadingSpan,
     VerseRef,
     verses_in_chapter,
@@ -22,8 +25,8 @@ from opensiddur.importer.humash.refs import (
 
 HEBREW_NUMERALS = {
     1: "א", 2: "ב", 3: "ג", 4: "ד", 5: "ה", 6: "ו", 7: "ז", 8: "ח", 9: "ט", 10: "י",
-    11: "יא", 12: "יב", 13: "יג", 14: "יד", 19: "יט", 20: "כ", 22: "כב", 25: "כה", 26: "כו",
-    31: "לא", 32: "לב",
+    11: "יא", 12: "יב", 13: "יג", 14: "יד", 15: "טו", 16: "טז", 17: "יז", 19: "יט", 20: "כ",
+    22: "כב", 25: "כה", 26: "כו", 31: "לא", 32: "לב",
 }
 
 
@@ -162,6 +165,81 @@ class TestParseParshiyot(unittest.TestCase):
     def test_unknown_parsha_name_is_rejected_rather_than_guessed(self):
         with self.assertRaises(KeyError):
             slug_for_hebrew("פרשה שאינה קיימת")
+
+
+class TestParseCombined(unittest.TestCase):
+    """The ``ג`` parameters, which divide the week the two parshiyot are read together.
+
+    The fixture is a synthetic Tazria-Metzora: Tazria runs Leviticus 12:1-13:17 and Metzora
+    14:1-15:17, and the combined reading deliberately has one aliyah that runs from one into
+    the other, which is the case the single parshiyot's divisions cannot express.
+    """
+
+    PAIR = "תזריע–מצֹרע"
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        sheets = self.root / "miqra_al_pi_hamasorah" / "sheets"
+        sheets.mkdir(parents=True)
+        _write_verse_counts(self.root)
+        rows = [
+            _row("ויקרא", 12, 1, ב0="תזריע", ב1="ראשון", ב2="כהן",
+                 ג0=self.PAIR, ג1="ראשון", ג2="כהן"),
+            _row("ויקרא", 12, 5, ב0="תזריע", ב2="לוי", ג0=self.PAIR, ג2="לוי"),
+            _row("ויקרא", 13, 1, ב0="תזריע", ב1="שני", ג0=self.PAIR, ג1="שני"),
+            _row("ויקרא", 13, 5, ב0="תזריע", ג0=self.PAIR, ג2='ע"כ ישראל'),
+            # No ג1 here: the combined second aliyah carries on past where Metzora begins.
+            _row("ויקרא", 14, 1, ב0="מצֹרע", ב1="ראשון", ג0=self.PAIR),
+            _row("ויקרא", 14, 5, ב0="מצֹרע", ב1="שני", ג0=self.PAIR, ג1="שלישי"),
+            _row("ויקרא", 14, 9, ב0="מצֹרע", ב3="מפטיר", ג0=self.PAIR, ג3="מפטיר"),
+            _row("ויקרא", 16, 1, ב0="אחרי מות", ב1="ראשון"),
+        ]
+        (sheets / "torah.tsv").write_text(
+            "\n".join("\t".join(["page", "id", "", row, "text"]) for row in rows) + "\n",
+            encoding="utf-8",
+        )
+        self.parshiyot, self.combined = aliyot.parse_readings(self.root)
+
+    def test_a_pair_covers_both_parshiyot_end_to_end(self):
+        self.assertEqual([pair.slug for pair in self.combined], ["tazria_metzora"])
+        pair = self.combined[0]
+        self.assertEqual(pair.members, ("tazria", "metzora"))
+        self.assertEqual(pair.start, VerseRef("leviticus", 12, 1))
+        # Metzora's own end, not the last marker's parshah: the pair runs to Achrei Mot.
+        self.assertEqual(pair.end, VerseRef("leviticus", 15, 17))
+
+    def test_a_combined_aliyah_may_run_from_one_parshah_into_the_other(self):
+        combined = self.combined[0].spans_in(UNIT_ALIYAH_COMBINED)
+        self.assertEqual([span.label for span in combined], ["1", "2", "3"])
+        self.assertEqual(combined[1].start, VerseRef("leviticus", 13, 1))
+        # Metzora begins at 14:1, and this aliyah is not cut there.
+        self.assertEqual(combined[1].end, VerseRef("leviticus", 14, 4))
+        self.assertEqual(combined[2].end, VerseRef("leviticus", 15, 17))
+
+    def test_the_singles_keep_their_own_divisions(self):
+        tazria, metzora = self.parshiyot[0], self.parshiyot[1]
+        self.assertEqual([p.slug for p in self.parshiyot[:2]], ["tazria", "metzora"])
+        second = tazria.spans_in(UNIT_ALIYAH)[1]
+        self.assertEqual(second.start, VerseRef("leviticus", 13, 1))
+        # Where the combined aliyah carries on, Tazria's own ends with Tazria.
+        self.assertEqual(second.end, VerseRef("leviticus", 13, 17))
+        self.assertEqual(metzora.spans_in(UNIT_MAFTIR)[0].start, VerseRef("leviticus", 14, 9))
+
+    def test_the_combined_maftir_runs_to_the_end_of_the_pair(self):
+        maftir = self.combined[0].spans_in(UNIT_MAFTIR_COMBINED)
+        self.assertEqual(len(maftir), 1)
+        self.assertEqual(maftir[0].start, VerseRef("leviticus", 14, 9))
+        self.assertEqual(maftir[0].end, VerseRef("leviticus", 15, 17))
+
+    def test_the_combined_weekday_reading_has_its_own_end_marker(self):
+        """The pair's ע"כ ישראל is its own, and does not move the singles' weekday reading."""
+        combined = self.combined[0].spans_in(UNIT_WEEKDAY_COMBINED)
+        self.assertEqual([span.label for span in combined], ["1", "2"])
+        self.assertEqual(combined[1].end, VerseRef("leviticus", 13, 4))
+        single = self.parshiyot[0].spans_in(UNIT_WEEKDAY)
+        self.assertEqual(single[1].end, VerseRef("leviticus", 13, 17))
 
 
 class TestReadingSpan(unittest.TestCase):

--- a/opensiddur/tests/importer/humash/test_aliyot.py
+++ b/opensiddur/tests/importer/humash/test_aliyot.py
@@ -1,0 +1,209 @@
+"""Tests for the MAM aliyah parse.
+
+The conversion logic is tested against synthetic TSV rows rather than the real torah.tsv, so
+that the tests do not change meaning when the source data is updated.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from opensiddur.importer.humash import aliyot
+from opensiddur.importer.humash.names import slug_for_hebrew
+from opensiddur.importer.humash.refs import (
+    UNIT_ALIYAH,
+    UNIT_MAFTIR,
+    UNIT_WEEKDAY,
+    ReadingSpan,
+    VerseRef,
+    verses_in_chapter,
+)
+
+HEBREW_NUMERALS = {
+    1: "א", 2: "ב", 3: "ג", 4: "ד", 5: "ה", 6: "ו", 7: "ז", 8: "ח", 9: "ט", 10: "י",
+    11: "יא", 12: "יב", 13: "יג", 14: "יד", 19: "יט", 20: "כ", 22: "כב", 25: "כה", 26: "כו",
+    31: "לא", 32: "לב",
+}
+
+
+def _row(book: str, chapter: int, verse: int, **params: str) -> str:
+    """One torah.tsv scaffolding cell carrying an aliyah marker."""
+    body = "|".join(f"{key}={value}" for key, value in params.items())
+    return (
+        f"{{{{מ:פסוק|{book}|{HEBREW_NUMERALS[chapter]}|{HEBREW_NUMERALS[verse]}"
+        f"|עלייה={{{{מ:עלייה|{body}}}}}}}}}"
+    )
+
+
+def _write_verse_counts(root: Path) -> None:
+    """A synthetic numverses.json, so the tests do not depend on the downloaded data.
+
+    Index 0 is a placeholder because hebcal numbers chapters from 1. Only the chapters the
+    tests reach need to be right.
+    """
+    genesis = [0] + [31, 25, 24, 26, 32, 22, 24, 22, 29, 32] + [30] * 40
+    directory = root / "hebcal_leyning"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "numverses.json").write_text(
+        json.dumps({
+            "Genesis": genesis,
+            "Exodus": [0] + [22] * 40,
+            "Leviticus": [0] + [17] * 27,
+            "Numbers": [0] + [23] * 36,
+            "Deuteronomy": [0] + [22] * 34,
+        }),
+        encoding="utf-8",
+    )
+
+
+class TestParseParshiyot(unittest.TestCase):
+    """Parse a synthetic torah.tsv holding two short parshiyot of Genesis."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        sheets = self.root / "miqra_al_pi_hamasorah" / "sheets"
+        sheets.mkdir(parents=True)
+        self.tsv = sheets / "torah.tsv"
+        _write_verse_counts(self.root)
+
+    def _write(self, scaffolds: list[str]) -> None:
+        lines = ["\t".join(["page", "id", "", scaffold, "text"]) for scaffold in scaffolds]
+        self.tsv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def _parse(self):
+        return aliyot.parse_parshiyot(self.root)
+
+    def test_shabbat_aliyot_end_where_the_next_one_starts(self):
+        self._write([
+            _row("בראשית", 1, 1, ב0="בראשית", ב1="ראשון"),
+            _row("בראשית", 2, 4, ב0="בראשית", ב1="שני"),
+            _row("בראשית", 6, 9, ב0="נֹח", ב1="ראשון"),
+        ])
+        parshiyot = self._parse()
+        self.assertEqual([p.slug for p in parshiyot], ["bereshit", "noach"])
+        bereshit = parshiyot[0]
+        first, second = bereshit.spans_in(UNIT_ALIYAH)
+        self.assertEqual(first.start, VerseRef("genesis", 1, 1))
+        self.assertEqual(first.end, VerseRef("genesis", 2, 3))
+        self.assertEqual(second.start, VerseRef("genesis", 2, 4))
+        # The last aliyah runs to the end of the parshah, which ends before Noach begins.
+        self.assertEqual(second.end, VerseRef("genesis", 6, 8))
+        self.assertEqual(bereshit.end, VerseRef("genesis", 6, 8))
+
+    def test_a_span_ending_at_a_chapter_boundary_uses_that_chapters_verse_count(self):
+        """Closing a span means stepping back a verse, which may cross into the chapter before."""
+        self._write([
+            _row("בראשית", 1, 1, ב0="בראשית", ב1="ראשון"),
+            _row("בראשית", 2, 1, ב0="בראשית", ב1="שני"),
+            _row("בראשית", 6, 9, ב0="נֹח", ב1="ראשון"),
+        ])
+        first = self._parse()[0].spans_in(UNIT_ALIYAH)[0]
+        # Genesis 1 has 31 verses in the fixture, so stepping back from 2:1 lands on 1:31.
+        self.assertEqual(first.end, VerseRef("genesis", 1, 31))
+
+    def test_maftir_overlaps_the_seventh_aliyah_instead_of_ending_it(self):
+        """The maftir re-reads the close of the parshah, so both run to the same last verse."""
+        self._write([
+            _row("בראשית", 5, 25, ב0="בראשית", ב1="שביעי"),
+            _row("בראשית", 6, 5, ב0="בראשית", ב3="מפטיר"),
+            _row("בראשית", 6, 9, ב0="נֹח", ב1="ראשון"),
+        ])
+        bereshit = self._parse()[0]
+        seventh = bereshit.spans_in(UNIT_ALIYAH)[0]
+        maftir = bereshit.spans_in(UNIT_MAFTIR)[0]
+        self.assertEqual(seventh.start, VerseRef("genesis", 5, 25))
+        self.assertEqual(seventh.end, VerseRef("genesis", 6, 8))
+        self.assertEqual(maftir.start, VerseRef("genesis", 6, 5))
+        self.assertEqual(maftir.end, VerseRef("genesis", 6, 8))
+        # The maftir begins inside the seventh aliyah and does not shorten it.
+        self.assertGreater(maftir.start, seventh.start)
+        self.assertEqual(maftir.end, seventh.end)
+
+    def test_weekday_reading_stops_at_the_end_marker(self):
+        """ע"כ ישראל closes the weekday reading rather than opening a fourth aliyah."""
+        self._write([
+            _row("בראשית", 1, 1, ב0="בראשית", ב1="ראשון", ב2="כהן"),
+            _row("בראשית", 1, 6, ב0="בראשית", ב2="לוי"),
+            _row("בראשית", 1, 9, ב0="בראשית", ב2="ישראל"),
+            _row("בראשית", 1, 14, ב0="בראשית", ב2='ע"כ ישראל'),
+            _row("בראשית", 6, 9, ב0="נֹח", ב1="ראשון"),
+        ])
+        weekday = self._parse()[0].spans_in(UNIT_WEEKDAY)
+        self.assertEqual([span.label for span in weekday], ["1", "2", "3"])
+        self.assertEqual(weekday[0].start, VerseRef("genesis", 1, 1))
+        self.assertEqual(weekday[0].end, VerseRef("genesis", 1, 5))
+        self.assertEqual(weekday[2].start, VerseRef("genesis", 1, 9))
+        # Ends at 1:13, the verse before the marker — not at the end of the parshah.
+        self.assertEqual(weekday[2].end, VerseRef("genesis", 1, 13))
+
+    def test_weekday_and_shabbat_aliyot_do_not_truncate_each_other(self):
+        """The two schemes are closed independently, so a weekday start stays inside aliyah 1."""
+        self._write([
+            _row("בראשית", 1, 1, ב0="בראשית", ב1="ראשון", ב2="כהן"),
+            _row("בראשית", 1, 6, ב0="בראשית", ב2="לוי"),
+            _row("בראשית", 2, 4, ב0="בראשית", ב1="שני"),
+            _row("בראשית", 6, 9, ב0="נֹח", ב1="ראשון"),
+        ])
+        bereshit = self._parse()[0]
+        first_aliyah = bereshit.spans_in(UNIT_ALIYAH)[0]
+        self.assertEqual(first_aliyah.end, VerseRef("genesis", 2, 3))
+        self.assertEqual(bereshit.spans_in(UNIT_WEEKDAY)[0].end, VerseRef("genesis", 1, 5))
+
+    def test_pointing_and_maqaf_survive_the_name_lookup(self):
+        """MAM points its names and writes לך־לך with a maqaf; neither may change the slug."""
+        self.assertEqual(slug_for_hebrew("נֹח"), "noach")
+        self.assertEqual(slug_for_hebrew("נח"), "noach")
+        self.assertEqual(slug_for_hebrew("לך־לך"), "lech_lecha")
+        self.assertEqual(slug_for_hebrew("בחֻקֹתי"), "bechukotai")
+
+    def test_unknown_parsha_name_is_rejected_rather_than_guessed(self):
+        with self.assertRaises(KeyError):
+            slug_for_hebrew("פרשה שאינה קיימת")
+
+
+class TestReadingSpan(unittest.TestCase):
+    def test_a_span_may_not_cross_books(self):
+        with self.assertRaises(ValueError):
+            ReadingSpan(UNIT_ALIYAH, "1", VerseRef("genesis", 50, 1), VerseRef("exodus", 1, 1))
+
+    def test_a_span_may_not_end_before_it_starts(self):
+        with self.assertRaises(ValueError):
+            ReadingSpan(UNIT_ALIYAH, "1", VerseRef("genesis", 2, 1), VerseRef("genesis", 1, 1))
+
+    def test_range_urn_is_unsuffixed_and_abbreviates_the_end(self):
+        start, end = VerseRef("genesis", 1, 1), VerseRef("genesis", 6, 8)
+        self.assertEqual(
+            start.range_urn(end), "urn:x-opensiddur:text:bible:genesis/1/1-6/8"
+        )
+
+    def test_range_urn_refuses_to_cross_books(self):
+        with self.assertRaises(ValueError):
+            VerseRef("genesis", 50, 26).range_urn(VerseRef("exodus", 1, 1))
+
+
+class TestNumbering(unittest.TestCase):
+    """The four chapters the editions divide differently."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        _write_verse_counts(self.root)
+
+    def test_divergent_chapters_depend_on_the_numbering(self):
+        """These four are looked up from a table, so they need no source file at all."""
+        self.assertEqual(verses_in_chapter("exodus", 20, self.root, "masorah"), 22)
+        self.assertEqual(verses_in_chapter("exodus", 20, self.root, "leningrad"), 26)
+        self.assertEqual(verses_in_chapter("exodus", 20, self.root, "common"), 23)
+
+    def test_other_chapters_are_the_same_in_every_numbering(self):
+        for numbering in ("masorah", "leningrad", "common"):
+            with self.subTest(numbering=numbering):
+                self.assertEqual(verses_in_chapter("genesis", 1, self.root, numbering), 31)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/importer/humash/test_aliyot.py
+++ b/opensiddur/tests/importer/humash/test_aliyot.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 from opensiddur.importer.humash import aliyot
 from opensiddur.importer.humash.names import slug_for_hebrew
+from opensiddur.common.versification import NUMBERING_COMMON, NUMBERING_MASORAH
 from opensiddur.importer.humash.refs import (
+    canonical_ref,
     UNIT_ALIYAH,
     UNIT_ALIYAH_COMBINED,
     UNIT_MAFTIR,
@@ -262,8 +264,8 @@ class TestReadingSpan(unittest.TestCase):
             VerseRef("genesis", 50, 26).range_urn(VerseRef("exodus", 1, 1))
 
 
-class TestNumbering(unittest.TestCase):
-    """The four chapters the editions divide differently."""
+class TestCanonicalVerseCounts(unittest.TestCase):
+    """Verse counts follow the canonical division of the bible URN space, not hebcal's."""
 
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -271,16 +273,44 @@ class TestNumbering(unittest.TestCase):
         self.root = Path(self.temp_dir.name)
         _write_verse_counts(self.root)
 
-    def test_divergent_chapters_depend_on_the_numbering(self):
-        """These four are looked up from a table, so they need no source file at all."""
-        self.assertEqual(verses_in_chapter("exodus", 20, self.root, "masorah"), 22)
-        self.assertEqual(verses_in_chapter("exodus", 20, self.root, "leningrad"), 26)
-        self.assertEqual(verses_in_chapter("exodus", 20, self.root, "common"), 23)
+    def test_a_divergent_chapter_is_counted_canonically(self):
+        """The canonical count comes from a table, so it needs no source file at all — and it
+        is finer than hebcal's, which follows the printed editions."""
+        self.assertEqual(verses_in_chapter("exodus", 20, self.root), 26)
+        self.assertEqual(verses_in_chapter("deuteronomy", 5, self.root), 33)
 
-    def test_other_chapters_are_the_same_in_every_numbering(self):
-        for numbering in ("masorah", "leningrad", "common"):
-            with self.subTest(numbering=numbering):
-                self.assertEqual(verses_in_chapter("genesis", 1, self.root, numbering), 31)
+    def test_an_ordinary_chapter_comes_from_the_source(self):
+        self.assertEqual(verses_in_chapter("genesis", 1, self.root), 31)
+
+
+class TestCanonicalRefs(unittest.TestCase):
+    """References stated in an edition's numbering are converted as they are read."""
+
+    def test_a_mam_reference_below_the_decalogue_is_unchanged(self):
+        self.assertEqual(
+            canonical_ref(NUMBERING_MASORAH, VerseRef("exodus", 20, 1)),
+            VerseRef("exodus", 20, 1),
+        )
+
+    def test_a_mam_reference_after_the_decalogue_shifts(self):
+        """MAM reads the four short commandments as one verse where canonical has four, so
+        everything after them is numbered lower in MAM."""
+        self.assertEqual(
+            canonical_ref(NUMBERING_MASORAH, VerseRef("exodus", 20, 22)),
+            VerseRef("exodus", 20, 26),
+        )
+
+    def test_a_merged_verse_opens_at_its_first_canonical_verse(self):
+        start = canonical_ref(NUMBERING_MASORAH, VerseRef("exodus", 20, 12))
+        end = canonical_ref(NUMBERING_MASORAH, VerseRef("exodus", 20, 12), at_end=True)
+        self.assertEqual((start.verse, end.verse), (13, 16))
+
+    def test_a_common_reference_is_converted_too(self):
+        """hebcal follows the printed editions, which split אנכי but merge the four."""
+        self.assertEqual(
+            canonical_ref(NUMBERING_COMMON, VerseRef("exodus", 20, 23)),
+            VerseRef("exodus", 20, 26),
+        )
 
 
 if __name__ == "__main__":

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -12,6 +12,7 @@ from lxml import etree
 
 from opensiddur.importer.humash import build
 from opensiddur.importer.humash.aliyot import CombinedParsha, Parsha
+from opensiddur.importer.humash.readings import Passage
 from opensiddur.importer.humash.refs import (
     UNIT_ALIYAH,
     UNIT_ALIYAH_COMBINED,
@@ -22,6 +23,7 @@ from opensiddur.importer.humash.refs import (
 
 TEI = "{http://www.tei-c.org/ns/1.0}"
 J = "{http://jewishliturgy.org/ns/jlptei/2}"
+XML = "{http://www.w3.org/XML/1998/namespace}"
 
 PAIR = "tazria_metzora"
 PATTERNS = {"TTS": "A", "TST": "B", "STT": "C"}
@@ -166,6 +168,122 @@ class TestPairFile(unittest.TestCase):
         self.assertEqual(ranges[-1][1], (15, 17))
         for earlier, later in zip(ranges, ranges[1:]):
             self.assertGreater(later[0], earlier[1], "the text is emitted more than once")
+
+
+def _passage(book: str, start, end, **kwargs) -> Passage:
+    return Passage(
+        key="test",
+        spans=[ReadingSpan(
+            unit="haftarah", label="1",
+            start=VerseRef(book, *start), end=VerseRef(book, *end), **kwargs,
+        )],
+    )
+
+
+class TestHaftarahFile(unittest.TestCase):
+    """The annual haftarah and the triennial ones are alternatives for the same Shabbat."""
+
+    ANNUAL = [_passage("isaiah", (42, 5), (43, 10))]
+
+    def _tree(self, slug: str, triennial_passages=None):
+        _, document = build.haftarah_file(slug, self.ANNUAL, triennial_passages)
+        return etree.fromstring(document.encode("utf-8"))
+
+    def _features(self, conditional) -> list[str]:
+        """The reading-cycle features a conditional tests for, in order."""
+        return [
+            f.get("name") for f in conditional.iter(f"{TEI}f")
+            if f.getparent().get("type") == "opensiddur:reading-cycle"
+        ]
+
+    def test_a_parshah_with_no_triennial_haftarah_is_unconditioned(self):
+        """Devarim, Vaetchanan and Vezot Haberakhah keep the annual reading in every year."""
+        tree = self._tree("devarim")
+        self.assertEqual(tree.findall(f".//{J}conditional"), [])
+
+    def test_each_year_becomes_a_headed_division_of_its_own(self):
+        tree = self._tree("bereshit", {
+            1: _passage("isaiah", (42, 5), (42, 21)),
+            2: _passage("isaiah", (40, 25), (40, 31)),
+            3: _passage("kings_2", (2, 1), (2, 13)),
+        })
+        divisions = [
+            div for div in tree.iter(f"{TEI}div")
+            if (div.get("n") or "").startswith("triennial_")
+        ]
+        self.assertEqual(
+            [div.get("corresp") for div in divisions],
+            [f"urn:x-opensiddur:text:bible:haftarah/bereshit/triennial/{year}"
+             for year in (1, 2, 3)],
+        )
+        self.assertEqual(
+            [div.find(f"{J}transclude").get("target") for div in divisions],
+            ["urn:x-opensiddur:text:bible:isaiah/42/5-42/21",
+             "urn:x-opensiddur:text:bible:isaiah/40/25-40/31",
+             "urn:x-opensiddur:text:bible:kings_2/2/1-2/13"],
+        )
+
+    def test_a_triennial_reading_turns_on_one_decisive_feature(self):
+        """Two tests would be undefined where one is false, and undefined keeps the text."""
+        tree = self._tree("bereshit", {1: _passage("isaiah", (42, 5), (42, 21))})
+        conditional = tree.findall(f".//{J}conditional")[-1]
+        self.assertEqual(self._features(conditional), ["triennial-year-1"])
+        self.assertEqual(
+            [b.get("value") for b in conditional.iter(f"{TEI}binary")], ["true"]
+        )
+
+    def test_a_year_is_selected_independently_of_the_others(self):
+        """A volume for a whole cycle turns on all three, so they cannot be one year number."""
+        tree = self._tree("bereshit", {
+            year: _passage("isaiah", (40, year), (40, year)) for year in (1, 2, 3)
+        })
+        triennial = tree.findall(f".//{J}conditional")[1:]
+        self.assertEqual(
+            [self._features(c) for c in triennial],
+            [["triennial-year-1"], ["triennial-year-2"], ["triennial-year-3"]],
+        )
+
+    def test_the_annual_reading_stands_in_for_the_years_that_have_none(self):
+        """Tazria is read alone in years 1 and 2 only, so year 3 falls back to the annual."""
+        tree = self._tree("tazria", {
+            1: _passage("isaiah", (46, 3), (46, 13)),
+            2: _passage("jeremiah", (30, 1), (30, 9)),
+        })
+        annual = tree.findall(f".//{J}conditional")[0]
+        self.assertEqual(annual.find(f"{J}any").tag, f"{J}any")
+        self.assertEqual(self._features(annual), ["annual", "triennial-year-3"])
+
+    def test_a_parshah_with_every_year_yields_the_annual_only_to_the_annual_feature(self):
+        tree = self._tree("bereshit", {
+            year: _passage("isaiah", (40, year), (40, year)) for year in (1, 2, 3)
+        })
+        annual = tree.findall(f".//{J}conditional")[0]
+        self.assertEqual(self._features(annual), ["annual"])
+
+    def test_every_conditional_is_closed(self):
+        tree = self._tree("bereshit", {
+            year: _passage("isaiah", (40, year), (40, year)) for year in (1, 2, 3)
+        })
+        opened = [c.get(f"{XML}id") for c in tree.findall(f".//{J}conditional")]
+        closed = [
+            c.get("target").lstrip("#") for c in tree.findall(f".//{J}endConditional")
+        ]
+        self.assertEqual(len(opened), 4)  # the annual one, and one per year
+        self.assertEqual(sorted(opened), sorted(closed))
+
+    def test_a_boundary_inside_a_verse_reads_the_whole_verse_and_says_where_to_stop(self):
+        tree = self._tree("emor", {
+            3: _passage("nahum", (2, 2), (2, 3), start_half="b", end_half="a"),
+        })
+        division = tree.findall(f".//{TEI}div[@n='triennial_3']")[0]
+        self.assertEqual(
+            [child.tag for child in division][1:],
+            [f"{TEI}note", f"{J}transclude", f"{TEI}note"],
+        )
+        self.assertEqual(
+            division.find(f"{J}transclude").get("target"),
+            "urn:x-opensiddur:text:bible:nahum/2/2-2/3",
+        )
 
 
 class TestBookFile(unittest.TestCase):

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -18,6 +18,8 @@ from opensiddur.importer.humash.refs import (
     UNIT_ALIYAH,
     UNIT_ALIYAH_COMBINED,
     UNIT_MAFTIR,
+    UNIT_PARSHA,
+    UNIT_PARSHA_COMBINED,
     ReadingSpan,
     VerseRef,
     triennial_unit,
@@ -113,10 +115,9 @@ class TestPairFile(unittest.TestCase):
             ["urn:x-opensiddur:text:bible:parsha/tazria",
              "urn:x-opensiddur:text:bible:parsha/metzora"],
         )
-        self.assertEqual(
-            by_unit["parsha.combined"][0].get("corresp"),
-            f"urn:x-opensiddur:text:bible:parsha/{PAIR}",
-        )
+        # The pair's own URN is on the file's div, which covers exactly the same text, so the
+        # marker does not claim it a second time.
+        self.assertIsNone(by_unit["parsha.combined"][0].get("corresp"))
         # Both parshiyot have a first aliyah, so the two must not land on one URN.
         self.assertEqual(
             [m.get("corresp") for m in by_unit["aliyah.annual"]],
@@ -575,3 +576,84 @@ class TestFestivalHaftarahHeading(unittest.TestCase):
         reading = {"name": "Pesach I", "aliyot": [_span(UNIT_ALIYAH, "1", (12, 21), (12, 28))],
                    "haftarot": []}
         self.assertNotIn(build.HAFTARAH_TITLE, self._heads(reading))
+
+
+class TestParshaUrnIsClaimedOnce(unittest.TestCase):
+    """A text URN names one stretch of text, so it may be mapped in only one place.
+
+    The file's own div and the parshah milestone cover exactly the same text in a file
+    holding one parshah. Naming it on both makes the reference database reject the file —
+    and, because indexing abandons a file on the first error, silently drops every other URN
+    in it along with the duplicate.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "numverses.json").write_text(
+            json.dumps({name: [0] + [40] * 30 for name in
+                        ("Genesis", "Exodus", "Leviticus", "Numbers", "Deuteronomy")}),
+            encoding="utf-8",
+        )
+
+    def _milestones(self, document: str) -> list:
+        return list(etree.fromstring(document.encode("utf-8")).iter(f"{TEI}milestone"))
+
+    def _parsha(self, slug: str, hebrew: str) -> Parsha:
+        return Parsha(
+            slug=slug, hebrew_name=hebrew, book="leviticus",
+            start=_ref(12, 1), end=_ref(13, 17),
+            spans=[
+                _span(UNIT_PARSHA, slug, (12, 1), (13, 17)),
+                _span(UNIT_ALIYAH, "1", (12, 1), (13, 17)),
+            ],
+        )
+
+    def test_a_parshah_read_alone_does_not_name_itself_twice(self):
+        _, document = build.parsha_file(self._parsha("tazria", "תזריע"), {}, self.root)
+        root = etree.fromstring(document.encode("utf-8"))
+        div = root.find(f"{TEI}text/{TEI}body/{TEI}div")
+        parsha_urn = div.get("corresp")
+        claimed = [
+            element.get("corresp")
+            for element in root.iter()
+            if element.get("corresp") == parsha_urn
+        ]
+        self.assertEqual(len(claimed), 1, f"{parsha_urn} is claimed {len(claimed)} times")
+
+    def test_the_marker_is_still_emitted(self):
+        _, document = build.parsha_file(self._parsha("tazria", "תזריע"), {}, self.root)
+        units = [m.get("unit") for m in self._milestones(document)]
+        self.assertIn(UNIT_PARSHA, units)
+
+    def test_no_urn_in_a_pair_file_is_claimed_twice(self):
+        """In a pair's file the members' URNs differ from the pair's, so they are kept.
+
+        pair_file marks each member itself, so the members carry only their aliyot here.
+        """
+        tazria = Parsha(
+            slug="tazria", hebrew_name="תזריע", book="leviticus",
+            start=_ref(12, 1), end=_ref(13, 17),
+            spans=[_span(UNIT_ALIYAH, "1", (12, 1), (13, 17))],
+        )
+        metzora = Parsha(
+            slug="metzora", hebrew_name="מצֹרע", book="leviticus",
+            start=_ref(14, 1), end=_ref(15, 33),
+            spans=[_span(UNIT_ALIYAH, "1", (14, 1), (15, 33))],
+        )
+        pair = CombinedParsha(
+            slug=PAIR, hebrew_name="תזריע–מצֹרע", book="leviticus",
+            members=("tazria", "metzora"), start=_ref(12, 1), end=_ref(15, 33),
+            spans=[_span(UNIT_ALIYAH_COMBINED, "1", (12, 1), (15, 33))],
+        )
+        _, document = build.pair_file(pair, [tazria, metzora], {}, {}, self.root)
+        claimed = [
+            element.get("corresp")
+            for element in etree.fromstring(document.encode("utf-8")).iter()
+            if element.get("corresp", "").startswith("urn:x-opensiddur:text:")
+        ]
+        self.assertEqual(len(claimed), len(set(claimed)), sorted(claimed))
+        self.assertIn(f"{build.URN_PREFIX}:parsha/tazria", claimed)

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -1,0 +1,185 @@
+"""Tests for emitting a pair of parshiyot that are sometimes read together as one file.
+
+The readings are synthetic, so the tests keep their meaning when MAM or hebcal is updated.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from lxml import etree
+
+from opensiddur.importer.humash import build
+from opensiddur.importer.humash.aliyot import CombinedParsha, Parsha
+from opensiddur.importer.humash.refs import (
+    UNIT_ALIYAH,
+    UNIT_ALIYAH_COMBINED,
+    ReadingSpan,
+    VerseRef,
+    triennial_unit,
+)
+
+TEI = "{http://www.tei-c.org/ns/1.0}"
+J = "{http://jewishliturgy.org/ns/jlptei/2}"
+
+PAIR = "tazria_metzora"
+PATTERNS = {"TTS": "A", "TST": "B", "STT": "C"}
+
+
+def _ref(chapter: int, verse: int) -> VerseRef:
+    return VerseRef("leviticus", chapter, verse)
+
+
+def _span(unit: str, label: str, start, end, owner=None) -> ReadingSpan:
+    return ReadingSpan(
+        unit=unit, label=label, start=_ref(*start), end=_ref(*end), owner=owner
+    )
+
+
+class TestPairFile(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "numverses.json").write_text(
+            json.dumps({name: [0] + [17] * 30 for name in
+                        ("Genesis", "Exodus", "Leviticus", "Numbers", "Deuteronomy")}),
+            encoding="utf-8",
+        )
+
+        self.tazria = Parsha(
+            slug="tazria", hebrew_name="תזריע", book="leviticus",
+            start=_ref(12, 1), end=_ref(13, 17),
+            spans=[_span(UNIT_ALIYAH, "1", (12, 1), (13, 17))],
+        )
+        self.metzora = Parsha(
+            slug="metzora", hebrew_name="מצֹרע", book="leviticus",
+            start=_ref(14, 1), end=_ref(15, 17),
+            spans=[_span(UNIT_ALIYAH, "1", (14, 1), (15, 17))],
+        )
+        self.pair = CombinedParsha(
+            slug=PAIR, hebrew_name="תזריע–מצֹרע", book="leviticus",
+            members=("tazria", "metzora"), start=_ref(12, 1), end=_ref(15, 17),
+            spans=[
+                # Runs from Tazria into Metzora, which is why the pair needs its own file.
+                _span(UNIT_ALIYAH_COMBINED, "1", (12, 1), (14, 4)),
+                _span(UNIT_ALIYAH_COMBINED, "2", (14, 5), (15, 17)),
+            ],
+        )
+        self.divisions = {
+            "tazria": {("A", 3): [_span(
+                triennial_unit(3, variation="A", owner="tazria"), "A.3.1",
+                (13, 1), (13, 17), owner="tazria",
+            )]},
+            "metzora": {("A", 3): [_span(
+                triennial_unit(3, variation="A", owner="metzora"), "A.3.1",
+                (14, 1), (14, 9), owner="metzora",
+            )]},
+            PAIR: {("combined", 1): [_span(
+                triennial_unit(1, variation="combined"), "combined.1.1", (12, 1), (12, 9),
+            )]},
+        }
+        name, document = build.pair_file(
+            self.pair, [self.tazria, self.metzora], self.divisions, PATTERNS, self.root
+        )
+        self.name = name
+        self.tree = etree.fromstring(document.encode("utf-8"))
+        self.milestones = self.tree.iter(f"{TEI}milestone")
+
+    def _by_unit(self) -> dict[str, list]:
+        found: dict[str, list] = {}
+        for milestone in self.tree.iter(f"{TEI}milestone"):
+            found.setdefault(milestone.get("unit"), []).append(milestone)
+        return found
+
+    def test_the_file_is_named_and_addressed_for_the_pair(self):
+        self.assertEqual(self.name, f"parashat_{PAIR}")
+        div = self.tree.find(f".//{TEI}body/{TEI}div")
+        self.assertEqual(
+            div.get("corresp"), f"urn:x-opensiddur:text:bible:parsha/{PAIR}"
+        )
+
+    def test_each_parshah_keeps_its_own_urn(self):
+        by_unit = self._by_unit()
+        self.assertEqual(
+            [m.get("corresp") for m in by_unit["parsha.annual"]],
+            ["urn:x-opensiddur:text:bible:parsha/tazria",
+             "urn:x-opensiddur:text:bible:parsha/metzora"],
+        )
+        self.assertEqual(
+            by_unit["parsha.combined"][0].get("corresp"),
+            f"urn:x-opensiddur:text:bible:parsha/{PAIR}",
+        )
+        # Both parshiyot have a first aliyah, so the two must not land on one URN.
+        self.assertEqual(
+            [m.get("corresp") for m in by_unit["aliyah.annual"]],
+            ["urn:x-opensiddur:text:bible:parsha/tazria/aliyah_annual/1",
+             "urn:x-opensiddur:text:bible:parsha/metzora/aliyah_annual/1"],
+        )
+
+    def test_a_variation_is_conditioned_on_the_patterns_that_select_it(self):
+        conditionals = self.tree.findall(f".//{J}conditional")
+        self.assertEqual(len(conditionals), 2)  # one per single's variation A
+        strings = [
+            element.text for element in conditionals[0].iter(f"{TEI}string")
+        ]
+        self.assertEqual(strings, ["TTS"])
+        feature = conditionals[0].find(f".//{TEI}f")
+        self.assertEqual(feature.get("name"), "triennial-pattern-tazria-metzora")
+        self.assertEqual(
+            len(self.tree.findall(f".//{J}endConditional")), len(conditionals)
+        )
+
+    def test_the_combined_divisions_are_unconditioned(self):
+        """A volume carries the pair both ways, so its combined reading is always present."""
+        # Each conditional wraps exactly the marker that follows it.
+        conditioned = {
+            next(conditional.itersiblings()).get("unit")
+            for conditional in self.tree.findall(f".//{J}conditional")
+        }
+        by_unit = self._by_unit()
+        self.assertIn("aliyah.combined", by_unit)
+        self.assertIn("aliyah.triennial.combined.1", by_unit)
+        self.assertNotIn("aliyah.combined", conditioned)
+        self.assertNotIn("aliyah.triennial.combined.1", conditioned)
+
+    def test_each_parshahs_variation_has_a_unit_space_of_its_own(self):
+        by_unit = self._by_unit()
+        self.assertIn("aliyah.triennial.tazria.A.3", by_unit)
+        self.assertIn("aliyah.triennial.metzora.A.3", by_unit)
+
+    def test_the_text_is_transcluded_once_end_to_end(self):
+        targets = [
+            element.get("target").rsplit(":", 1)[1]
+            for element in self.tree.iter(f"{J}transclude")
+        ]
+        ranges = []
+        for target in targets:
+            start, _, end = target.partition("-")
+            _, chapter, verse = start.split("/")
+            end_chapter, end_verse = end.split("/")
+            ranges.append(((int(chapter), int(verse)), (int(end_chapter), int(end_verse))))
+        self.assertEqual(ranges[0][0], (12, 1))
+        self.assertEqual(ranges[-1][1], (15, 17))
+        for earlier, later in zip(ranges, ranges[1:]):
+            self.assertGreater(later[0], earlier[1], "the text is emitted more than once")
+
+
+class TestBookFile(unittest.TestCase):
+    def test_a_pair_is_transcluded_once_by_the_pairs_urn(self):
+        parshiyot = [
+            Parsha(slug=slug, hebrew_name=slug, book="leviticus", start=_ref(1, 1))
+            for slug in ("vayikra", "tazria", "metzora", "emor")
+        ]
+        _, document = build.book_file("leviticus", parshiyot)
+        targets = [
+            element.get("target")
+            for element in etree.fromstring(document.encode("utf-8")).iter(f"{J}transclude")
+        ]
+        self.assertEqual(
+            [target.rsplit("/", 1)[1] for target in targets],
+            ["vayikra", PAIR, "emor"],
+        )

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -281,12 +281,195 @@ class TestHaftarahFile(unittest.TestCase):
         division = tree.findall(f".//{TEI}div[@n='triennial_3']")[0]
         self.assertEqual(
             [child.tag for child in division][1:],
-            [f"{TEI}note", f"{J}transclude", f"{TEI}note"],
+            [f"{TEI}milestone", f"{TEI}note", f"{J}transclude", f"{TEI}note"],
         )
         self.assertEqual(
             division.find(f"{J}transclude").get("target"),
             "urn:x-opensiddur:text:bible:nahum/2/2-2/3",
         )
+
+
+class TestCitation(unittest.TestCase):
+    """build._citation/_citation_range: the "<book> <chapter>:<verse>-..." string a haftarah
+    or festival reading's citation milestone carries (see TestPassageCitationMilestones)."""
+
+    def test_a_single_verse_span_has_no_dash(self):
+        span = ReadingSpan(
+            unit="haftarah", label="1",
+            start=VerseRef("isaiah", 42, 5), end=VerseRef("isaiah", 42, 5),
+        )
+        self.assertEqual(build._citation([span]), "ישעיהו 42:5")
+
+    def test_a_multi_verse_span_gives_a_range(self):
+        span = ReadingSpan(
+            unit="haftarah", label="1",
+            start=VerseRef("isaiah", 42, 5), end=VerseRef("isaiah", 43, 10),
+        )
+        self.assertEqual(build._citation([span]), "ישעיהו 42:5–43:10")
+
+    def test_a_second_span_in_the_same_book_does_not_repeat_the_name(self):
+        spans = [
+            ReadingSpan(
+                unit="haftarah", label="1",
+                start=VerseRef("jeremiah", 34, 8), end=VerseRef("jeremiah", 34, 22),
+            ),
+            ReadingSpan(
+                unit="haftarah", label="2",
+                start=VerseRef("jeremiah", 33, 25), end=VerseRef("jeremiah", 33, 26),
+            ),
+        ]
+        self.assertEqual(build._citation(spans), "ירמיהו 34:8–34:22; 33:25–33:26")
+
+    def test_a_span_in_a_different_book_restates_the_name(self):
+        spans = [
+            ReadingSpan(
+                unit="haftarah", label="1",
+                start=VerseRef("kings_1", 18, 46), end=VerseRef("kings_1", 18, 46),
+            ),
+            ReadingSpan(
+                unit="haftarah", label="2",
+                start=VerseRef("malachi", 3, 4), end=VerseRef("malachi", 3, 24),
+            ),
+        ]
+        self.assertEqual(build._citation(spans), "מלכים א 18:46; מלאכי 3:4–3:24")
+
+    def test_a_torah_book_is_named_too(self):
+        """Festival aliyot cite a Torah book, not only the haftarah's prophetic ones."""
+        self.assertEqual(
+            build._citation_range("genesis", VerseRef("genesis", 22, 1), VerseRef("genesis", 22, 24)),
+            "בראשית 22:1–22:24",
+        )
+
+
+class TestPassageContiguity(unittest.TestCase):
+    """build._is_contiguous decides whether a passage's next span picks up exactly where
+    the one before it left off, or whether the reading jumps."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "numverses.json").write_text(
+            json.dumps({"Jeremiah": [0] + [30] * 52, "Isaiah": [0] + [30] * 66}),
+            encoding="utf-8",
+        )
+
+    def test_the_next_verse_of_the_same_book_is_contiguous(self):
+        prev = ReadingSpan(
+            unit="haftarah", label="1",
+            start=VerseRef("isaiah", 42, 1), end=VerseRef("isaiah", 42, 5),
+        )
+        following = ReadingSpan(
+            unit="haftarah", label="2",
+            start=VerseRef("isaiah", 42, 6), end=VerseRef("isaiah", 42, 9),
+        )
+        self.assertTrue(build._is_contiguous(prev, following, self.root))
+
+    def test_a_chapter_boundary_is_still_contiguous(self):
+        prev = ReadingSpan(
+            unit="haftarah", label="1",
+            start=VerseRef("isaiah", 42, 1), end=VerseRef("isaiah", 42, 30),
+        )
+        following = ReadingSpan(
+            unit="haftarah", label="2",
+            start=VerseRef("isaiah", 43, 1), end=VerseRef("isaiah", 43, 5),
+        )
+        self.assertTrue(build._is_contiguous(prev, following, self.root))
+
+    def test_a_backward_jump_is_not_contiguous(self):
+        """Mishpatim's haftarah: Jeremiah 34:8-22, then back to 33:25-26."""
+        prev = ReadingSpan(
+            unit="haftarah", label="1",
+            start=VerseRef("jeremiah", 34, 8), end=VerseRef("jeremiah", 34, 22),
+        )
+        following = ReadingSpan(
+            unit="haftarah", label="2",
+            start=VerseRef("jeremiah", 33, 25), end=VerseRef("jeremiah", 33, 26),
+        )
+        self.assertFalse(build._is_contiguous(prev, following, self.root))
+
+    def test_a_skip_ahead_is_not_contiguous(self):
+        prev = ReadingSpan(
+            unit="haftarah", label="1",
+            start=VerseRef("isaiah", 42, 1), end=VerseRef("isaiah", 42, 5),
+        )
+        following = ReadingSpan(
+            unit="haftarah", label="2",
+            start=VerseRef("isaiah", 42, 10), end=VerseRef("isaiah", 42, 15),
+        )
+        self.assertFalse(build._is_contiguous(prev, following, self.root))
+
+    def test_a_change_of_book_is_not_contiguous(self):
+        prev = ReadingSpan(
+            unit="haftarah", label="1",
+            start=VerseRef("isaiah", 42, 1), end=VerseRef("isaiah", 42, 5),
+        )
+        following = ReadingSpan(
+            unit="haftarah", label="2",
+            start=VerseRef("jeremiah", 1, 1), end=VerseRef("jeremiah", 1, 5),
+        )
+        self.assertFalse(build._is_contiguous(prev, following, self.root))
+
+
+class TestPassageCitationMilestones(unittest.TestCase):
+    """_passage_xml (via haftarah_file) opens a passage with a citation, and states one
+    again at any span that does not pick up where the one before it left off."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "numverses.json").write_text(
+            json.dumps({"Jeremiah": [0] + [30] * 52}), encoding="utf-8",
+        )
+
+    def _citations(self, passages) -> list[str]:
+        _, document = build.haftarah_file("mishpatim", passages, None, self.root)
+        tree = etree.fromstring(document.encode("utf-8"))
+        return [m.get("n") for m in tree.iter(f"{TEI}milestone") if m.get("unit") == "citation"]
+
+    def test_a_continuous_passage_gets_one_citation(self):
+        passage = _passage("isaiah", (42, 5), (43, 10))
+        self.assertEqual(self._citations([passage]), ["ישעיהו 42:5–43:10"])
+
+    def test_a_discontinuous_passage_gets_a_second_citation_at_the_jump(self):
+        passage = Passage(
+            key="mishpatim",
+            spans=[
+                ReadingSpan(
+                    unit="haftarah", label="1",
+                    start=VerseRef("jeremiah", 34, 8), end=VerseRef("jeremiah", 34, 22),
+                ),
+                ReadingSpan(
+                    unit="haftarah", label="2",
+                    start=VerseRef("jeremiah", 33, 25), end=VerseRef("jeremiah", 33, 26),
+                ),
+            ],
+        )
+        self.assertEqual(
+            self._citations([passage]),
+            ["ירמיהו 34:8–34:22; 33:25–33:26", "ירמיהו 33:25–33:26"],
+        )
+
+    def test_a_contiguous_two_span_passage_gets_only_the_opening_citation(self):
+        passage = Passage(
+            key="test",
+            spans=[
+                ReadingSpan(
+                    unit="haftarah", label="1",
+                    start=VerseRef("jeremiah", 1, 1), end=VerseRef("jeremiah", 1, 5),
+                ),
+                ReadingSpan(
+                    unit="haftarah", label="2",
+                    start=VerseRef("jeremiah", 1, 6), end=VerseRef("jeremiah", 1, 10),
+                ),
+            ],
+        )
+        self.assertEqual(self._citations([passage]), ["ירמיהו 1:1–1:5; 1:6–1:10"])
 
 
 class TestBookFile(unittest.TestCase):

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -307,7 +307,7 @@ class TestBookFile(unittest.TestCase):
 
 class TestIndexFile(unittest.TestCase):
     def test_has_a_title_page_before_the_body(self):
-        _, document = build.index_file([])
+        _, document = build.index_file({})
         root = etree.fromstring(document.encode("utf-8"))
         text = root.find(f"{TEI}text")
         front = text.find(f"{TEI}front")
@@ -324,6 +324,44 @@ class TestIndexFile(unittest.TestCase):
         alt = doc_title.find(f'{TEI}titlePart[@type="alt"]')
         self.assertEqual(alt.get(f"{XML}lang"), "en")
         self.assertEqual(alt.text, "Humash")
+
+    def _body(self, sections: dict) -> object:
+        _, document = build.index_file(sections)
+        root = etree.fromstring(document.encode("utf-8"))
+        return root.find(f"{TEI}text/{TEI}body/{TEI}div")
+
+    def test_the_books_stand_directly_under_the_volume(self):
+        body = self._body({})
+        targets = [t.get("target") for t in body.findall(f"{J}transclude")]
+        self.assertEqual(len(targets), 5)
+        self.assertTrue(all("humash/" in target for target in targets))
+
+    def test_each_group_becomes_a_headed_section(self):
+        body = self._body({
+            "haftarot": [f"{build.URN_PREFIX}:haftarah/bereshit"],
+            "megillot": [f"{build.URN_PREFIX}:megillah/esther"],
+            "readings": [f"{build.URN_PREFIX}:reading/pesach_i"],
+        })
+        sections = body.findall(f"{TEI}div")
+        self.assertEqual(
+            [section.get("n") for section in sections], ["haftarot", "megillot", "readings"]
+        )
+        self.assertEqual(
+            [section.find(f"{TEI}head").text for section in sections],
+            [title for _, title in build.SECTIONS],
+        )
+
+    def test_a_section_holds_its_own_readings(self):
+        body = self._body({"megillot": [f"{build.URN_PREFIX}:megillah/esther"]})
+        section = body.find(f'{TEI}div[@n="megillot"]')
+        self.assertEqual(
+            [t.get("target") for t in section.findall(f"{J}transclude")],
+            [f"{build.URN_PREFIX}:megillah/esther"],
+        )
+
+    def test_an_empty_group_gets_no_section(self):
+        body = self._body({"haftarot": [], "megillot": [], "readings": []})
+        self.assertEqual(body.findall(f"{TEI}div"), [])
 
 
 class TestMaftirMilestoneTitle(unittest.TestCase):

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -10,7 +10,8 @@ from pathlib import Path
 
 from lxml import etree
 
-from opensiddur.importer.humash import build
+from opensiddur.importer.humash import build, names
+from opensiddur.importer.util.hebrew import normalize_hebrew
 from opensiddur.importer.humash.aliyot import CombinedParsha, Parsha
 from opensiddur.importer.humash.readings import Passage
 from opensiddur.importer.humash.refs import (
@@ -304,6 +305,27 @@ class TestBookFile(unittest.TestCase):
         )
 
 
+class TestIndexFile(unittest.TestCase):
+    def test_has_a_title_page_before_the_body(self):
+        _, document = build.index_file([])
+        root = etree.fromstring(document.encode("utf-8"))
+        text = root.find(f"{TEI}text")
+        front = text.find(f"{TEI}front")
+        self.assertIsNotNone(front)
+        self.assertEqual(list(text).index(front), 0)
+
+        doc_title = front.find(f"{TEI}titlePage/{TEI}docTitle")
+        self.assertIsNotNone(doc_title)
+
+        main = doc_title.find(f'{TEI}titlePart[@type="main"]')
+        self.assertEqual(main.get(f"{XML}lang"), "he")
+        self.assertEqual(main.text, "חֻמָּשׁ")
+
+        alt = doc_title.find(f'{TEI}titlePart[@type="alt"]')
+        self.assertEqual(alt.get(f"{XML}lang"), "en")
+        self.assertEqual(alt.text, "Humash")
+
+
 class TestMaftirMilestoneTitle(unittest.TestCase):
     """Regression: Sukkot Chol HaMoed's per-day maftir labels ("maftir_day1", etc., after
     readings.festival_readings normalizes them) used to have no entry in ALIYAH_TITLES and
@@ -408,3 +430,110 @@ class TestMegillahFile(unittest.TestCase):
     def test_the_range_ends_on_the_last_verse_of_the_last_chapter(self):
         targets = self._targets("ruth", "רוּת", "shavuot")
         self.assertEqual(targets[0], f"{build.URN_PREFIX}:ruth/1/1-4/22")
+
+
+class TestVocalizedNames(unittest.TestCase):
+    """Titles are pointed. The shared table's names are the form to match source text
+    against; a heading wants vowels."""
+
+    def test_every_pointed_name_has_the_same_consonants_as_the_shared_table(self):
+        for slug, pointed in names.SLUG_TO_VOCALIZED.items():
+            with self.subTest(slug=slug):
+                self.assertEqual(
+                    normalize_hebrew(pointed),
+                    normalize_hebrew(names.SLUG_TO_HEBREW[slug]),
+                    f"{pointed!r} is not {names.SLUG_TO_HEBREW[slug]!r} with vowels",
+                )
+
+    def test_every_parshah_and_pair_is_pointed(self):
+        for slug in names.SLUG_TO_HEBREW:
+            with self.subTest(slug=slug):
+                self.assertIn(slug, names.SLUG_TO_VOCALIZED)
+
+    def test_a_pair_joins_its_members_pointed_names(self):
+        self.assertEqual(
+            names.SLUG_TO_VOCALIZED["matot_masei"],
+            f"{names.SLUG_TO_VOCALIZED['matot']}–{names.SLUG_TO_VOCALIZED['masei']}",
+        )
+
+    def test_an_unknown_slug_falls_back_to_itself(self):
+        self.assertEqual(names.vocalized_name("no_such_parshah"), "no_such_parshah")
+
+    def test_every_pointed_book_name_has_the_same_consonants_as_the_table(self):
+        from opensiddur.importer.humash.refs import (
+            SLUG_TO_HEBREW_BOOK, SLUG_TO_VOCALIZED_BOOK,
+        )
+        for slug, pointed in SLUG_TO_VOCALIZED_BOOK.items():
+            with self.subTest(slug=slug):
+                self.assertEqual(
+                    normalize_hebrew(pointed), normalize_hebrew(SLUG_TO_HEBREW_BOOK[slug])
+                )
+
+    def test_every_book_is_pointed(self):
+        from opensiddur.importer.humash.refs import (
+            SLUG_TO_HEBREW_BOOK, SLUG_TO_VOCALIZED_BOOK,
+        )
+        self.assertEqual(set(SLUG_TO_VOCALIZED_BOOK), set(SLUG_TO_HEBREW_BOOK))
+
+    def test_a_book_heading_is_pointed(self):
+        from opensiddur.importer.humash.refs import SLUG_TO_VOCALIZED_BOOK
+        parshiyot = [
+            Parsha(slug="vayikra", hebrew_name="ויקרא", book="leviticus", start=_ref(1, 1))
+        ]
+        _, document = build.book_file("leviticus", parshiyot)
+        heads = [
+            element.text
+            for element in etree.fromstring(document.encode("utf-8")).iter(f"{TEI}head")
+        ]
+        self.assertIn(SLUG_TO_VOCALIZED_BOOK["leviticus"], heads)
+
+    def test_a_parshah_heading_is_pointed(self):
+        parsha = Parsha(
+            slug="tazria", hebrew_name="תזריע", book="leviticus",
+            start=_ref(12, 1), end=_ref(13, 17),
+            spans=[_span(UNIT_ALIYAH, "1", (12, 1), (13, 17))],
+        )
+        _, document = build.parsha_file(parsha, {}, None)
+        heads = [
+            element.text
+            for element in etree.fromstring(document.encode("utf-8")).iter(f"{TEI}head")
+        ]
+        self.assertIn(names.SLUG_TO_VOCALIZED["tazria"], heads)
+
+
+class TestFestivalHaftarahHeading(unittest.TestCase):
+    """A festival's haftarah is a headed division, not a continuation of the maftir."""
+
+    def _heads(self, reading: dict) -> list[str]:
+        _, document = build.festival_file("pesach_i", reading, None)
+        return [
+            element.text
+            for element in etree.fromstring(document.encode("utf-8")).iter(f"{TEI}head")
+        ]
+
+    def _reading(self, rite, title) -> dict:
+        span = _span(UNIT_ALIYAH, "1", (12, 21), (12, 28))
+        passage = Passage(
+            key="Pesach I",
+            spans=[ReadingSpan(
+                unit="haftarah", label="1",
+                start=VerseRef("joshua", 5, 2), end=VerseRef("joshua", 6, 1),
+            )],
+            rite=rite,
+            title=title,
+        )
+        return {"name": "Pesach I", "aliyot": [span], "haftarot": [passage]}
+
+    def test_a_single_rite_haftarah_is_still_headed(self):
+        self.assertIn(build.HAFTARAH_TITLE, self._heads(self._reading(None, None)))
+
+    def test_a_rite_heading_sits_under_the_haftarah_heading(self):
+        heads = self._heads(self._reading("ashkenaz", "מִנְהַג אַשְׁכְּנַז"))
+        self.assertIn(build.HAFTARAH_TITLE, heads)
+        self.assertIn("מִנְהַג אַשְׁכְּנַז", heads)
+        self.assertLess(heads.index(build.HAFTARAH_TITLE), heads.index("מִנְהַג אַשְׁכְּנַז"))
+
+    def test_a_reading_with_no_haftarah_gets_no_haftarah_heading(self):
+        reading = {"name": "Pesach I", "aliyot": [_span(UNIT_ALIYAH, "1", (12, 21), (12, 28))],
+                   "haftarot": []}
+        self.assertNotIn(build.HAFTARAH_TITLE, self._heads(reading))

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -328,3 +328,83 @@ class TestMaftirMilestoneTitle(unittest.TestCase):
             for day in (1, 2, 3, 4, 5)
         }
         self.assertEqual(len(titles), 5)
+
+
+class TestHaftarahOrder(unittest.TestCase):
+    """Haftarot follow the order the parshiyot are read, not the order of their slugs.
+
+    The parshiyot here are synthetic, so this holds whatever MAM and hebcal say.
+    """
+
+    def _parshiyot(self, *slugs):
+        return [
+            Parsha(slug=slug, hebrew_name=slug, book="leviticus", start=_ref(1, 1))
+            for slug in slugs
+        ]
+
+    def test_reading_order_is_kept_rather_than_alphabetical(self):
+        parshiyot = self._parshiyot("vayikra", "tzav", "shmini", "emor")
+        available = {slug: [] for slug in ("emor", "shmini", "tzav", "vayikra")}
+        self.assertEqual(
+            build.haftarah_order(parshiyot, available),
+            ["vayikra", "tzav", "shmini", "emor"],
+        )
+
+    def test_a_pair_follows_both_of_its_members(self):
+        parshiyot = self._parshiyot("vayikra", "tazria", "metzora", "emor")
+        available = {slug: [] for slug in ("vayikra", "tazria", "metzora", PAIR, "emor")}
+        self.assertEqual(
+            build.haftarah_order(parshiyot, available),
+            ["vayikra", "tazria", "metzora", PAIR, "emor"],
+        )
+
+    def test_a_parshah_with_no_haftarah_is_skipped(self):
+        parshiyot = self._parshiyot("vayikra", "tzav", "shmini")
+        self.assertEqual(
+            build.haftarah_order(parshiyot, {"vayikra": [], "shmini": []}),
+            ["vayikra", "shmini"],
+        )
+
+    def test_a_haftarah_belonging_to_no_parshah_is_kept_at_the_end(self):
+        parshiyot = self._parshiyot("vayikra", "tzav")
+        order = build.haftarah_order(parshiyot, {"tzav": [], "vayikra": [], "unknown": []})
+        self.assertEqual(order, ["vayikra", "tzav", "unknown"])
+
+
+class TestMegillahFile(unittest.TestCase):
+    """A megillah is read whole, but must still name the verses it is made of.
+
+    Asking for the book's own URN would take whichever project stands first in priority order
+    and claims that book, whether or not that project has the text — and one that carries only
+    the title exists. The verse counts here are synthetic.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "numverses.json").write_text(
+            json.dumps({"Esther": [0, 22, 23, 15], "Ruth": [0, 22, 23, 18, 22]}),
+            encoding="utf-8",
+        )
+
+    def _targets(self, book: str, hebrew: str, holiday: str) -> list[str]:
+        _, document = build.megillah_file(book, hebrew, holiday, self.root)
+        return [
+            element.get("target")
+            for element in etree.fromstring(document.encode("utf-8")).iter(f"{J}transclude")
+        ]
+
+    def test_the_whole_book_is_transcluded_as_a_verse_range(self):
+        targets = self._targets("esther", "אֶסְתֵּר", "purim")
+        self.assertEqual(targets[0], f"{build.URN_PREFIX}:esther/1/1-3/15")
+
+    def test_the_books_own_urn_is_not_used(self):
+        targets = self._targets("esther", "אֶסְתֵּר", "purim")
+        self.assertNotIn(f"{build.URN_PREFIX}:esther", targets)
+
+    def test_the_range_ends_on_the_last_verse_of_the_last_chapter(self):
+        targets = self._targets("ruth", "רוּת", "shavuot")
+        self.assertEqual(targets[0], f"{build.URN_PREFIX}:ruth/1/1-4/22")

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -16,6 +16,7 @@ from opensiddur.importer.humash.readings import Passage
 from opensiddur.importer.humash.refs import (
     UNIT_ALIYAH,
     UNIT_ALIYAH_COMBINED,
+    UNIT_MAFTIR,
     ReadingSpan,
     VerseRef,
     triennial_unit,
@@ -301,3 +302,29 @@ class TestBookFile(unittest.TestCase):
             [target.rsplit("/", 1)[1] for target in targets],
             ["vayikra", PAIR, "emor"],
         )
+
+
+class TestMaftirMilestoneTitle(unittest.TestCase):
+    """Regression: Sukkot Chol HaMoed's per-day maftir labels ("maftir_day1", etc., after
+    readings.festival_readings normalizes them) used to have no entry in ALIYAH_TITLES and
+    so fell back to the raw label, which is Latin text with no place inside a Hebrew RTL
+    milestone (it prints mirrored, as `readings.py`'s TRIENNIAL_YEARS comment warns).
+    """
+
+    def test_ordinary_maftir_is_unchanged(self):
+        span = _span(UNIT_MAFTIR, "maftir", (1, 1), (1, 1))
+        self.assertEqual(build._milestone_title(span), "מַפְטִיר")
+
+    def test_a_days_maftir_gets_a_hebrew_day_qualified_title(self):
+        span = _span(UNIT_MAFTIR, "maftir_day1", (1, 1), (1, 1))
+        title = build._milestone_title(span)
+        self.assertNotIn("day", title.lower())
+        self.assertNotIn("1", title)
+        self.assertIn("מַפְטִיר", title)
+
+    def test_each_day_gets_a_distinct_title(self):
+        titles = {
+            build._milestone_title(_span(UNIT_MAFTIR, f"maftir_day{day}", (1, 1), (1, 1)))
+            for day in (1, 2, 3, 4, 5)
+        }
+        self.assertEqual(len(titles), 5)

--- a/opensiddur/tests/importer/humash/test_festival_names.py
+++ b/opensiddur/tests/importer/humash/test_festival_names.py
@@ -38,11 +38,11 @@ class TestHebrewName(unittest.TestCase):
 
     def test_a_reading_named_by_its_parshah(self):
         self.assertEqual(
-            hebrew_name("Masei on Shabbat Rosh Chodesh"), "מסעי (בְּשַׁבָּת רֹאשׁ חֹדֶשׁ)"
+            hebrew_name("Masei on Shabbat Rosh Chodesh"), "מַסְעֵי (בְּשַׁבָּת רֹאשׁ חֹדֶשׁ)"
         )
 
     def test_a_parshah_named_inside_a_qualifier(self):
-        self.assertEqual(hebrew_name("Shabbat Shuva (with Ha'azinu)"), "שַׁבָּת שׁוּבָה (עִם האזינו)")
+        self.assertEqual(hebrew_name("Shabbat Shuva (with Ha'azinu)"), "שַׁבָּת שׁוּבָה (עִם הַאֲזִינוּ)")
 
     def test_an_unknown_occasion_keeps_its_english_and_warns(self):
         with self.assertLogs("opensiddur.importer.humash.festival_names", logging.WARNING):

--- a/opensiddur/tests/importer/humash/test_festival_names.py
+++ b/opensiddur/tests/importer/humash/test_festival_names.py
@@ -1,0 +1,67 @@
+"""Tests for the Hebrew titles of the festival readings.
+
+The names given here are hebcal's own naming conventions rather than a copy of its data, so
+these keep their meaning when hebcal adds or renames a reading.
+"""
+
+import logging
+import unittest
+
+from opensiddur.importer.humash.festival_names import hebrew_name
+
+
+class TestHebrewName(unittest.TestCase):
+    def test_a_plain_occasion(self):
+        self.assertEqual(hebrew_name("Shabbat Shekalim"), "שַׁבָּת שְׁקָלִים")
+
+    def test_a_qualifier_becomes_a_hebrew_parenthetical(self):
+        self.assertEqual(hebrew_name("Yom Kippur (Mincha)"), "יוֹם הַכִּפּוּרִים (מִנְחָה)")
+
+    def test_a_roman_numeral_becomes_a_hebrew_letter(self):
+        self.assertEqual(hebrew_name("Pesach VII"), "פֶּסַח ז׳")
+
+    def test_a_numeral_and_a_qualifier_together(self):
+        self.assertEqual(hebrew_name("Sukkot I (on Shabbat)"), "סֻכּוֹת א׳ (בְּשַׁבָּת)")
+
+    def test_a_numbered_day(self):
+        self.assertEqual(hebrew_name("Chanukah Day 3"), "חֲנֻכָּה יוֹם ג׳")
+
+    def test_the_longer_occasion_wins_over_the_shorter_one(self):
+        """"Shabbat Rosh Chodesh Chanukah" is its own reading, not Rosh Chodesh."""
+        self.assertEqual(
+            hebrew_name("Shabbat Rosh Chodesh Chanukah"), "שַׁבָּת רֹאשׁ חֹדֶשׁ חֲנֻכָּה"
+        )
+
+    def test_a_month_is_not_read_as_an_ordinal(self):
+        """Adar II is the second Adar, not the second Rosh Chodesh Adar."""
+        self.assertEqual(hebrew_name("Rosh Chodesh Adar II"), "רֹאשׁ חֹדֶשׁ אֲדָר ב׳")
+
+    def test_a_reading_named_by_its_parshah(self):
+        self.assertEqual(
+            hebrew_name("Masei on Shabbat Rosh Chodesh"), "מסעי (בְּשַׁבָּת רֹאשׁ חֹדֶשׁ)"
+        )
+
+    def test_a_parshah_named_inside_a_qualifier(self):
+        self.assertEqual(hebrew_name("Shabbat Shuva (with Ha'azinu)"), "שַׁבָּת שׁוּבָה (עִם האזינו)")
+
+    def test_an_unknown_occasion_keeps_its_english_and_warns(self):
+        with self.assertLogs("opensiddur.importer.humash.festival_names", logging.WARNING):
+            self.assertEqual(hebrew_name("Feast of Something"), "Feast of Something")
+
+    def test_an_unknown_qualifier_keeps_its_english_and_warns(self):
+        with self.assertLogs("opensiddur.importer.humash.festival_names", logging.WARNING):
+            self.assertEqual(hebrew_name("Purim (in a leap year)"), "פּוּרִים (in a leap year)")
+
+    def test_no_hebrew_title_contains_latin_letters(self):
+        for name in (
+            "Pesach Chol ha-Moed Day 2 on Sunday",
+            "Sukkot Final Day (Hoshana Raba)",
+            "Ta'anit Esther (Mincha)",
+            "Rosh Chodesh Sh'vat",
+            "Fast Day (Morning)",
+        ):
+            with self.subTest(name=name):
+                self.assertFalse(
+                    any(c.isascii() and c.isalpha() for c in hebrew_name(name)),
+                    hebrew_name(name),
+                )

--- a/opensiddur/tests/importer/humash/test_model.py
+++ b/opensiddur/tests/importer/humash/test_model.py
@@ -1,0 +1,150 @@
+"""Tests for turning overlapping reading divisions into a linear sequence.
+
+These use synthetic spans rather than the real reading data, so they keep their meaning when
+the sources are updated.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from opensiddur.importer.humash import model
+from opensiddur.importer.humash.refs import (
+    UNIT_ALIYAH,
+    UNIT_MAFTIR,
+    UNIT_WEEKDAY,
+    ReadingSpan,
+    VerseRef,
+)
+
+
+def _verse_counts(root: Path) -> None:
+    directory = root / "hebcal_leyning"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "numverses.json").write_text(
+        json.dumps({name: [0] + [31] * 40 for name in
+                    ("Genesis", "Exodus", "Leviticus", "Numbers", "Deuteronomy")}),
+        encoding="utf-8",
+    )
+
+
+def _span(unit: str, label: str, start: tuple[int, int], end: tuple[int, int]) -> ReadingSpan:
+    return ReadingSpan(
+        unit=unit, label=label,
+        start=VerseRef("genesis", *start), end=VerseRef("genesis", *end),
+    )
+
+
+class TestSegmentation(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        _verse_counts(self.root)
+
+    def _ranges(self, segments) -> list[tuple[tuple[int, int], tuple[int, int]]]:
+        return [
+            ((s.start.chapter, s.start.verse), (s.end.chapter, s.end.verse)) for s in segments
+        ]
+
+    def test_the_text_is_cut_at_every_boundary_and_emitted_once(self):
+        spans = [
+            _span(UNIT_ALIYAH, "1", (1, 1), (1, 10)),
+            _span(UNIT_ALIYAH, "2", (1, 11), (1, 20)),
+            _span(UNIT_WEEKDAY, "1", (1, 1), (1, 5)),
+        ]
+        segments = model.segment_reading(
+            spans, VerseRef("genesis", 1, 1), VerseRef("genesis", 1, 20), self.root
+        )
+        # The weekday boundary at 1:5 cuts aliyah 1 in two; no verse is emitted twice.
+        self.assertEqual(
+            self._ranges(segments), [((1, 1), (1, 5)), ((1, 6), (1, 10)), ((1, 11), (1, 20))]
+        )
+        self.assertFalse(any(segment.duplicate for segment in segments))
+
+    def test_a_maftir_inside_the_last_aliyah_splits_it_without_repeating_it(self):
+        spans = [
+            _span(UNIT_ALIYAH, "7", (1, 1), (1, 10)),
+            _span(UNIT_MAFTIR, "maftir", (1, 8), (1, 10)),
+        ]
+        segments = model.segment_reading(
+            spans, VerseRef("genesis", 1, 1), VerseRef("genesis", 1, 10), self.root
+        )
+        self.assertEqual(self._ranges(segments), [((1, 1), (1, 7)), ((1, 8), (1, 10))])
+        # The maftir milestone opens the second segment; the aliyah still covers both.
+        self.assertEqual([s.unit for s in segments[0].opening], [UNIT_ALIYAH])
+        self.assertEqual([s.unit for s in segments[1].opening], [UNIT_MAFTIR])
+
+    def test_segments_close_before_the_next_one_opens(self):
+        """A span ending short of the next start must not swallow the gap between them."""
+        spans = [
+            _span(UNIT_WEEKDAY, "1", (1, 1), (1, 3)),
+            _span(UNIT_ALIYAH, "1", (1, 1), (1, 10)),
+        ]
+        segments = model.segment_reading(
+            spans, VerseRef("genesis", 1, 1), VerseRef("genesis", 1, 10), self.root
+        )
+        self.assertEqual(self._ranges(segments), [((1, 1), (1, 3)), ((1, 4), (1, 10))])
+
+    def test_overlap_inside_one_unit_repeats_the_shared_verses(self):
+        """Weekday Rosh Hodesh: kohen ends at 28:3 and levi begins there, so it is read twice."""
+        spans = [
+            _span(UNIT_WEEKDAY, "1", (28, 1), (28, 3)),
+            _span(UNIT_WEEKDAY, "2", (28, 3), (28, 5)),
+        ]
+        segments = model.segment_reading(spans, sourcetexts_root=self.root)
+        self.assertEqual(self._ranges(segments), [((28, 1), (28, 3)), ((28, 3), (28, 5))])
+        self.assertFalse(segments[0].duplicate)
+        self.assertTrue(segments[1].duplicate)
+
+    def test_overlap_between_units_does_not_repeat_anything(self):
+        """Only same-unit overlap means the text is read twice."""
+        spans = [
+            _span(UNIT_ALIYAH, "7", (1, 1), (1, 10)),
+            _span(UNIT_MAFTIR, "maftir", (1, 8), (1, 10)),
+        ]
+        self.assertFalse(model.has_internal_overlap(spans))
+        self.assertEqual(model.overlapping_units(spans), [])
+
+    def test_duplication_can_be_refused_for_a_continuous_reading(self):
+        """A parshah is emitted once even if one scheme overlaps itself somewhere in it."""
+        spans = [
+            _span(UNIT_ALIYAH, "1", (1, 1), (1, 10)),
+            _span(UNIT_ALIYAH, "2", (1, 8), (1, 20)),
+        ]
+        self.assertTrue(model.has_internal_overlap(spans))
+        segments = model.segment_reading(
+            spans, VerseRef("genesis", 1, 1), VerseRef("genesis", 1, 20), self.root,
+            allow_duplication=False,
+        )
+        self.assertFalse(any(segment.duplicate for segment in segments))
+        emitted = sum(
+            (s.end.verse - s.start.verse + 1) for s in segments
+        )
+        self.assertEqual(emitted, 20)
+
+    def test_overlapping_units_names_the_scheme_at_fault(self):
+        spans = [
+            _span(UNIT_ALIYAH, "1", (1, 1), (1, 10)),
+            _span(UNIT_ALIYAH, "2", (1, 8), (1, 20)),
+            _span(UNIT_WEEKDAY, "1", (1, 1), (1, 5)),
+        ]
+        self.assertEqual(model.overlapping_units(spans), [UNIT_ALIYAH])
+
+    def test_a_boundary_crossing_a_chapter_end_steps_into_the_next_chapter(self):
+        spans = [
+            _span(UNIT_ALIYAH, "1", (1, 1), (1, 31)),
+            _span(UNIT_ALIYAH, "2", (2, 1), (2, 5)),
+        ]
+        segments = model.segment_reading(
+            spans, VerseRef("genesis", 1, 1), VerseRef("genesis", 2, 5), self.root
+        )
+        self.assertEqual(self._ranges(segments), [((1, 1), (1, 31)), ((2, 1), (2, 5))])
+
+    def test_no_spans_yields_no_segments(self):
+        self.assertEqual(model.segment_reading([], sourcetexts_root=self.root), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/importer/humash/test_readings.py
+++ b/opensiddur/tests/importer/humash/test_readings.py
@@ -10,8 +10,10 @@ division and the table saying which variation each cycle pattern selects.
 import json
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
+from opensiddur.importer.humash import readings
 from opensiddur.importer.humash.readings import (
     festival_readings,
     triennial,
@@ -268,3 +270,51 @@ class TestFestivalReadingsMaftir(unittest.TestCase):
     def test_sukkot_chol_hamoed_non_maftir_aliyah_is_unaffected(self):
         span = self._span("sukkot_shabbat_chol_ha_moed", "1")
         self.assertEqual(span.unit, UNIT_ALIYAH)
+
+
+class TestHebcalCorrections(unittest.TestCase):
+    """The table that repairs references hebcal names to verses that do not exist.
+
+    The data here is synthetic and shaped like the real file, so these keep their meaning
+    whether or not hebcal has fixed anything.
+    """
+
+    NAME = "triennial-haft.json"
+
+    def setUp(self):
+        self.corrections = {
+            self.NAME: {("Ki Teitzei", "3", 1, "b"): ("4:20", "48:20")},
+        }
+        patcher = unittest.mock.patch.object(
+            readings, "HEBCAL_CORRECTIONS", self.corrections
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _data(self, value: str) -> dict:
+        return {"Ki Teitzei": {"3": [
+            {"k": "Isaiah", "b": "48:12", "e": "48:21"},
+            {"k": "Isaiah", "b": value, "e": "48:20"},
+        ]}}
+
+    def test_the_bad_reference_is_replaced(self):
+        data = readings._apply_corrections(self.NAME, self._data("4:20"))
+        self.assertEqual(data["Ki Teitzei"]["3"][1]["b"], "48:20")
+
+    def test_a_value_already_corrected_upstream_is_left_alone(self):
+        with self.assertNoLogs(readings.logger, "WARNING"):
+            data = readings._apply_corrections(self.NAME, self._data("48:20"))
+        self.assertEqual(data["Ki Teitzei"]["3"][1]["b"], "48:20")
+
+    def test_an_unrecognized_value_is_kept_and_warned_about(self):
+        with self.assertLogs(readings.logger, "WARNING"):
+            data = readings._apply_corrections(self.NAME, self._data("49:20"))
+        self.assertEqual(data["Ki Teitzei"]["3"][1]["b"], "49:20")
+
+    def test_a_path_that_no_longer_exists_is_warned_about(self):
+        with self.assertLogs(readings.logger, "WARNING"):
+            readings._apply_corrections(self.NAME, {"Ki Teitzei": {}})
+
+    def test_a_file_with_no_corrections_is_untouched(self):
+        data = {"Ki Teitzei": {"3": []}}
+        self.assertEqual(readings._apply_corrections("aliyot.json", data), data)

--- a/opensiddur/tests/importer/humash/test_readings.py
+++ b/opensiddur/tests/importer/humash/test_readings.py
@@ -12,7 +12,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from opensiddur.importer.humash.readings import triennial, triennial_patterns
+from opensiddur.importer.humash.readings import (
+    triennial,
+    triennial_haftarot,
+    triennial_patterns,
+)
 
 
 def _aliyot(chapter: int) -> dict[str, list[str]]:
@@ -117,3 +121,84 @@ class TestTriennialPatterns(unittest.TestCase):
 
     def test_a_hyphenated_single_parshah_is_not_taken_for_a_pair(self):
         self.assertNotIn("lech_lecha", self.patterns)
+
+
+# A synthetic triennial-haft.json in hebcal's shape: a year is one reading object, or a list of
+# them where the reading is discontinuous. Every quirk the real file has is represented once.
+TRIENNIAL_HAFT_FIXTURE = {
+    "Bereshit": {
+        "1": {"k": "Isaiah", "b": "42:5", "e": "42:21", "note": "creation"},
+        "2": {"k": "Isaiah", "b": "40:25", "e": "40:31"},
+        # Discontinuous, and closing with the verse the pairing turns on — which lies inside
+        # the piece before it and is not read a second time.
+        "3": [
+            {"k": "II Kings", "b": "2:1", "e": "2:13"},
+            {"k": "II Kings", "b": "2:14", "e": "2:18"},
+            {"k": "II Kings", "b": "2:15", "e": "2:16"},
+        ],
+    },
+    # Read alone only in the first two years of a cycle, so it has no third.
+    "Tazria": {
+        "1": {"k": "Isaiah", "b": "46:3", "e": "46:13"},
+        # A boundary inside a verse, and a stray space of the kind the real file has.
+        "2": {"k": "Jeremiah", "b": "30:1b", "e": " 30:9a"},
+    },
+    # Runs backwards, which the haftarot really do and which is not an anchor verse.
+    "Noach": {"1": [{"k": "Isaiah", "b": "54:1", "e": "54:10"},
+                    {"k": "Isaiah", "b": "53:1", "e": "53:2"}]},
+    # In the file but not a parshah, so it has nowhere to go.
+    "Tish'a B'Av": {"1": {"k": "Jeremiah", "b": "8:13", "e": "8:23"}},
+}
+
+
+class TestTriennialHaftarot(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "triennial-haft.json").write_text(
+            json.dumps(TRIENNIAL_HAFT_FIXTURE), encoding="utf-8"
+        )
+        self.haftarot = triennial_haftarot(self.root)
+
+    def _spans(self, slug: str, year: int) -> list[tuple[str, str]]:
+        return [
+            (str(span.start), str(span.end))
+            for span in self.haftarot[slug][year].spans
+        ]
+
+    def test_each_year_is_keyed_by_plain_cycle_year(self):
+        self.assertEqual(sorted(self.haftarot["bereshit"]), [1, 2, 3])
+
+    def test_a_single_reading_object_becomes_one_span(self):
+        self.assertEqual(self._spans("bereshit", 1), [("isaiah 42:5", "isaiah 42:21")])
+
+    def test_a_list_of_readings_becomes_a_span_each(self):
+        """A list year was dropped entirely before, losing 36 of the 150 readings."""
+        self.assertEqual(
+            self._spans("bereshit", 3),
+            [("kings_2 2:1", "kings_2 2:13"), ("kings_2 2:14", "kings_2 2:18")],
+        )
+
+    def test_a_piece_inside_an_earlier_one_is_not_read_again(self):
+        self.assertNotIn(("kings_2 2:15", "kings_2 2:16"), self._spans("bereshit", 3))
+
+    def test_a_piece_that_runs_backwards_is_kept(self):
+        self.assertEqual(
+            self._spans("noach", 1),
+            [("isaiah 54:1", "isaiah 54:10"), ("isaiah 53:1", "isaiah 53:2")],
+        )
+
+    def test_a_half_verse_boundary_reads_the_whole_verse_and_says_so(self):
+        span = self.haftarot["tazria"][2].spans[0]
+        self.assertEqual((str(span.start), str(span.end)), ("jeremiah 30:1", "jeremiah 30:9"))
+        self.assertEqual((span.start_half, span.end_half), ("b", "a"))
+
+    def test_a_parshah_read_alone_in_two_years_has_only_those(self):
+        self.assertEqual(sorted(self.haftarot["tazria"]), [1, 2])
+
+    def test_an_occasion_that_is_not_a_parshah_is_dropped(self):
+        self.assertNotIn("tisha_bav", self.haftarot)
+        self.assertEqual(sorted(self.haftarot), ["bereshit", "noach", "tazria"])

--- a/opensiddur/tests/importer/humash/test_readings.py
+++ b/opensiddur/tests/importer/humash/test_readings.py
@@ -226,6 +226,10 @@ HOLIDAY_READINGS_FIXTURE = {
             "M-day5": {"k": 4, "b": "29:29", "e": "29:34"},
         },
     },
+    # A pointer rather than a reading: hebcal names the occasion and says which reading it
+    # takes. Real examples are every Rosh Chodesh of a named month, the fast days, and the
+    # Israel names for the chol ha-moed days.
+    "Pesach III (CH''M)": {"alias": True, "il": True, "key": "Pesach I"},
 }
 
 
@@ -318,3 +322,34 @@ class TestHebcalCorrections(unittest.TestCase):
     def test_a_file_with_no_corrections_is_untouched(self):
         data = {"Ki Teitzei": {"3": []}}
         self.assertEqual(readings._apply_corrections("aliyot.json", data), data)
+
+
+class TestFestivalAliases(unittest.TestCase):
+    """An aliased occasion is not a reading of its own.
+
+    Following the pointer would print the same text under another heading; which occasion
+    falls on which day is the calendar's business, not a division of the text.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "holiday-readings.json").write_text(
+            json.dumps(HOLIDAY_READINGS_FIXTURE), encoding="utf-8"
+        )
+        self.festivals = festival_readings(self.root)
+
+    def test_an_alias_gets_no_reading_of_its_own(self):
+        self.assertNotIn("pesach_iii_(chm)", self.festivals)
+
+    def test_the_reading_it_points_at_is_still_there(self):
+        self.assertIn("pesach_i", self.festivals)
+        self.assertTrue(self.festivals["pesach_i"]["aliyot"])
+
+    def test_no_reading_is_left_without_content_by_the_alias_rule(self):
+        for slug, reading in self.festivals.items():
+            with self.subTest(slug=slug):
+                self.assertTrue(reading["aliyot"] or reading["haftarot"])

--- a/opensiddur/tests/importer/humash/test_readings.py
+++ b/opensiddur/tests/importer/humash/test_readings.py
@@ -13,10 +13,12 @@ import unittest
 from pathlib import Path
 
 from opensiddur.importer.humash.readings import (
+    festival_readings,
     triennial,
     triennial_haftarot,
     triennial_patterns,
 )
+from opensiddur.importer.humash.refs import UNIT_ALIYAH, UNIT_MAFTIR
 
 
 def _aliyot(chapter: int) -> dict[str, list[str]]:
@@ -202,3 +204,67 @@ class TestTriennialHaftarot(unittest.TestCase):
     def test_an_occasion_that_is_not_a_parshah_is_dropped(self):
         self.assertNotIn("tisha_bav", self.haftarot)
         self.assertEqual(sorted(self.haftarot), ["bereshit", "noach", "tazria"])
+
+
+HOLIDAY_READINGS_FIXTURE = {
+    # Ordinary festival: one maftir, keyed "M".
+    "Pesach I": {
+        "fullkriyah": {
+            "1": {"k": 2, "b": "12:21", "e": "12:28"},
+            "M": {"k": 4, "b": "28:16", "e": "28:25"},
+        },
+    },
+    # Sukkot's Chol HaMoed Shabbat: the maftir varies by which intermediate day it is,
+    # keyed "M-day1".."M-day5" rather than a plain "M" (real hebcal shape).
+    "Sukkot Shabbat Chol ha-Moed": {
+        "fullkriyah": {
+            "1": {"k": 2, "b": "33:12", "e": "33:16"},
+            "M-day1": {"k": 4, "b": "29:17", "e": "29:22"},
+            "M-day2": {"k": 4, "b": "29:20", "e": "29:25"},
+            "M-day5": {"k": 4, "b": "29:29", "e": "29:34"},
+        },
+    },
+}
+
+
+class TestFestivalReadingsMaftir(unittest.TestCase):
+    """Regression: Sukkot Chol HaMoed's per-day maftir keys ("M-day1"..) used to fall
+    through to UNIT_ALIYAH with the raw, untranslated key kept as the label, which then
+    surfaced as backwards-looking raw English ("M-day1") inside an all-Hebrew RTL milestone.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "holiday-readings.json").write_text(
+            json.dumps(HOLIDAY_READINGS_FIXTURE), encoding="utf-8"
+        )
+        self.festivals = festival_readings(self.root)
+
+    def _span(self, occasion: str, label: str):
+        spans = self.festivals[occasion]["aliyot"]
+        matches = [span for span in spans if span.label == label]
+        self.assertEqual(len(matches), 1, f"expected exactly one span labeled {label!r}")
+        return matches[0]
+
+    def test_ordinary_single_maftir_is_normalized_to_maftir(self):
+        span = self._span("pesach_i", "maftir")
+        self.assertEqual(span.unit, UNIT_MAFTIR)
+
+    def test_sukkot_chol_hamoed_day_maftirs_are_recognized_as_maftir(self):
+        for day in (1, 2, 5):
+            span = self._span("sukkot_shabbat_chol_ha_moed", f"maftir_day{day}")
+            self.assertEqual(span.unit, UNIT_MAFTIR)
+
+    def test_sukkot_chol_hamoed_day_maftirs_are_not_left_as_raw_source_keys(self):
+        labels = {span.label for span in self.festivals["sukkot_shabbat_chol_ha_moed"]["aliyot"]}
+        self.assertNotIn("M-day1", labels)
+        self.assertNotIn("M-day2", labels)
+        self.assertNotIn("M-day5", labels)
+
+    def test_sukkot_chol_hamoed_non_maftir_aliyah_is_unaffected(self):
+        span = self._span("sukkot_shabbat_chol_ha_moed", "1")
+        self.assertEqual(span.unit, UNIT_ALIYAH)

--- a/opensiddur/tests/importer/humash/test_readings.py
+++ b/opensiddur/tests/importer/humash/test_readings.py
@@ -1,0 +1,119 @@
+"""Tests for reading the triennial cycle out of the hebcal data.
+
+These use a synthetic triennial.json rather than the downloaded one, so that they keep their
+meaning when hebcal updates its data. The fixture keeps hebcal's shape: a parshah that always
+divides the same way holds "years", one that is sometimes read combined with its partner holds
+"variations" keyed by variation and cycle year, and the pair itself holds both the combined
+division and the table saying which variation each cycle pattern selects.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from opensiddur.importer.humash.readings import triennial, triennial_patterns
+
+
+def _aliyot(chapter: int) -> dict[str, list[str]]:
+    """A whole year's aliyot inside one chapter, so the fixture stays short."""
+    return {
+        str(index): [f"{chapter}:{index}", f"{chapter}:{index}"] for index in range(1, 8)
+    } | {"M": [f"{chapter}:7", f"{chapter}:7"]}
+
+
+TRIENNIAL_FIXTURE = {
+    "Bereshit": {"book": 1, "years": {f"Y.{year}": _aliyot(year) for year in (1, 2, 3)}},
+    "Tazria": {
+        "book": 3,
+        "variations": {
+            "A.3": _aliyot(11),
+            "B.2": _aliyot(12),
+            # An alias: variation C's third year divides exactly as A's does.
+            "C.3": "A.3",
+        },
+    },
+    "Metzora": {"book": 3, "variations": {"A.3": _aliyot(21)}},
+    "Tazria-Metzora": {
+        "book": 3,
+        "years": {f"Y.{year}": _aliyot(year) for year in (1, 2, 3)},
+        "patterns": {"TTS": "A", "TST": "B", "STT": "C"},
+    },
+    # Hyphenated, but one parshah rather than a pair, so it has no patterns to read.
+    "Lech-Lecha": {"book": 1, "years": {"Y.1": _aliyot(4)}},
+}
+
+
+class TestTriennial(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "triennial.json").write_text(
+            json.dumps(TRIENNIAL_FIXTURE), encoding="utf-8"
+        )
+        # triennial() caches by file name and root, so each test gets a fresh directory.
+        self.divisions = triennial(self.root)
+
+    def test_a_parshah_with_no_variation_is_keyed_by_cycle_year_alone(self):
+        self.assertEqual(
+            sorted(self.divisions["bereshit"]), [(None, 1), (None, 2), (None, 3)]
+        )
+        spans = self.divisions["bereshit"][(None, 2)]
+        self.assertEqual([span.unit for span in spans][:1], ["aliyah.triennial.2"])
+        self.assertEqual(spans[-1].unit, "maftir.triennial.2")
+
+    def test_a_variation_is_keyed_by_variation_and_year(self):
+        """The twelve that are sometimes doubled were skipped entirely before."""
+        self.assertEqual(
+            sorted(self.divisions["tazria"]), [("A", 3), ("B", 2), ("C", 3)]
+        )
+
+    def test_an_aliased_variation_resolves_to_the_division_it_names(self):
+        aliased = self.divisions["tazria"][("C", 3)]
+        named = self.divisions["tazria"][("A", 3)]
+        self.assertEqual(
+            [(str(span.start), str(span.end)) for span in aliased],
+            [(str(span.start), str(span.end)) for span in named],
+        )
+
+    def test_a_variation_names_its_parshah_in_its_unit_space(self):
+        """Both parshiyot of a pair share a file, and their variations may cover one verse."""
+        tazria = self.divisions["tazria"][("A", 3)][0]
+        metzora = self.divisions["metzora"][("A", 3)][0]
+        self.assertEqual(tazria.unit, "aliyah.triennial.tazria.A.3")
+        self.assertEqual(metzora.unit, "aliyah.triennial.metzora.A.3")
+        self.assertEqual(tazria.owner, "tazria")
+
+    def test_the_combined_reading_is_keyed_by_the_pairs_slug(self):
+        pair = self.divisions["tazria_metzora"]
+        self.assertEqual(
+            sorted(pair), [("combined", 1), ("combined", 2), ("combined", 3)]
+        )
+        span = pair[("combined", 1)][0]
+        self.assertEqual(span.unit, "aliyah.triennial.combined.1")
+        # The combined reading owns the file it is emitted in, so it names no owner.
+        self.assertIsNone(span.owner)
+
+
+class TestTriennialPatterns(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        directory = self.root / "hebcal_leyning"
+        directory.mkdir(parents=True)
+        (directory / "triennial.json").write_text(
+            json.dumps(TRIENNIAL_FIXTURE), encoding="utf-8"
+        )
+        self.patterns = triennial_patterns(self.root)
+
+    def test_patterns_are_read_from_the_pair(self):
+        self.assertEqual(
+            self.patterns["tazria_metzora"], {"TTS": "A", "TST": "B", "STT": "C"}
+        )
+
+    def test_a_hyphenated_single_parshah_is_not_taken_for_a_pair(self):
+        self.assertNotIn("lech_lecha", self.patterns)

--- a/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
+++ b/opensiddur/tests/importer/miqra_al_pi_hamasorah/test_miqra_to_tei_xslt.py
@@ -280,5 +280,63 @@ class TestNavAndScaffoldNotes(unittest.TestCase):
         self.assertNotIn("הערה", "".join(body.itertext()))
 
 
+class TestChapterMilestone(unittest.TestCase):
+    """A chapter milestone has no column of its own in MAM's source; it is inferred from a
+    row's chapter differing from the one before it."""
+
+    def _chapter_milestones(self, body: etree._Element) -> list[tuple[str, str]]:
+        return [
+            (m.get("n"), m.get("corresp"))
+            for m in body.findall(f".//{{{TEI_NS}}}milestone")
+            if m.get("unit") == "chapter"
+        ]
+
+    def test_first_verse_of_the_book_opens_a_chapter(self):
+        body, _ = _transform(_row("1", "AAA", chapter="20"))
+        self.assertEqual(
+            [("20", "urn:x-opensiddur:text:bible:exodus/20")],
+            self._chapter_milestones(body),
+        )
+
+    def test_chapter_milestone_precedes_the_verse_milestone(self):
+        body, _ = _transform(_row("1", "AAA", chapter="20"))
+        p = body.find(f"{{{TEI_NS}}}div/{{{TEI_NS}}}p")
+        milestones = list(p.findall(f"{{{TEI_NS}}}milestone"))
+        self.assertEqual("chapter", milestones[0].get("unit"))
+        self.assertEqual("verse", milestones[1].get("unit"))
+
+    def test_no_milestone_for_a_later_verse_of_the_same_chapter(self):
+        body, _ = _transform(
+            _row("1", "AAA", chapter="20"), _row("2", "BBB", chapter="20"),
+        )
+        self.assertEqual(
+            [("20", "urn:x-opensiddur:text:bible:exodus/20")],
+            self._chapter_milestones(body),
+        )
+
+    def test_chapter_change_opens_a_new_milestone(self):
+        body, _ = _transform(
+            _row("18", "AAA", chapter="20"), _row("1", "BBB", chapter="21"),
+        )
+        self.assertEqual(
+            [
+                ("20", "urn:x-opensiddur:text:bible:exodus/20"),
+                ("21", "urn:x-opensiddur:text:bible:exodus/21"),
+            ],
+            self._chapter_milestones(body),
+        )
+
+    def test_mid_verse_parashah_break_does_not_repeat_the_chapter_milestone(self):
+        """A verse split by a parashah break still opens only once (see
+        TestMidVerseParashah); the chapter milestone must not double up with it."""
+        body, _ = _transform(
+            _row("13", 'AAA<miqra:parashah type="close-inline" midVerse="true"/>BBB', chapter="20"),
+        )
+        self.assertEqual(
+            [("20", "urn:x-opensiddur:text:bible:exodus/20")],
+            self._chapter_milestones(body),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -846,6 +846,10 @@ The weekly parsha and special additions can also be calculated:
    <tei:f name="israel-parsha">
       <tei:string/>
    </tei:f>
+   <!-- Which of the three years of the modern triennial cycle the date falls in. -->
+   <tei:f name="triennial-year">
+      <tei:numeric/>
+   </tei:f>
    <!-- One per pair of parshiyot that is sometimes read combined; see below. -->
    <tei:f name="triennial-pattern-vayakhel-pekudei">
       <tei:string/>
@@ -916,6 +920,66 @@ The value is reckoned for the diaspora or for Israel according to `opensiddur:is
 the two diverge whenever a festival falling on Shabbat puts them a week apart. No separate
 test on `opensiddur:israel` is needed alongside the pattern: a pattern that can only arise in
 Israel selects an Israel division on its own.
+
+Which cycle of readings a volume follows is a choice it makes rather than something the date
+settles — every date falls in some year of the triennial cycle, including the dates a volume
+that reads annually is compiled for. It is declared:
+```xml
+<tei:fs type="opensiddur:reading-cycle">
+   <tei:f name="annual">
+      <!-- true if this volume carries the annual haftarah of each week. Defaults to true. -->
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="triennial">
+      <!-- true if this volume reads the modern triennial cycle. Defaults to false. This is
+      the opt-in that gives a declared date meaning here; on its own it selects nothing. -->
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="triennial-year-1">
+      <!-- true if this volume carries the first year's triennial readings. Defaults to false.
+      Derived, along with its siblings and with annual, from
+      opensiddur:torah-reading/triennial-year when triennial is true and a date is declared. -->
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="triennial-year-2">
+      <tei:binary/>
+   </tei:f>
+   <tei:f name="triennial-year-3">
+      <tei:binary/>
+   </tei:f>
+</tei:fs>
+```
+
+One binary per year rather than a single year number, because several may be true at once, the
+way several rites may be. A volume for one Shabbat has one year; a volume covering a whole
+three-year cycle turns on all three, which a year number could not express:
+
+| volume | declares | carries |
+| --- | --- | --- |
+| annual | nothing | the annual haftarah |
+| one Shabbat | `triennial` and a date | that cycle year's |
+| a whole cycle | the three year features, `annual` false | all three years' |
+| complete reference | the three year features | all four |
+
+Unlike most features these take a value rather than staying `undefined`, because the readings
+they select are alternatives to one another. The annual haftarah of a parshah and its three
+triennial ones are all read on the same Shabbat, and an undefined condition keeps its text, so
+an open feature here would print four haftarot for one week. A volume that says nothing gets
+the annual reading. The humash conditions its haftarot this way:
+
+```xml
+<j:conditional xml:id="triennial_haftarah_1">
+   <tei:fs type="opensiddur:reading-cycle">
+      <tei:f name="triennial-year-1"><tei:binary value="true"/></tei:f>
+   </tei:fs>
+</j:conditional>
+```
+
+Always one feature per test: `j:all` over a false test and an undefined one is `undefined`
+rather than false, per the truth tables below, so a condition that has to be decisive must turn
+on a single feature that always has a value. Where a reading covers several cases — the humash's
+annual haftarah stands in for the cycle years a parshah has no reading for — the tests are
+combined with `j:any`, which does answer true as soon as one of them is true.
 
 There are also special manual overrides available, which
 are never set automatically (they default to the `false` value)

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -833,6 +833,25 @@ The weekly parsha and special additions can also be calculated:
    <tei:f name="israel-parsha">
       <tei:string/>
    </tei:f>
+   <!-- One per pair of parshiyot that is sometimes read combined; see below. -->
+   <tei:f name="triennial-pattern-vayakhel-pekudei">
+      <tei:string/>
+   </tei:f>
+   <tei:f name="triennial-pattern-tazria-metzora">
+      <tei:string/>
+   </tei:f>
+   <tei:f name="triennial-pattern-achrei-mot-kedoshim">
+      <tei:string/>
+   </tei:f>
+   <tei:f name="triennial-pattern-behar-bechukotai">
+      <tei:string/>
+   </tei:f>
+   <tei:f name="triennial-pattern-chukat-balak">
+      <tei:string/>
+   </tei:f>
+   <tei:f name="triennial-pattern-matot-masei">
+      <tei:string/>
+   </tei:f>
    <tei:f name="shabbat-shuva">
       <tei:binary/>
    </tei:f>
@@ -859,6 +878,31 @@ The weekly parsha and special additions can also be calculated:
    </tei:f>
 </tei:fs>
 ```
+
+Each `triennial-pattern-` feature describes the three-year triennial cycle the date falls in,
+not the date itself: one character per year of the cycle, `T` where that pair of parshiyot was
+read together and `S` where the two were read apart. `TSS` therefore means the pair was
+combined in the first year of the cycle and separate in the second and third.
+
+Six pairs have one, because the triennial division of a parshah that is sometimes doubled
+depends on how the pair fell across the whole cycle rather than on the cycle year alone. A
+text that divides differently per pattern conditions each division on the patterns it belongs
+to, as the humash does:
+
+```xml
+<j:conditional xml:id="triennial_1">
+   <j:any>
+      <tei:fs type="opensiddur:torah-reading">
+         <tei:f name="triennial-pattern-vayakhel-pekudei"><tei:string>TSS</tei:string></tei:f>
+      </tei:fs>
+   </j:any>
+</j:conditional>
+```
+
+The value is reckoned for the diaspora or for Israel according to `opensiddur:israel`, since
+the two diverge whenever a festival falling on Shabbat puts them a week apart. No separate
+test on `opensiddur:israel` is needed alongside the pattern: a pattern that can only arise in
+Israel selects an Israel division on its own.
 
 There are also special manual overrides available, which
 are never set automatically (they default to the `false` value)


### PR DESCRIPTION
## Summary
Generates the humash project — the Torah arranged by weekly/festival liturgical reading, with haftarot, megillot, and festival readings — and exports it to a Hebrew-only PDF via reledmac/LuaLaTeX.

- Importer (`opensiddur/importer/humash/`): reads the weekly parshiyot and aliyot from Miqra al pi ha-Masorah, and haftarot/festival readings/triennial cycle from hebcal, and emits transclusion-only JLPTEI files (no text of its own).
- Exporter (`opensiddur/exporter/tex/reledmac.xslt` and friends): renders verse numbers, aliyah/maftir/parsha markers, chapter-boundary markers, and haftarah/reading source citations.
- Fixes two shared-compiler bugs surfaced while adding chapter markers: a range-boundary milestone (e.g. a chapter marker landing exactly at a reading division's start) was being silently excluded from the compiled range (`external_compiler.py`), and a parallel-stream segment whose only content was a bare milestone was pruned as "empty" (`marker_reconstruct.py`).

Companion PR: opensiddur/opensiddur-projects#11 regenerates the derived project files this branch's importer produces.

The dual-column Hebrew/English parallel edition has a separate, still-open pagination bug in reledpar's page-pairing under the newly-dense chapter/citation milestones; that's being tracked on `feat/parallel-humash` rather than blocking this PR.

## Test plan
- [x] `uv run pytest` — full suite passes (1395 tests)
- [x] RelaxNG/Schematron validation on every generated project file
- [x] Hebrew-only humash compiles end-to-end (`opensiddur.exporter.compiler` → `opensiddur.exporter.pdf.pdf`) to a 455-page PDF with no LaTeX errors
- [x] Chapter markers verified present at every chapter boundary across all five Torah books (50/40/27/36/34), including book-opening ones, by direct inspection of the compiled XML and the rendered PDF
- [x] Haftarah/festival-reading source citations verified in the rendered PDF, including the Mishpatim haftarah's backward jump (Jeremiah 34:8-22 then 33:25-26) and Simchat Torah's three-book festival aliyot

🤖 Generated with [Claude Code](https://claude.com/claude-code)