### PR TITLE
Fix the parallel humash blowing up to 377MB and 15000+ pages

### DIFF
--- a/opensiddur/exporter/external_compiler.py
+++ b/opensiddur/exporter/external_compiler.py
@@ -142,6 +142,26 @@ class ExternalCompilerProcessor(CompilerProcessor):
 
     # ── Marker-mode helpers ─────────────────────────────────────────────────
 
+    def _tail_is_in_range(self) -> bool:
+        """True when the tail of the child just processed belongs to the compiled range.
+
+        Must be consulted *after* the child has been processed, so that the range flags
+        already reflect crossing the start or the end element: a `tei:p` that spans the
+        range start owns children on both sides of it, and only the ones after it
+        contribute text.
+
+        Marker mode has to ask, because `copy_text` is fixed for the whole element while
+        `before_start` flips partway through its children. Carrying tails unconditionally
+        prepended every verse preceding a range to that range's output, which grew
+        quadratically across the aliyot and inflated the parallel humash to 377MB.
+        """
+        context = self.linear_data.processing_context[-1]
+        if context['before_start']:
+            return False
+        if context['after_end']:
+            return bool(context['include_tail_after_end'])
+        return True
+
     def _process_element_as_marker(
         self,
         element: ElementBase,
@@ -185,9 +205,10 @@ class ExternalCompilerProcessor(CompilerProcessor):
 
                 if child_context["command"] == _ProcessingCommand.RECURSE:
                     # Before the range's start (#63, same root cause as #53): don't resolve
-                    # the transclusion or emit suspend/resume brackets for it at all.
-                    if child.tail:
-                        self._carry_dropped_tail(result, child)
+                    # the transclusion or emit suspend/resume brackets for it at all. RECURSE
+                    # here also means the start is not inside this child (a start ancestor
+                    # would have been COPY_ELEMENT_AND_RECURSE), so its tail is pre-range
+                    # text and is dropped with it.
                     self._update_processing_context_after(child)
                     continue
 
@@ -209,14 +230,17 @@ class ExternalCompilerProcessor(CompilerProcessor):
                     resume.set(f"{{{p_ns}}}resume", sid)
                     result.append(resume)
 
-                if child.tail and result:
-                    result[-1].tail = (result[-1].tail or '') + child.tail
-
+                # After the context update, as in the else branch below: if this transclude
+                # was the range's end element, after_end is only set by that call, and
+                # whether its tail survives is then include_tail_after_end's decision.
                 self._update_processing_context_after(child)
+
+                if child.tail and result and self._tail_is_in_range():
+                    result[-1].tail = (result[-1].tail or '') + child.tail
             else:
                 child_result = self._process_element(child, root)
                 result.extend(child_result)
-                if child.tail:
+                if child.tail and self._tail_is_in_range():
                     if child_result:
                         last = child_result[-1]
                         last.tail = (last.tail or '') + child.tail
@@ -1001,6 +1025,22 @@ class ExternalCompilerProcessor(CompilerProcessor):
             # external transclusion individually. A project that only arranges transclusions
             # (a humash built from Tanakh verses) has no document-level counterpart at all --
             # its correspondence with the parallel project lives entirely in its targets.
+
+        # A p:parallel must end up a flat sibling of the surrounding flow, never wrapped in a
+        # tei:div (specs/COMPILER_SPECIFICATION.md, "Parallel Compilation"). That only holds
+        # if the containers *above* the parallel-triggering transclusion are marker pairs
+        # too: _split_at_milestones can then suspend them at each alignment boundary and
+        # marker_reconstruct rebuilds them inside each column, stamped with p:part.
+        #
+        # Marker mode used to begin at _transclude_parallel, so everything above the first
+        # parallel transclusion stayed ordinary nested elements. Real books came out as
+        # body/div/transclude/div[book]/transclude/div/transclude/p:parallel, and the TeX
+        # stage -- which groups on p:parallel among the top-level nodes -- never saw a single
+        # block, emitted no \begin{pairs}, and ran both columns together into one numbered
+        # stream.
+        if is_root and self.linear_data.parallel_projects and not self._in_parallel_compilation:
+            if self.marker_stack is None:
+                self.marker_stack = []
 
         # set the root language to the language of the deepest common ancestor if present, else root
         self.root_language = self._get_in_scope_language(

--- a/opensiddur/exporter/marker_reconstruct.py
+++ b/opensiddur/exporter/marker_reconstruct.py
@@ -169,11 +169,17 @@ def _move_plain_content(
         fragments.append(el)
 
 
-def reconstruct_parallel_item(
+def reconstruct_container(
     pi: etree.ElementBase,
     pid_state: defaultdict[str, dict[str, Any]],
 ) -> None:
-    """Rebuild pi's direct linear stream into nested TEI fragments (mutating pi)."""
+    """Rebuild a container's direct linear stream into nested TEI fragments (mutating it).
+
+    Container-agnostic: it consumes whatever direct children it is given. A parallel
+    column (`p:parallelItem`) is the original caller, but with document-wide marker mode
+    the top-level flow (`tei:body`, and each `p:transclude`) is a marker stream too and
+    is rebuilt by the same walk.
+    """
     fragments: list[etree.ElementBase] = []
     stack: list[_Frame] = []
 
@@ -216,7 +222,7 @@ def reconstruct_parallel_item(
         _move_plain_content(el, stack, fragments)
 
     if stack:
-        raise ValueError(f"unclosed structural frames remain in parallelItem: {[f.pid for f in stack]}")
+        raise ValueError(f"unclosed structural frames remain in container: {[f.pid for f in stack]}")
 
     for frag in fragments:
         pi.append(frag)
@@ -287,16 +293,46 @@ def doc_needs_marker_reconstruction(root: etree.ElementBase) -> bool:
     return False
 
 
+def _marker_containers(root: etree.ElementBase) -> list[etree.ElementBase]:
+    """Elements outside the parallel columns whose direct children form a marker stream.
+
+    Under document-wide marker mode the top-level flow is flattened the same way a column
+    is, so `tei:body` — and any `p:transclude` or transcluded `tei:body` beneath it — has
+    to be rebuilt too. Found by inspection rather than by tag, because which element ends
+    up holding the stream depends on how the transclusion was spliced in.
+    """
+    containers = []
+    for el in root.iter():
+        if el.tag == _PARALLEL_ITEM:
+            continue
+        if any(child.tag in STRUCTURAL_BLOCKS and _structural_marker_map(child) for child in el):
+            containers.append(el)
+    return containers
+
+
+def _depth(el: etree.ElementBase) -> int:
+    return sum(1 for _ in el.iterancestors())
+
+
 def reconstruct_markered_document(root: etree.ElementBase) -> None:
     pid_state: defaultdict[str, dict[str, Any]] = defaultdict(dict)
 
-    # Snapshot before iterating: reconstruct_parallel_item mutates the tree underneath us.
+    # Snapshot before iterating: reconstruct_container mutates the tree underneath us.
     for parallel in list(root.iter()):
         if parallel.tag != _PARALLEL:
             continue
         for pi in parallel:
             if pi.tag == _PARALLEL_ITEM:
-                reconstruct_parallel_item(pi, pid_state)
+                reconstruct_container(pi, pid_state)
+
+    # Then the flow around them, deepest first, so a container is rebuilt before an
+    # ancestor's pass moves it. One shared pid_state throughout: a structural element
+    # suspended before a transclusion resumes in a later segment, and both halves need
+    # the same logical-id for normalize_segment_parts to pair them. Pids cannot collide
+    # across passes -- _get_path_hash folds in the whole processing-context stack,
+    # including each range's bounds.
+    for container in sorted(_marker_containers(root), key=_depth, reverse=True):
+        reconstruct_container(container, pid_state)
 
     normalize_segment_parts(root)
 

--- a/opensiddur/tests/exporter/test_external_compiler.py
+++ b/opensiddur/tests/exporter/test_external_compiler.py
@@ -1654,6 +1654,72 @@ class TestExternalCompilerProcessor(unittest.TestCase):
         self.assertNotIn("Chapter 2 verse 1", result_str)
         self.assertIn("Chapter 2 verse 2", result_str)
 
+    # The shape the parallel humash actually compiles: one tei:p holding a run of verses,
+    # each opened by a milestone whose text is carried as that milestone's *tail*. A range
+    # starting mid-paragraph therefore has to reject the tails of the children before it.
+    MID_PARAGRAPH_VERSES_SOURCE = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="he">
+    <tei:text>
+        <tei:body>
+            <tei:div type="book"><tei:p><tei:milestone unit="verse" n="1" corresp="urn:x-opensiddur:text:bible:book/1/1"/>Verse one text.<tei:milestone unit="verse" n="2" corresp="urn:x-opensiddur:text:bible:book/1/2"/>Verse two text.<tei:milestone unit="verse" n="3" corresp="urn:x-opensiddur:text:bible:book/1/3"/>Verse three text.<tei:milestone unit="verse" n="4" corresp="urn:x-opensiddur:text:bible:book/1/4"/>Verse four text.</tei:p></tei:div>
+        </tei:body>
+    </tei:text>
+</tei:TEI>'''
+
+    def _compile_mid_paragraph_range(self, file_name, corresp, *, marker_mode):
+        xml_bytes = self.MID_PARAGRAPH_VERSES_SOURCE.encode('utf-8')
+        project, name = self._create_test_file(file_name, xml_bytes)
+
+        root = etree.fromstring(xml_bytes)
+        tree = root.getroottree()
+        milestone = root.xpath(f"//*[@corresp='{corresp}']")[0]
+        from_start = tree.getpath(milestone)
+        end_path, include_tail = find_end_of_mapping(milestone)
+
+        processor = ExternalCompilerProcessor(
+            project, name, from_start, end_path, include_tail_after_end=include_tail)
+        if marker_mode:
+            processor.marker_stack = []
+        result = processor.process()
+        return ''.join(etree.tostring(elem, encoding='unicode') for elem in result)
+
+    def test_marker_mode_range_starting_mid_paragraph_drops_preceding_verse_text(self):
+        """Regression: in marker mode, a tei:p spanning the range start carried the tails of
+        every child preceding it, so a ranged transclusion was prefixed with all the text
+        before its own start. Each aliyah re-emitted every earlier one and the parallel
+        humash grew to 377MB."""
+        result_str = self._compile_mid_paragraph_range(
+            "mid_paragraph_marker.xml",
+            "urn:x-opensiddur:text:bible:book/1/3",
+            marker_mode=True)
+
+        self.assertIn("Verse three text.", result_str)
+        self.assertNotIn("Verse one text.", result_str)
+        self.assertNotIn("Verse two text.", result_str)
+        self.assertNotIn("Verse four text.", result_str)
+
+    def test_non_marker_mode_range_starting_mid_paragraph_is_unchanged(self):
+        """Positive control: the non-marker path was already correct here and must stay so."""
+        result_str = self._compile_mid_paragraph_range(
+            "mid_paragraph_plain.xml",
+            "urn:x-opensiddur:text:bible:book/1/3",
+            marker_mode=False)
+
+        self.assertIn("Verse three text.", result_str)
+        self.assertNotIn("Verse one text.", result_str)
+        self.assertNotIn("Verse two text.", result_str)
+        self.assertNotIn("Verse four text.", result_str)
+
+    def test_marker_mode_range_from_the_first_verse_keeps_its_own_text(self):
+        """The guard must reject only pre-range tails: a range starting at the paragraph's
+        first child still carries that child's text."""
+        result_str = self._compile_mid_paragraph_range(
+            "mid_paragraph_first.xml",
+            "urn:x-opensiddur:text:bible:book/1/1",
+            marker_mode=True)
+
+        self.assertIn("Verse one text.", result_str)
+        self.assertNotIn("Verse two text.", result_str)
+
     def test_range_keeps_declarations_made_before_the_start(self):
         """A j:declare preceding the range inside the DCA is still in scope in the range."""
         xml_bytes = '''<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:j="http://jewishliturgy.org/ns/jlptei/2" xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="he">

--- a/opensiddur/tests/exporter/test_marker_reconstruct.py
+++ b/opensiddur/tests/exporter/test_marker_reconstruct.py
@@ -9,7 +9,7 @@ from opensiddur.exporter.external_compiler import PROCESSING_NAMESPACE, TEI_NS
 from opensiddur.exporter.marker_reconstruct import (
     doc_needs_marker_reconstruction,
     reconstruct_markered_document,
-    reconstruct_parallel_item,
+    reconstruct_container,
     substantive_content,
 )
 from opensiddur.exporter import marker_reconstruct as mr
@@ -157,7 +157,7 @@ class TestMarkerReconstruct(unittest.TestCase):
         </p:parallelItem>"""
         pi = etree.fromstring(xml.encode())
         with self.assertRaises(ValueError):
-            reconstruct_parallel_item(pi, mr.defaultdict(dict))
+            reconstruct_container(pi, mr.defaultdict(dict))
 
     def test_close_open_segment_validates_stack_and_pid(self):
         stack: list[mr._Frame] = []
@@ -259,5 +259,5 @@ class TestMarkerReconstruct(unittest.TestCase):
         </p:parallelItem>"""
         pi = etree.fromstring(xml.encode())
         with unittest.mock.patch.object(mr, "_structural_marker_map", return_value={"unknown": "z"}):
-            reconstruct_parallel_item(pi, mr.defaultdict(dict))
+            reconstruct_container(pi, mr.defaultdict(dict))
         self.assertEqual(len(pi), 2)

--- a/opensiddur/tests/exporter/test_parallel_e2e.py
+++ b/opensiddur/tests/exporter/test_parallel_e2e.py
@@ -678,6 +678,110 @@ class TestArrangementProjectRootE2E(_E2EBase):
             self.assertEqual(primary.get(f"{{{XML_NS}}}lang"), "he")
             self.assertEqual(parallel.get(f"{{{XML_NS}}}lang"), "en")
 
+    def test_no_parallel_block_is_wrapped_in_a_div(self):
+        """The invariant the TeX stage depends on: p:parallel is a flat sibling of the flow.
+
+        The wrapper's tei:div encloses the transclusion in the source, so before
+        document-wide marker mode the compiled block came out as
+        body/div/transclude/p:parallel. reledmac.xslt groups on p:parallel among the
+        top-level nodes of the (transclude-flattened) body, so a block behind a div was
+        invisible to it: no \\begin{pairs} was emitted at all and both columns were run
+        together into one numbered stream.
+        """
+        root = self._compiled_root()
+        parallels = root.findall(f".//{{{P_NS}}}parallel")
+        self.assertGreater(len(parallels), 0, "expected per-transclusion parallels")
+
+        for par in parallels:
+            div_ancestors = [a for a in par.iterancestors(f"{{{TEI_NS}}}div")]
+            self.assertEqual(
+                div_ancestors, [],
+                "a p:parallel must not have a tei:div ancestor")
+
+    def test_the_enclosing_structure_is_reproduced_inside_each_column(self):
+        """Structure is not discarded to achieve that — it is copied into the columns."""
+        root = self._compiled_root()
+
+        rows_with_content = [
+            par for par in root.findall(f".//{{{P_NS}}}parallel")
+            if "".join(par.itertext()).strip()
+        ]
+        self.assertGreater(len(rows_with_content), 0)
+
+        for par in rows_with_content:
+            for item in par.findall(f"{{{P_NS}}}parallelItem"):
+                self.assertIsNotNone(
+                    item.find(f"{{{TEI_NS}}}div"),
+                    "each column must carry its own copy of the source's div")
+
+    def test_the_wrapper_div_still_encloses_its_own_heading(self):
+        """Marker-ifying the wrapper must not lose it: its head is still inside a div."""
+        root = self._compiled_root()
+        heads = root.findall(f".//{{{TEI_NS}}}div/{{{TEI_NS}}}head")
+        self.assertIn("Arrangement", [h.text for h in heads])
+
+
+class TestSplitStructureAcrossParallelsE2E(TestArrangementProjectRootE2E):
+    """Two transclusions inside one div: the div is split into segments around them."""
+
+    # Text of the wrapper's own between the two readings, so the enclosing div really is
+    # cut into two non-empty segments. Two adjacent transclusions would leave the segment
+    # between them empty, and an empty segment is pruned rather than marked.
+    _WRAPPER_XML = TestArrangementProjectRootE2E._WRAPPER_XML.replace(
+        b'<j:transclude type="external" target="urn:x-test:section/1"/>',
+        b'<j:transclude type="external" target="urn:x-test:section/1"/>\n'
+        b'        <tei:p>Between the readings.</tei:p>\n'
+        b'        <j:transclude type="external" target="urn:x-test:section/2"/>',
+    )
+
+    def _mock_resolve_range(self, urn):
+        base_urn, _, hint = urn.partition("@")
+        if base_urn == "urn:x-test:section/2":
+            if hint == self.ENGLISH_PROJECT:
+                project, xml_bytes = self.ENGLISH_PROJECT, _PARALLEL_XML
+            else:
+                project, xml_bytes = self.PARALLEL_PROJECT, _PRIMARY_XML
+            path = self._milestone_path(xml_bytes, "2")
+            return [ResolvedUrn(
+                urn=base_urn, project=project, file_name="verses.xml",
+                element_path=path, end_element_path=path, end_includes_tail=True)]
+        return super()._mock_resolve_range(urn)
+
+    def test_both_transclusions_reach_the_output(self):
+        text = "".join(self._compiled_root().itertext())
+        self.assertIn("Hebrew verse 1", text)
+        self.assertIn("English verse 1", text)
+        self.assertIn("Hebrew verse 2", text)
+        self.assertIn("English verse 2", text)
+
+    def test_each_verse_appears_once_per_column(self):
+        """Guards the quadratic tail leak at the level it actually mattered: a ranged
+        transclusion must carry its own verse and no earlier one."""
+        text = "".join(self._compiled_root().itertext())
+        self.assertEqual(text.count("Hebrew verse 1"), 1)
+        self.assertEqual(text.count("English verse 1"), 1)
+        self.assertEqual(text.count("Hebrew verse 2"), 1)
+        self.assertEqual(text.count("English verse 2"), 1)
+
+    def test_split_column_segments_are_marked_with_p_part(self):
+        """A structural element split across rows is stamped first/middle/last so the
+        exporter can tell a continuation from a fresh block."""
+        root = self._compiled_root()
+        parts = [
+            el.get(f"{{{P_NS}}}part")
+            for el in root.iter()
+            if el.get(f"{{{P_NS}}}part")
+        ]
+        self.assertIn("first", parts)
+        self.assertIn("last", parts)
+
+    def test_no_raw_markers_survive_reconstruction(self):
+        """The new top-level pass must consume its markers, not leave them in the output."""
+        root = self._compiled_root()
+        for attr in ("start", "end", "suspend", "resume", "logical-id"):
+            leftovers = root.findall(f".//*[@{{{P_NS}}}{attr}]")
+            self.assertEqual(leftovers, [], f"p:{attr} survived reconstruction")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -248,6 +248,44 @@ class TestSingleStreamMapping(unittest.TestCase):
         out = _transform(xml)
         self.assertIn(r"\chno{{\textdir TLT\selectlanguage{english}12}}", out)
 
+    def test_chapter_milestone_inside_a_parallel_column_still_emits_its_number(self):
+        """The book div now lives *inside* each column, not around the p:parallel.
+
+        Chapter numbers are gated on ancestor::tei:div[@type='book'], so the compiler
+        reproducing that div inside each p:parallelItem (stamped p:part when the div is
+        split across rows) is what keeps the gate satisfied in parallel mode. If the div
+        were hoisted away to flatten the blocks instead, \\chno would silently vanish.
+        """
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0"
+                 xmlns:p="http://jewishliturgy.org/ns/processing" xml:lang="he">
+          <tei:text><tei:body>
+            <p:parallel column-order="primary_first">
+              <p:parallelItem role="primary" xml:lang="he">
+                <tei:div type="book" p:part="first">
+                  <tei:p>
+                    <tei:milestone unit="chapter" n="3"/>
+                    <tei:milestone unit="verse" n="1"/>טקסט
+                  </tei:p>
+                </tei:div>
+              </p:parallelItem>
+              <p:parallelItem role="parallel" xml:lang="en">
+                <tei:div type="book" p:part="first">
+                  <tei:p>
+                    <tei:milestone unit="chapter" n="3"/>
+                    <tei:milestone unit="verse" n="1"/>Text
+                  </tei:p>
+                </tei:div>
+              </p:parallelItem>
+            </p:parallel>
+          </tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml, layout="pairs")
+        self.assertIn(r"\chno{{\textdir TLT\selectlanguage{english}3}}", out)
+        # ...and it is genuinely the two-column path, not the linear fallback.
+        self.assertIn(r"\begin{pairs}", out)
+        self.assertIn(r"\Columns", out)
+
     def test_verse_numbers_appear_as_superscripts(self):
         out = _transform(self.XML)
         # The \vno{} command renders as a superscript prefix.

--- a/specs/COMPILER_SPECIFICATION.md
+++ b/specs/COMPILER_SPECIFICATION.md
@@ -255,6 +255,14 @@ rather than failing loudly, so they are asserted in the parallel test suites.
    hierarchy inside it is *independent of*, not nested within, any enclosing one — which is
    precisely what makes (1) and (2) hold simultaneously.
 
+4. **A `p:parallel` never has a `tei:div` (or any other structural) ancestor.** Only
+   `p:transclude` wrappers may stand between it and `tei:body`, because those are the only
+   thing the TeX stage flattens. Enclosing structure is not discarded to achieve this: it is
+   reproduced *inside* each `p:parallelItem`, stamped `p:part="first|middle|last"` when one
+   source element spans several rows. Both halves matter — the flat outside is what lets
+   `reledmac.xslt` find the blocks and emit `\begin{pairs}`, and the copy inside each column
+   is what keeps `ancestor::tei:div[@type='book']` true so chapter numbers still render.
+
 So the shape is a flat alternation at each level, recursively:
 
 ```
@@ -270,7 +278,7 @@ tei:body
 
 ### Enforcement
 
-Two mechanisms, both required:
+Three mechanisms, all required:
 
 - `LinearData.parallel_compilation_depth` is incremented for the duration of any parallel
   sub-compilation (`ExternalCompilerProcessor._parallel_sub_compilation`). While it is non-zero,
@@ -283,6 +291,25 @@ Two mechanisms, both required:
   row, and recurses into the boundary transclude with the same split. `make_rows` is therefore
   the only producer of `p:parallel`, and only ever receives segments from which every
   `p:transclude` has been removed — so invariants (1) and (2) hold by construction.
+
+- **Marker mode is document-wide whenever `parallel.projects` is configured**, switched on for
+  the root processor in `ExternalCompilerProcessor.process` and propagated to every nested one.
+  Structural elements then compile to `p:start`/`p:end` marker pairs everywhere, and
+  `_process_element_as_marker` brackets each external transclusion with `p:suspend`/`p:resume`
+  for every open frame — which is what leaves the transclusion, and so the `p:parallel` inside
+  it, a *sibling* of the enclosing element's segments rather than a child. `marker_reconstruct`
+  then rebuilds the nesting: `reconstruct_container` runs over each `p:parallelItem` and over
+  the surrounding flow (`tei:body` and the `p:transclude` wrappers), deepest first and sharing
+  one `pid_state`, and `normalize_segment_parts` prunes empty segments and assigns `p:part`.
+  This is what invariant (4) rests on.
+
+  Enabling marker mode only inside `_transclude_parallel` is not enough, and was the bug: every
+  container *above* the first parallel-triggering transclusion stayed an ordinary nested
+  element, so a real book compiled to
+  `body/div/transclude/div[book]/transclude/div/transclude/p:parallel`. `reledmac.xslt` groups
+  on `p:parallel` among the top-level nodes of the transclude-flattened body and never matched
+  one, emitted no `\begin{pairs}` at all, and ran both columns together into a single numbered
+  stream.
 
 ## Annotation Processing
 


### PR DESCRIPTION
The dual-column Hebrew/English humash could not be built: the LuaLaTeX run was killed after
15,735 pages while still in early Exodus, with 15,418 underfull-vbox warnings, from a 377MB
compiled XML and a 362MB `.tex`.

This is not a LaTeX or reledpar problem. Two independent, pre-existing bugs, both reachable
only in parallel mode because marker mode was never enabled for the Hebrew-only edition. The
Aug-15 artifact, built before the chapter/citation work in #78, was already 291MB.

## 1. Pre-range tail leak — 97% of the bytes

`_process_element_as_marker` carried a child's tail with no range guard, so a `tei:p` spanning
the range start also emitted the tails of every child *before* it. A ranged transclusion came
out prefixed with all the text preceding its own start, markup and milestones stripped. Every
aliyah re-emitted every earlier one, so the cost grew quadratically — each verse of Bereshit
appeared 260–291 times.

Classifying the compiled rows:

| rows | count | text chars |
|---|---|---|
| with milestones (real content) | 15,148 | 6,725,439 |
| **without milestones (blobs)** | **1,563** | **242,913,088** |

`copy_text` is fixed for the whole element while `before_start` flips partway through its
children, so the guard has to read the live range flags, after the child is processed.

## 2. Parallel blocks never reached reledpar

The 362MB `.tex` contained **zero** `\begin{pairs}`, `\Leftside`, `\Rightside` or `\Columns`,
despite 16,711 `p:parallel` elements — both columns ran together into one numbered stream.

Marker mode began at `_transclude_parallel`, so containers *above* the parallel-triggering
transclusion stayed ordinary nested elements and a book compiled to
`body/div/transclude/div[book]/transclude/div/transclude/p:parallel`. `reledmac.xslt` groups on
`p:parallel` among the top-level nodes of the transclude-flattened body, so it matched none of
them. This violated the flat-shape invariant in `specs/COMPILER_SPECIFICATION.md`.

Marker mode is now document-wide whenever `parallel.projects` is configured. Structural
elements become marker pairs everywhere, the `p:suspend`/`p:resume` brackets around each
transclusion leave the block a *sibling* rather than a child, and `marker_reconstruct` rebuilds
the nesting inside each column with `p:part`. Structure is preserved by copying it into the
columns rather than discarding it, which is what keeps `ancestor::tei:div[@type='book']` true
so chapter numbers still render. `reconstruct_parallel_item` is renamed `reconstruct_container`
and now also runs over the surrounding flow, deepest first.

No change to `reledmac.xslt` was needed.

## Results

| | before | after |
|---|---|---|
| compiled XML | 377 MB | **20.2 MB** |
| `.tex` | 362 MB | **8.4 MB** |
| `\pstart` | 266,128 | 32,292 |
| `\begin{pairs}` / `\Columns` | **0** | 1,555 |
| blob-row text | 242,913,088 chars | **0** |
| `p:parallel` under a `tei:div` | all 16,711 | **0** |
| pages | 15,735+, killed, still climbing | **1,709, converged** |
| underfull `\vbox` | 15,418 | 2,534 |
| TeX capacity override (`max_strings`) | required | not needed |

`\vno` / `\chno` / `\OScitation` counts are unchanged (29105 / 1012 / 269), and all 1,555 pairs
groups have matching `\pstart` counts on both sides — the reledpar pairing invariant.

## Test plan

- Full suite: 1414 passed, 13 skipped.
- 19 new tests, each verified to fail without the fix. They close a real gap: every previous
  fixture placed `p:parallel` as a direct child of `tei:body` or inside a `p:transclude` —
  never inside a `tei:div` — which is why the suite passed while the pipeline was broken.
- **The Hebrew-only compiled XML rebuilds byte-for-byte identical**, confirming the edition
  merged in #78 is untouched rather than relying on the marker-mode argument.
- End-to-end: full humash rebuilt through compile → TeX → LuaLaTeX, converging at 1,709 pages
  over three passes with no rerun markers left.

## Known follow-up, not addressed here

1,709 pages is ~3.75x the 455-page Hebrew-only edition, more than adding a facing translation
should cost, and 2,534 underfull-vbox warnings remain. reledpar pairs one `\pstart` per verse,
so each aligned row is as tall as the taller column, and in a 0.43-textwidth measure the
English usually runs longer than the Hebrew. That is layout tuning (alignment granularity,
column widths, font size), independent of these two compiler bugs.