### PR TITLE
Add submodules and a release procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 __pycache__/
-sources/
-project/
 schema/*.relaxng
 schema/*.rnc
 schema/*.schematron

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,8 @@
+[submodule "sourcetexts"]
+	path = sourcetexts
+	url = git@github.com:opensiddur/sourcetexts.git
+	branch = master
+[submodule "opensiddur-projects"]
+	path = opensiddur-projects
+	url = git@github.com:opensiddur/opensiddur-projects.git
+	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,17 @@ This file provides guidance to coding agents when working with code in this repo
 
 The project derives from 3 repositories:
 opensiddur-ai https://github.com/opensiddur/opensiddur-ai (this repository)
-sourcetexts https://github.com/opensiddur/sourcetexts (sources/ subdirectory)
-opensiddur-projects https://github.com/opensiddur/projects (project/ subdirectory)
+sourcetexts https://github.com/opensiddur/sourcetexts (submodule at sourcetexts/, content in sourcetexts/sources/)
+opensiddur-projects https://github.com/opensiddur/opensiddur-projects (submodule at opensiddur-projects/, content in opensiddur-projects/project/)
+
+The other two repositories are git submodules of this one, so a release tag pins the exact
+source and project commits it was built against. See `RELEASE_PROCEDURE.md`.
 
 This repository has 3 parts: 
 (1) schema documentation for the Jewish Liturgy Project TEI extension (`JLPTEI-3.md`) and formal RelaxNG and Schematron schemas (schema/ subdirectory)
 (2) importers (opensiddur/importer/ subdirectory) that 
- (a) download raw data and put them into the sources/ subdirectory and 
- (b) convert the raw data into JLPTEI XML format and save them as projects (project/ subdirectory)
+ (a) download raw data and put them into the sourcetexts/sources/ submodule and 
+ (b) convert the raw data into JLPTEI XML format and save them as projects (opensiddur-projects/project/ submodule)
 (3) exporters (opensiddur/exporter/ subdirectory) that 
  (a) compile JLPTEI projects containing multiple JLPTEI files and/or reference multiple projects into a compiled intermediate format and 
  (b) export the intermediate format into finalized consumable forms (currently PDF via LuaLaTeX).
@@ -20,11 +23,14 @@ Any specifications for agents to build code should be stored in the specs/ direc
 
 ## Commands
 
-**Set up a fresh checkout or worktree** — run both before trusting a test run:
+**Set up a fresh checkout or worktree** — run all three before trusting a test run:
 ```bash
+git submodule update --init
 uv sync --all-groups
 bash scripts/build-schema.sh
 ```
+A new worktree starts with empty submodule directories, so the importers and exporters find
+no sources or projects until `git submodule update --init` has run.
 The compiled schema artifacts are gitignored, so a new worktree has none. Without them
 ~47 validation tests fail in a way that looks like a real regression rather than missing
 setup.
@@ -62,32 +68,27 @@ bash scripts/build-schema.sh
 
 **Validate a JLPTEI file** (requires `jing`: `apt install jing`):
 ```bash
-uv run python -m opensiddur.importer.util.validation project/wlc/ruth.xml
+uv run python -m opensiddur.importer.util.validation opensiddur-projects/project/wlc/ruth.xml
 ```
 
 **Download Feinstein/Heidenheim haggadah sources** (OSP compilation + HebrewBooks PDF):
 ```bash
-uv run python -m opensiddur.importer.feinstein_haggadah.download \
-  --sourcetexts-root ~/src/opensiddur-repos/sourcetexts/sources
+uv run python -m opensiddur.importer.feinstein_haggadah.download
 ```
 
 **Align page breaks** from the 1822 PDF facsimile (writes `page_breaks.json`):
 ```bash
-uv run python -m opensiddur.importer.feinstein_haggadah.align_page_breaks \
-  --sourcetexts-root ~/src/opensiddur-repos/sourcetexts/sources
+uv run python -m opensiddur.importer.feinstein_haggadah.align_page_breaks
 ```
 
 **Convert haggadah sources to JLPTEI projects** (each output file is validated against RelaxNG + Schematron before write):
 ```bash
-uv run python -m opensiddur.importer.feinstein_haggadah.convert \
-  --sourcetexts-root ~/src/opensiddur-repos/sourcetexts/sources \
-  --project-dir ~/src/opensiddur-repos/opensiddur-projects/project
+uv run python -m opensiddur.importer.feinstein_haggadah.convert
 ```
 
 **Sync reference database** after adding or updating projects:
 ```bash
-uv run python -m opensiddur.exporter.refdb \
-  --project-directory ~/src/opensiddur-repos/opensiddur-projects/project
+uv run python -m opensiddur.exporter.refdb
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ This is a work in progress to convert the Open Siddur Project to use AI to aid i
 * A new version of JLPTEI (2) with a simplified schema.
 * Less emphasis on UI: This is primarily about converting texts from any input format to JLPTEI, and converting the JLPTEI to useful output formats and combining texts in novel ways.
 
+## Checkout
+
+The source texts and the derived JLPTEI projects live in two other repositories, both attached
+here as git submodules — `sourcetexts/` and `opensiddur-projects/`. A release tag of this
+repository therefore names the exact commits of both (see `RELEASE_PROCEDURE.md`).
+
+```bash
+git clone git@github.com:opensiddur/opensiddur-ai.git
+cd opensiddur-ai
+git submodule update --init
+uv sync --all-groups
+```
+
+A new git worktree starts with empty submodule directories; run `git submodule update --init`
+there too.
+
+See [RELEASE_PROCEDURE.md](RELEASE_PROCEDURE.md) for how a version of this repository is tagged
+and how it pins `sourcetexts`/`opensiddur-projects` commits.
+
 ## Schema
 To compile the schema:
 
@@ -24,50 +43,45 @@ The output will be in the `schema` directory as RelaxNG XML (and, eventually, IS
 
 ## Sources
 
-Available sources in their original (or close to original) form are in the `sources` directory.
-The canonical source texts repository is at [opensiddur/sourcetexts](https://github.com/opensiddur/sourcetexts).
-Clone or symlink it as the `sources` root before running any importers.
+Available sources in their original (or close to original) form are in `sourcetexts/sources`,
+the [opensiddur/sourcetexts](https://github.com/opensiddur/sourcetexts) submodule. Every importer
+reads from there by default; `--sourcetexts-root` overrides it with an external clone.
 
 Input converters for each specific source are in the `importer` directory.
 
-Example: run the WLC importer against an external clone:
+Example: run the WLC importer:
 
 ```bash
-uv run python -m opensiddur.importer.wlc.wlc \
-  --sourcetexts-root ~/src/opensiddur-repos/sourcetexts/sources \
-  --project-dir ~/src/opensiddur-repos/opensiddur-projects/project/wlc
+uv run python -m opensiddur.importer.wlc.wlc
 ```
 
-Example: run the JPS 1917 importer against an external clone:
+Example: run the JPS 1917 importer:
 
 ```bash
-uv run python -m opensiddur.importer.jps1917.convert_wikisource \
-  --sourcetexts-root ~/src/opensiddur-repos/sourcetexts/sources \
-  --project-dir ~/src/opensiddur-repos/opensiddur-projects/project/jps1917
+uv run python -m opensiddur.importer.jps1917.convert_wikisource
 ```
 
 Example: download Miqra al pi ha-Masorah from Google Sheets into sourcetexts:
 
 ```bash
-uv run python -m opensiddur.importer.miqra_al_pi_hamasorah.download \
-  --sourcetexts-root ~/src/opensiddur-repos/sourcetexts/sources
+uv run python -m opensiddur.importer.miqra_al_pi_hamasorah.download
 ```
 
 ## JLPTEI sources
 
-JLPTEI sources are compiled into the `project` directory.
-The canonical projects repository is at [opensiddur/opensiddur-projects](https://github.com/opensiddur/opensiddur-projects).
-Clone or symlink it as the `project` root before running the compiler or exporter.
+JLPTEI sources are compiled into `opensiddur-projects/project`, the
+[opensiddur/opensiddur-projects](https://github.com/opensiddur/opensiddur-projects) submodule.
+`--project-directory` overrides it with an external clone.
 
 ## Reference database
 
 The exporter resolves `urn:x-opensiddur:` URIs to project files via a SQLite
 database at `database/reference.db`. Whenever you add, remove, or rename files
-in the `project/` directory (e.g. a clone of [opensiddur/opensiddur-projects](https://github.com/opensiddur/opensiddur-projects)),
-re-sync the database so the compiler can find them, as in the example here:
+in `opensiddur-projects/project/`,
+re-sync the database so the compiler can find them:
 
 ```bash
-uv run python -m opensiddur.exporter.refdb --project-directory ~/src/opensiddur-projects/project
+uv run python -m opensiddur.exporter.refdb
 ```
 
 The command scans every `project/<name>/` subdirectory, updates URN and
@@ -79,7 +93,7 @@ You must re-sync before running the compiler on any newly-added project.
 
 ## Compilation (JLPTEI → compiled linear XML)
 
-The compiler takes a `project/<name>/` file (from [opensiddur/opensiddur-projects](https://github.com/opensiddur/opensiddur-projects)),
+The compiler takes an `opensiddur-projects/project/<name>/` file,
 resolves transclusions, annotations, and parallel texts,
 and outputs a single “compiled” XML file that can be 
 converted into a final printable format (eg, PDF).
@@ -88,7 +102,6 @@ Example (compile `project/wlc/ruth.xml` to `compiled.xml`):
 
 ```bash
 uv run python -m opensiddur.exporter.compiler \
-  --project-directory ~/src/opensiddur-repos/opensiddur-projects/project \
   --project wlc \
   --file_name ruth.xml \
   --output_file compiled.xml
@@ -98,7 +111,6 @@ Example with a settings YAML (controls project priorities, annotations, and opti
 
 ```bash
 uv run python -m opensiddur.exporter.compiler \
-  --project-directory ~/src/opensiddur-repos/opensiddur-projects/project \
   --project wlc \
   --file_name ruth.xml \
   --settings doc/exporter-settings.example.yaml \
@@ -111,7 +123,6 @@ Convert the compiled XML file to LuaLaTeX using the `reledmac`/`reledpar` pipeli
 
 ```bash
 uv run python -m opensiddur.exporter.tex.latex \
-  --project-directory ~/src/opensiddur-repos/opensiddur-projects/project \
   compiled.xml \
   --settings doc/exporter-settings.example.yaml \
   --output compiled.tex
@@ -123,7 +134,6 @@ Export directly to PDF (generates TeX internally, then runs LuaLaTeX/latexmk):
 
 ```bash
 uv run python -m opensiddur.exporter.pdf.pdf \
-  --project-directory ~/src/opensiddur-repos/opensiddur-projects/project \
   --settings doc/exporter-settings.example.yaml \
   compiled.xml \
   output.pdf
@@ -133,7 +143,6 @@ Keep the intermediate TeX (helpful for debugging LaTeX issues):
 
 ```bash
 uv run python -m opensiddur.exporter.pdf.pdf \
-  --project-directory ~/src/opensiddur-repos/opensiddur-projects/project \
   --settings doc/exporter-settings.example.yaml \
   --keep-tex \
   compiled.xml \

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -1,0 +1,100 @@
+# Release procedure
+
+A release is a `v<major>.<minor>.<patch>` tag on this repository (`opensiddur-ai`). The tag's
+commit pins exact commits of the `sourcetexts` and `opensiddur-projects` submodules, so a given
+release fully identifies the code and the data it was built and tested against. Neither
+`sourcetexts` nor `opensiddur-projects` is tagged itself — the submodule pointers are the record.
+
+## Versioning policy
+
+- **0.x series** (current): every release bumps the **minor** version
+  (`0.1.0 -> 0.2.0 -> 0.3.0 ...`). Backwards compatibility is not promised between releases.
+- **1.0.0 and above**: strict [Semantic Versioning](https://semver.org/). Choose the bump level
+  deliberately — major for incompatible changes, minor for backwards-compatible features, patch
+  for backwards-compatible fixes.
+
+## Before releasing
+
+Work from an up-to-date worktree on `main`, per this project's [worktree convention](../CLAUDE.md):
+
+```bash
+git worktree add ../main origin/main   # if you don't already have a main worktree
+cd ../main
+git fetch origin
+git status                              # must be clean
+git submodule update --init
+uv sync --all-groups
+bash scripts/build-schema.sh
+uv run coverage run -m unittest discover -s opensiddur/tests -v
+```
+
+Confirm:
+- The working tree is clean and `main` is up to date with `origin/main`.
+- The full test suite passes.
+- `sourcetexts/` and `opensiddur-projects/` are on the commits you intend to ship — if you need
+  a specific commit rather than the tip of each repo's default branch, update the submodule by
+  hand first (`cd sourcetexts && git checkout <commit>`) and commit that.
+- `CHANGELOG.md`'s `## [Unreleased]` section accurately describes what's shipping. The release
+  will fail if it's empty.
+- You have push access to `origin` and `gh auth status` shows you're logged in (needed for the
+  GitHub Release step).
+
+## Releasing
+
+Dry run first — this prints every command and file change and touches nothing:
+
+```bash
+uv run python -m opensiddur.release --dry-run
+```
+
+Review the printed version bump, the changelog diff, and the submodule commits it would pin.
+Then run it for real:
+
+```bash
+uv run python -m opensiddur.release
+```
+
+Flags:
+- `--minor` / `--major` / `--patch` — choose the bump level. Below 1.0.0 this defaults to
+  `--minor`; at 1.0.0 and above one of these (or `--version`) is required.
+- `--version X.Y.Z` — release an exact version instead of bumping.
+- `--no-publish` — tag and push, but skip creating the GitHub Release.
+- `--dry-run` — as above.
+
+What it does, in order:
+1. Reads the current version from `pyproject.toml`.
+2. Computes the next version and checks that its tag doesn't already exist locally or on
+   `origin`.
+3. Runs `git submodule update --init --remote` to move `sourcetexts` and `opensiddur-projects`
+   to the tip of the branch each tracks (`master` and `main` respectively — see `.gitmodules`).
+4. Writes the new version into `pyproject.toml`.
+5. Rolls `CHANGELOG.md`'s `[Unreleased]` section into a new `## [X.Y.Z] - <date>` section,
+   appends the pinned submodule commits to it, and leaves a fresh empty `[Unreleased]` above it.
+6. Commits `pyproject.toml`, `CHANGELOG.md`, and the two submodule pointers as `Release vX.Y.Z`.
+7. Creates an annotated tag `vX.Y.Z` with the new changelog section as its message.
+8. Pushes the branch and the tag to `origin`.
+9. Creates a GitHub Release for the tag via `gh release create`, using the same notes (skipped
+   with `--no-publish`).
+
+## After releasing
+
+- Check the [releases page](https://github.com/opensiddur/opensiddur-ai/releases) and the pushed
+  tag.
+- Confirm `git submodule status` on the tag shows the commits you expected.
+- If a downstream worktree needs the release, `git fetch --tags` and check out the tag, then
+  `git submodule update --init`.
+
+## Undoing a bad release
+
+If something is wrong before anyone has pulled the tag:
+
+```bash
+gh release delete vX.Y.Z --yes           # if a GitHub Release was created
+git push origin :refs/tags/vX.Y.Z        # delete the remote tag
+git tag -d vX.Y.Z                        # delete the local tag
+git revert <release-commit>              # or reset, if it hasn't been pulled elsewhere
+git push origin main
+```
+
+Prefer `git revert` over rewriting `main` history once the release commit has been pushed, so
+that anyone who already fetched it doesn't end up with a diverged branch.

--- a/opensiddur/common/constants.py
+++ b/opensiddur/common/constants.py
@@ -1,5 +1,10 @@
 from pathlib import Path
 
 
-PROJECT_DIRECTORY = Path(__file__).resolve().parent.parent.parent / "project"
-INDEX_DB_DIRECTORY = Path(__file__).resolve().parent.parent.parent / "database"
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# The sourcetexts and opensiddur-projects repositories are git submodules of this one,
+# checked out at the repository root. Each keeps its content in a subdirectory.
+SOURCETEXTS_ROOT = REPO_ROOT / "sourcetexts" / "sources"
+PROJECT_DIRECTORY = REPO_ROOT / "opensiddur-projects" / "project"
+INDEX_DB_DIRECTORY = REPO_ROOT / "database"

--- a/opensiddur/exporter/compiler.py
+++ b/opensiddur/exporter/compiler.py
@@ -919,7 +919,7 @@ def main(argv: list[str] | None = None):  # pragma: no cover
         "--project-directory",
         type=Path,
         default=PROJECT_DIRECTORY,
-        help="Base directory containing project subdirectories (default: <repo>/project).",
+        help="Base directory containing project subdirectories (default: <repo>/opensiddur-projects/project).",
     )
     args = parser.parse_args(argv)
 

--- a/opensiddur/exporter/pdf/pdf.py
+++ b/opensiddur/exporter/pdf/pdf.py
@@ -366,7 +366,7 @@ Examples:
         "--project-directory",
         type=Path,
         default=PROJECT_DIRECTORY,
-        help="Base directory containing project subdirectories (default: <repo>/project).",
+        help="Base directory containing project subdirectories (default: <repo>/opensiddur-projects/project).",
     )
 
     args = parser.parse_args()

--- a/opensiddur/exporter/refdb.py
+++ b/opensiddur/exporter/refdb.py
@@ -820,7 +820,7 @@ def main(argv: list[str] | None = None) -> None:  # pragma: no cover
         "--project-directory",
         type=Path,
         default=PROJECT_DIRECTORY,
-        help="Base directory containing project subdirectories (default: <repo>/project).",
+        help="Base directory containing project subdirectories (default: <repo>/opensiddur-projects/project).",
     )
     parser.add_argument(
         "--reference-db",

--- a/opensiddur/exporter/tex/latex.py
+++ b/opensiddur/exporter/tex/latex.py
@@ -446,7 +446,7 @@ Examples:
         "--project-directory",
         type=Path,
         default=PROJECT_DIRECTORY,
-        help="Base directory containing project subdirectories (default: <repo>/project).",
+        help="Base directory containing project subdirectories (default: <repo>/opensiddur-projects/project).",
     )
 
     args = parser.parse_args()

--- a/opensiddur/importer/agent/text_encoding_agent.py
+++ b/opensiddur/importer/agent/text_encoding_agent.py
@@ -56,7 +56,7 @@ class TextEncodingAgentState(TypedDict):
     session_id: Optional[str]
     last_checkpoint_time: Optional[str]
 
-    # JPS 1917 page files live under <sourcetexts_root>/jps1917 (None = default <repo>/sources)
+    # JPS 1917 page files live under <sourcetexts_root>/jps1917 (None = default <repo>/sourcetexts/sources)
     sourcetexts_root: Optional[str]
 
 
@@ -73,7 +73,7 @@ class TextEncodingAgentInput(BaseModel):
     enable_checkpointing: bool = Field(default=True, description="Enable checkpointing for this session")
     sourcetexts_root: Optional[Path] = Field(
         default=None,
-        description="Root of sourcetexts repo; Wikisource page dumps under <root>/jps1917 (default: <repo>/sources).",
+        description="Root of sourcetexts repo; Wikisource page dumps under <root>/jps1917 (default: <repo>/sourcetexts/sources).",
     )
 
 

--- a/opensiddur/importer/feinstein_haggadah/download.py
+++ b/opensiddur/importer/feinstein_haggadah/download.py
@@ -308,7 +308,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--sourcetexts-root",
         type=Path,
         default=default_sourcetexts_root(),
-        help="Root of sourcetexts (default: <repo>/sources).",
+        help="Root of sourcetexts (default: <repo>/sourcetexts/sources).",
     )
     parser.add_argument(
         "--dry-run",

--- a/opensiddur/importer/jps1917/README.md
+++ b/opensiddur/importer/jps1917/README.md
@@ -74,14 +74,12 @@ The conversion process follows a three-stage pipeline:
 uv run python -m opensiddur.importer.jps1917.convert_wikisource
 ```
 
-If you are using external clones of [opensiddur/sourcetexts](https://github.com/opensiddur/sourcetexts)
-and [opensiddur/opensiddur-projects](https://github.com/opensiddur/opensiddur-projects), pass the
-paths explicitly:
+To use external clones instead of the submodules, pass the paths explicitly:
 
 ```bash
 uv run python -m opensiddur.importer.jps1917.convert_wikisource \
-  --sourcetexts-root ~/src/opensiddur-repos/sourcetexts/sources \
-  --project-dir ~/src/opensiddur-repos/opensiddur-projects/project/jps1917
+  --sourcetexts-root /path/to/sourcetexts/sources \
+  --project-dir /path/to/opensiddur-projects/project/jps1917
 ```
 
 ### Complete Workflow (Programmatic)

--- a/opensiddur/importer/jps1917/convert_wikisource.py
+++ b/opensiddur/importer/jps1917/convert_wikisource.py
@@ -25,10 +25,6 @@ logger = logging.getLogger(__name__)
 MEDIAWIKI_TO_TEI_XSLT = Path(__file__).parent / "mediawiki_to_tei.xslt"
 
 
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parent.parent.parent.parent
-
-
 def make_project_directory(project_dir: Path | None = None) -> Path:
     """Create the JPS 1917 project directory if missing; return its path."""
     directory = (
@@ -715,15 +711,18 @@ def index_file(
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
-    repo = _repo_root()
     parser = argparse.ArgumentParser(
-        description="Convert JPS 1917 Wikisource page dumps to JLPTEI under project/jps1917."
+        description="Convert JPS 1917 Wikisource page dumps to JLPTEI under "
+                    "opensiddur-projects/project/jps1917."
     )
     parser.add_argument(
         "--project-dir",
         type=Path,
-        default=repo / "project" / "jps1917",
-        help="Output directory for generated JLPTEI (default: <repo>/project/jps1917).",
+        default=_default_project_directory(),
+        help=(
+            "Output directory for generated JLPTEI "
+            "(default: <repo>/opensiddur-projects/project/jps1917)."
+        ),
     )
     parser.add_argument(
         "--sourcetexts-root",
@@ -731,7 +730,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=default_sourcetexts_root(),
         help=(
             "Root of the opensiddur/sourcetexts repository; page text is read from "
-            "<root>/jps1917 (default: <repo>/sources)."
+            "<root>/jps1917 (default: <repo>/sourcetexts/sources)."
         ),
     )
     return parser

--- a/opensiddur/importer/jps1917/template_finder.py
+++ b/opensiddur/importer/jps1917/template_finder.py
@@ -422,7 +422,7 @@ def _run_cli() -> None:  # pragma: no cover
         "--sourcetexts-root",
         type=Path,
         default=default_sourcetexts_root(),
-        help="Root of sourcetexts repo; JPS pages under <root>/jps1917 (default: <repo>/sources).",
+        help="Root of sourcetexts repo; JPS pages under <root>/jps1917 (default: <repo>/sourcetexts/sources).",
     )
     args = parser.parse_args()
     root = args.sourcetexts_root

--- a/opensiddur/importer/jps1917/wikisource.py
+++ b/opensiddur/importer/jps1917/wikisource.py
@@ -18,7 +18,7 @@ pages = range(start_page, 1158 + 1)
 # Backward-compatible name for JPS tree under sourcetexts
 jps1917_output_directory = jps1917_data_directory
 
-# Default layout (legacy): <repo>/sources/jps1917
+# Default layout: <repo>/sourcetexts/sources/jps1917
 output_directory = jps1917_data_directory()
 
 
@@ -114,7 +114,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=default_sourcetexts_root(),
         help=(
             "Root of the opensiddur/sourcetexts repository; page text is written under "
-            "<root>/jps1917 (default: <repo>/sources for legacy sources/jps1917)."
+            "<root>/jps1917 (default: <repo>/sourcetexts/sources)."
         ),
     )
     parser.add_argument(

--- a/opensiddur/importer/miqra_al_pi_hamasorah/README.md
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/README.md
@@ -8,11 +8,11 @@ The README tab of the source spreadsheet states that the text is prepared by Avi
 
 ## Download
 
-Prerequisites: clone [opensiddur/sourcetexts](https://github.com/opensiddur/sourcetexts) (or use `<repo>/sources`).
+Writes into the `sourcetexts` submodule (`sourcetexts/sources`) by default; pass
+`--sourcetexts-root` to use an external clone instead.
 
 ```bash
-uv run python -m opensiddur.importer.miqra_al_pi_hamasorah.download \
-  --sourcetexts-root ~/src/opensiddur-repos/sourcetexts/sources
+uv run python -m opensiddur.importer.miqra_al_pi_hamasorah.download
 ```
 
 Use `--dry-run` to print paths without downloading.

--- a/opensiddur/importer/miqra_al_pi_hamasorah/convert_tsv.py
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/convert_tsv.py
@@ -570,14 +570,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--sourcetexts-root",
         type=Path,
         default=default_sourcetexts_root(),
-        help="Root of sourcetexts tree (default: <repo>/sources).",
+        help="Root of sourcetexts tree (default: <repo>/sourcetexts/sources).",
     )
     parser.add_argument(
         "--project-dir",
         type=Path,
         default=None,
         help=(
-            "Output project directory (default: <repo>/project/miqra_al_pi_hamasorah)."
+            "Output project directory (default: <repo>/opensiddur-projects/project/miqra_al_pi_hamasorah)."
         ),
     )
     parser.add_argument(

--- a/opensiddur/importer/miqra_al_pi_hamasorah/download.py
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/download.py
@@ -198,7 +198,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=default_sourcetexts_root(),
         help=(
             "Root of the sourcetexts tree; output is written under "
-            "<root>/miqra_al_pi_hamasorah (default: <repo>/sources)."
+            "<root>/miqra_al_pi_hamasorah (default: <repo>/sourcetexts/sources)."
         ),
     )
     parser.add_argument(

--- a/opensiddur/importer/util/pages.py
+++ b/opensiddur/importer/util/pages.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 from typing import Optional
 
-from opensiddur.importer.util.constants import BASE_PATH, Page
+from opensiddur.common.constants import SOURCETEXTS_ROOT
+from opensiddur.importer.util.constants import Page
 
 
 def default_sourcetexts_root() -> Path:
-    """Default opensiddur/sourcetexts checkout root (legacy layout: <repo>/sources)."""
-    return BASE_PATH / "sources"
+    """Default opensiddur/sourcetexts checkout root (the sourcetexts submodule)."""
+    return SOURCETEXTS_ROOT
 
 
 def jps1917_data_directory(sourcetexts_root: Path | None = None) -> Path:

--- a/opensiddur/importer/wlc/README.md
+++ b/opensiddur/importer/wlc/README.md
@@ -11,21 +11,19 @@ To download the data:
 uv run python -m download_tanach 
 ```
 
-The data will be downloaded to the `sources/wlc` directory.
+The data will be downloaded to the `sourcetexts/sources/wlc` directory (the sourcetexts submodule).
 
 To convert the data to JLPTEI 2:
 ```bash
 uv run python -m opensiddur.importer.wlc.wlc
 ```
 
-The output will be in the `project/wlc` directory.
+The output will be in the `opensiddur-projects/project/wlc` directory (the opensiddur-projects submodule).
 
-If you are using external clones of [opensiddur/sourcetexts](https://github.com/opensiddur/sourcetexts)
-and [opensiddur/opensiddur-projects](https://github.com/opensiddur/opensiddur-projects), pass the
-paths explicitly:
+To use external clones instead of the submodules, pass the paths explicitly:
 
 ```bash
 uv run python -m opensiddur.importer.wlc.wlc \
-  --sourcetexts-root ~/src/opensiddur-repos/sourcetexts/sources \
-  --project-dir ~/src/opensiddur-repos/opensiddur-projects/project/wlc
+  --sourcetexts-root /path/to/sourcetexts/sources \
+  --project-dir /path/to/opensiddur-projects/project/wlc
 ```

--- a/opensiddur/importer/wlc/download_tanach.py
+++ b/opensiddur/importer/wlc/download_tanach.py
@@ -6,16 +6,14 @@ from zipfile import ZipFile
 
 import requests
 
+from opensiddur.common.constants import SOURCETEXTS_ROOT
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parent.parent.parent.parent
-
-
 def _default_sourcetexts_root() -> Path:
-    return _repo_root() / "sources"
+    return SOURCETEXTS_ROOT
 
 
 def download_and_unzip_tanach(sourcetexts_root: Path | None = None) -> None:
@@ -60,7 +58,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=_default_sourcetexts_root(),
         help=(
             "Root of the opensiddur/sourcetexts repository; files are written under "
-            "<root>/wlc (default: <repo>/sources so output matches legacy sources/wlc)."
+            "<root>/wlc (default: <repo>/sourcetexts/sources)."
         ),
     )
     return parser

--- a/opensiddur/importer/wlc/wlc.py
+++ b/opensiddur/importer/wlc/wlc.py
@@ -4,20 +4,17 @@ import os
 import sys
 from pathlib import Path
 
+from opensiddur.common.constants import PROJECT_DIRECTORY, SOURCETEXTS_ROOT
 from opensiddur.common.xslt import xslt_transform
 from opensiddur.importer.util.validation import validate
 
 logger = logging.getLogger(__name__)
 
 
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parent.parent.parent.parent
-
-
 def make_project_directory(project_dir: Path | None = None) -> Path:
     """Create the WLC project directory if missing; return its path."""
     directory = (
-        project_dir.resolve() if project_dir is not None else _repo_root() / "project" / "wlc"
+        project_dir.resolve() if project_dir is not None else PROJECT_DIRECTORY / "wlc"
     )
     directory.mkdir(parents=True, exist_ok=True)
     return directory
@@ -28,7 +25,7 @@ def get_source_directory(sourcetexts_root: Path | None = None) -> Path:
     root = (
         sourcetexts_root.resolve()
         if sourcetexts_root is not None
-        else _repo_root() / "sources"
+        else SOURCETEXTS_ROOT
     )
     return root / "wlc"
 
@@ -44,23 +41,25 @@ def _wlc_directory_uri(wlc_directory: Path) -> str:
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
-    repo = _repo_root()
     parser = argparse.ArgumentParser(
         description="Transform WLC UXLC XML from sourcetexts into JLPTEI project files."
     )
     parser.add_argument(
         "--project-dir",
         type=Path,
-        default=repo / "project" / "wlc",
-        help="Output directory for generated JLPTEI (default: <repo>/project/wlc).",
+        default=PROJECT_DIRECTORY / "wlc",
+        help=(
+            "Output directory for generated JLPTEI "
+            "(default: <repo>/opensiddur-projects/project/wlc)."
+        ),
     )
     parser.add_argument(
         "--sourcetexts-root",
         type=Path,
-        default=repo / "sources",
+        default=SOURCETEXTS_ROOT,
         help=(
             "Root of the opensiddur/sourcetexts repository; WLC files are read from "
-            "<root>/wlc/Books (default: <repo>/sources so legacy layout stays <repo>/sources/wlc)."
+            "<root>/wlc/Books (default: <repo>/sourcetexts/sources)."
         ),
     )
     return parser

--- a/opensiddur/release/__init__.py
+++ b/opensiddur/release/__init__.py
@@ -1,0 +1,1 @@
+"""Release tooling for opensiddur-ai. See RELEASE_PROCEDURE.md."""

--- a/opensiddur/release/__main__.py
+++ b/opensiddur/release/__main__.py
@@ -1,0 +1,81 @@
+"""Cut a release: `uv run python -m opensiddur.release [--minor] [--dry-run]`.
+
+See RELEASE_PROCEDURE.md for what to do before and after running this.
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from opensiddur.common.constants import REPO_ROOT
+from opensiddur.release.release import ReleaseError, Repository, release
+from opensiddur.release.version import Version
+
+logger = logging.getLogger(__name__)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m opensiddur.release",
+        description=(
+            "Bump the version, pin the sourcetexts and opensiddur-projects submodules to "
+            "their tracked branches, roll the changelog, tag, push, and publish a GitHub "
+            "release. Below 1.0.0 the default bump is the minor version."
+        ),
+    )
+    level = parser.add_mutually_exclusive_group()
+    level.add_argument(
+        "--major", dest="level", action="store_const", const="major",
+        help="Bump the major version (incompatible changes).",
+    )
+    level.add_argument(
+        "--minor", dest="level", action="store_const", const="minor",
+        help="Bump the minor version (the default below 1.0.0).",
+    )
+    level.add_argument(
+        "--patch", dest="level", action="store_const", const="patch",
+        help="Bump the patch version (fixes only).",
+    )
+    level.add_argument(
+        "--version", dest="explicit", type=Version.parse, metavar="X.Y.Z",
+        help="Release exactly this version instead of bumping.",
+    )
+    parser.add_argument(
+        "--repo", type=Path, default=REPO_ROOT,
+        help="The opensiddur-ai checkout to release from (default: this one).",
+    )
+    parser.add_argument(
+        "--no-publish", dest="publish", action="store_false",
+        help="Tag and push, but do not create the GitHub release.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print every command and file that would change, and change nothing.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    repo = Repository(root=args.repo.resolve(), dry_run=args.dry_run)
+    try:
+        plan = release(
+            repo, level=args.level, explicit=args.explicit, publish=args.publish
+        )
+    except (ReleaseError, ValueError) as error:
+        logger.error("%s", error)
+        return 1
+
+    verb = "would release" if args.dry_run else "released"
+    logger.info("")
+    logger.info("%s %s -> %s", verb, plan.current, plan.version)
+    for path, commit in sorted(plan.pinned.items()):
+        logger.info("  %s pinned at %s", path, commit)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/opensiddur/release/changelog.py
+++ b/opensiddur/release/changelog.py
@@ -1,0 +1,68 @@
+"""Rolling the Keep a Changelog `[Unreleased]` section into a released version."""
+
+import re
+from dataclasses import dataclass
+
+from opensiddur.release.version import Version
+
+UNRELEASED_HEADING = "## [Unreleased]"
+SECTION_HEADING_RE = re.compile(r"^## ", re.MULTILINE)
+
+PINNED_HEADING = "### Pinned sources"
+
+
+class ChangelogError(ValueError):
+    """The changelog is not in a state a release can be cut from."""
+
+
+@dataclass(frozen=True)
+class RolledChangelog:
+    text: str
+    """The whole changelog, with an emptied `[Unreleased]` above the new version section."""
+
+    notes: str
+    """The body of the new version section: the release notes, without the heading."""
+
+
+def _section_bounds(lines: list[str], heading: str) -> tuple[int, int]:
+    """Line indexes of the heading and of the section heading that follows it (or EOF)."""
+    try:
+        start = next(i for i, line in enumerate(lines) if line.strip() == heading)
+    except StopIteration:
+        raise ChangelogError(f"No {heading!r} heading in the changelog.") from None
+    end = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")),
+        len(lines),
+    )
+    return start, end
+
+
+def pinned_sources_note(pinned: dict[str, str]) -> str:
+    """The block recording which submodule commits this release was cut against."""
+    lines = [PINNED_HEADING, ""]
+    lines += [f"- `{path}`: {commit}" for path, commit in sorted(pinned.items())]
+    return "\n".join(lines)
+
+
+def roll(text: str, version: Version, date: str, pinned: dict[str, str] | None = None) -> RolledChangelog:
+    """Move the `[Unreleased]` entries into a `## [version] - date` section beneath it.
+
+    `pinned` maps a submodule path to the commit this release pins it to; it is appended to
+    the new section so the changelog says what the tag was built against.
+    """
+    lines = text.splitlines()
+    start, end = _section_bounds(lines, UNRELEASED_HEADING)
+
+    body = "\n".join(lines[start + 1 : end]).strip("\n")
+    if not body.strip():
+        raise ChangelogError(
+            "The [Unreleased] section is empty; there is nothing to release."
+        )
+
+    notes = body
+    if pinned:
+        notes = f"{notes}\n\n{pinned_sources_note(pinned)}"
+
+    released = [f"## [{version}] - {date}", "", notes, ""]
+    rolled = lines[: start + 1] + [""] + released + lines[end:]
+    return RolledChangelog(text="\n".join(rolled).rstrip("\n") + "\n", notes=notes)

--- a/opensiddur/release/release.py
+++ b/opensiddur/release/release.py
@@ -1,0 +1,232 @@
+"""The release itself: bump, pin the submodules, roll the changelog, tag, push, announce.
+
+Every step that changes something goes through `Repository.run` or `Repository.write`, and
+those two are what `--dry-run` and the tests replace. Commands that only read state go
+through `Repository.capture` and run even under `--dry-run`, so a dry run reports the real
+versions, the real tags, and the commits the release would actually pin.
+"""
+
+import logging
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from datetime import date as date_type
+from pathlib import Path
+
+from opensiddur.release import changelog
+from opensiddur.release.version import (
+    BumpLevel,
+    Version,
+    next_version,
+    read_pyproject_version,
+    write_pyproject_version,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ReleaseError(RuntimeError):
+    """The release cannot proceed."""
+
+
+@dataclass
+class Submodule:
+    name: str
+    path: str
+    url: str
+    branch: str
+
+
+@dataclass
+class Repository:
+    """A checkout the release acts on, with the write side switchable off."""
+
+    root: Path
+    dry_run: bool = False
+    performed: list[list[str]] = field(default_factory=list)
+    """Every mutating command, in order — what a dry run reports and the tests assert on."""
+
+    written: dict[Path, str] = field(default_factory=dict)
+    """Every file the release would write, by path."""
+
+    def capture(self, *args: str) -> str:
+        """Run a read-only command and return its stdout. Runs even under --dry-run."""
+        result = subprocess.run(
+            args, cwd=self.root, capture_output=True, text=True, check=False
+        )
+        if result.returncode != 0:
+            raise ReleaseError(
+                f"{' '.join(args)} failed ({result.returncode}): {result.stderr.strip()}"
+            )
+        return result.stdout.strip()
+
+    def run(self, *args: str) -> None:
+        """Run a mutating command, or, under --dry-run, only record it."""
+        self.performed.append(list(args))
+        if self.dry_run:
+            logger.info("would run: %s", " ".join(args))
+            return
+        logger.info("running: %s", " ".join(args))
+        result = subprocess.run(args, cwd=self.root, check=False)
+        if result.returncode != 0:
+            raise ReleaseError(f"{' '.join(args)} failed ({result.returncode}).")
+
+    def read(self, relative: str) -> str:
+        return (self.root / relative).read_text()
+
+    def write(self, relative: str, text: str) -> None:
+        """Write a file, or, under --dry-run, only record what would be written."""
+        path = self.root / relative
+        self.written[path] = text
+        if self.dry_run:
+            logger.info("would write: %s (%d bytes)", relative, len(text))
+            return
+        logger.info("writing: %s", relative)
+        path.write_text(text)
+
+    # --- read-only queries -------------------------------------------------
+
+    def current_branch(self) -> str:
+        return self.capture("git", "rev-parse", "--abbrev-ref", "HEAD")
+
+    def submodules(self) -> list[Submodule]:
+        """The submodules declared in .gitmodules, each with the branch it tracks."""
+        raw = self.capture(
+            "git", "config", "-f", ".gitmodules", "--get-regexp", r"^submodule\..*"
+        )
+        values: dict[str, dict[str, str]] = {}
+        for line in raw.splitlines():
+            key, _, value = line.partition(" ")
+            _, name, attribute = key.split(".", 2)
+            values.setdefault(name, {})[attribute] = value
+        modules = []
+        for name, attributes in sorted(values.items()):
+            if "branch" not in attributes:
+                raise ReleaseError(
+                    f"Submodule {name!r} declares no branch in .gitmodules, so the release "
+                    "cannot tell which branch to pin it from."
+                )
+            modules.append(
+                Submodule(
+                    name=name,
+                    path=attributes["path"],
+                    url=attributes["url"],
+                    branch=attributes["branch"],
+                )
+            )
+        return modules
+
+    def tag_exists(self, tag: str) -> bool:
+        if self.capture("git", "tag", "--list", tag):
+            return True
+        return bool(self.capture("git", "ls-remote", "--tags", "origin", tag))
+
+    def remote_head(self, submodule: Submodule) -> str:
+        """The commit at the tip of the branch a submodule tracks, read from its remote."""
+        raw = self.capture(
+            "git", "ls-remote", submodule.url, f"refs/heads/{submodule.branch}"
+        )
+        if not raw:
+            raise ReleaseError(
+                f"{submodule.url} has no branch {submodule.branch!r} to pin {submodule.path} from."
+            )
+        return raw.split()[0]
+
+    def submodule_head(self, submodule: Submodule) -> str:
+        return self.capture("git", "-C", submodule.path, "rev-parse", "HEAD")
+
+
+@dataclass
+class ReleasePlan:
+    current: Version
+    version: Version
+    pinned: dict[str, str]
+    notes: str
+
+
+def update_submodules(repo: Repository) -> dict[str, str]:
+    """Move every submodule to the tip of the branch it tracks; return the pinned commits.
+
+    Under a dry run nothing moves, so the commits are read from the remotes instead — the
+    same commits the real run would land on, barring a push in between.
+    """
+    submodules = repo.submodules()
+    if not submodules:
+        raise ReleaseError("No submodules are declared; there is nothing to pin.")
+    repo.run("git", "submodule", "update", "--init", "--remote")
+    return {
+        module.path: (
+            repo.remote_head(module) if repo.dry_run else repo.submodule_head(module)
+        )
+        for module in submodules
+    }
+
+
+def release(
+    repo: Repository,
+    level: BumpLevel | None = None,
+    explicit: Version | None = None,
+    today: date_type | None = None,
+    publish: bool = True,
+) -> ReleasePlan:
+    """Cut a release from the checkout `repo` points at, and return what it did."""
+    current = read_pyproject_version(repo.read("pyproject.toml"))
+    version = next_version(current, level=level, explicit=explicit)
+    if repo.tag_exists(version.tag):
+        raise ReleaseError(f"{version.tag} already exists locally or on origin.")
+
+    pinned = update_submodules(repo)
+
+    repo.write(
+        "pyproject.toml", write_pyproject_version(repo.read("pyproject.toml"), version)
+    )
+    rolled = changelog.roll(
+        repo.read("CHANGELOG.md"),
+        version,
+        (today or date_type.today()).isoformat(),
+        pinned=pinned,
+    )
+    repo.write("CHANGELOG.md", rolled.text)
+
+    branch = repo.current_branch()
+    repo.run("git", "add", "pyproject.toml", "CHANGELOG.md", *sorted(pinned))
+    repo.run("git", "commit", "-m", f"Release {version.tag}")
+    with _notes_file(repo, version, rolled.notes) as notes_path:
+        repo.run("git", "tag", "-a", version.tag, "-F", str(notes_path))
+        repo.run("git", "push", "origin", branch)
+        repo.run("git", "push", "origin", version.tag)
+        if publish:
+            repo.run(
+                "gh", "release", "create", version.tag,
+                "--title", version.tag,
+                "--notes-file", str(notes_path),
+            )
+
+    return ReleasePlan(current=current, version=version, pinned=pinned, notes=rolled.notes)
+
+
+class _notes_file:
+    """A temporary file holding the release notes, for `git tag -F` and `gh --notes-file`.
+
+    Under a dry run no file is created; the printed commands name where it would have been.
+    """
+
+    def __init__(self, repo: Repository, version: Version, notes: str):
+        self.repo = repo
+        self.body = f"{version.tag}\n\n{notes}\n"
+        self.path: Path | None = None
+
+    def __enter__(self) -> Path:
+        if self.repo.dry_run:
+            return Path(tempfile.gettempdir()) / "release-notes.md"
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix=".md", prefix="release-notes-", delete=False
+        )
+        with handle:
+            handle.write(self.body)
+        self.path = Path(handle.name)
+        return self.path
+
+    def __exit__(self, *exc_info) -> None:
+        if self.path is not None:
+            self.path.unlink(missing_ok=True)

--- a/opensiddur/release/version.py
+++ b/opensiddur/release/version.py
@@ -1,0 +1,90 @@
+"""Version parsing and bumping.
+
+Below 1.0.0 every release bumps the minor version and backwards compatibility is not
+promised. From 1.0.0 on the project follows semantic versioning strictly, so the bump
+level must be chosen deliberately rather than defaulted.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+BumpLevel = Literal["major", "minor", "patch"]
+
+VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+#: `[project] version = "..."` in pyproject.toml. Anchored to the line so that a version
+#: pin inside a dependency specifier cannot match.
+PYPROJECT_VERSION_RE = re.compile(r'^version = "(\d+\.\d+\.\d+)"$', re.MULTILINE)
+
+
+@dataclass(frozen=True, order=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    @property
+    def tag(self) -> str:
+        return f"v{self}"
+
+    @classmethod
+    def parse(cls, text: str) -> "Version":
+        match = VERSION_RE.match(text.strip())
+        if match is None:
+            raise ValueError(f"Not a major.minor.patch version: {text!r}")
+        return cls(*(int(g) for g in match.groups()))
+
+    def bump(self, level: BumpLevel) -> "Version":
+        if level == "major":
+            return Version(self.major + 1, 0, 0)
+        if level == "minor":
+            return Version(self.major, self.minor + 1, 0)
+        if level == "patch":
+            return Version(self.major, self.minor, self.patch + 1)
+        raise ValueError(f"Unknown bump level: {level!r}")
+
+
+def next_version(
+    current: Version,
+    level: BumpLevel | None = None,
+    explicit: Version | None = None,
+) -> Version:
+    """The version to release, given the current one and what the caller asked for.
+
+    With no level and no explicit version, a 0.x series bumps the minor version. At 1.0.0
+    and above there is no safe default: the caller must say which level semver calls for.
+    """
+    if explicit is not None:
+        if level is not None:
+            raise ValueError("Give a bump level or an explicit version, not both.")
+        if explicit <= current:
+            raise ValueError(f"{explicit} is not later than the current version {current}.")
+        return explicit
+    if level is None:
+        if current.major >= 1:
+            raise ValueError(
+                f"The current version is {current}; at 1.0.0 and above the bump level must be "
+                "given explicitly (--major, --minor, or --patch)."
+            )
+        level = "minor"
+    return current.bump(level)
+
+
+def read_pyproject_version(text: str) -> Version:
+    """The project version declared in the text of a pyproject.toml."""
+    match = PYPROJECT_VERSION_RE.search(text)
+    if match is None:
+        raise ValueError("No `version = \"X.Y.Z\"` line found in pyproject.toml.")
+    return Version.parse(match.group(1))
+
+
+def write_pyproject_version(text: str, version: Version) -> str:
+    """The text of a pyproject.toml with its project version replaced. Nothing else moves."""
+    new_text, count = PYPROJECT_VERSION_RE.subn(f'version = "{version}"', text, count=1)
+    if count != 1:
+        raise ValueError("No `version = \"X.Y.Z\"` line found in pyproject.toml.")
+    return new_text

--- a/opensiddur/tests/release/__init__.py
+++ b/opensiddur/tests/release/__init__.py
@@ -1,0 +1,1 @@
+# Test package

--- a/opensiddur/tests/release/test_changelog.py
+++ b/opensiddur/tests/release/test_changelog.py
@@ -1,0 +1,93 @@
+"""Rolling [Unreleased] into a released version section."""
+
+import unittest
+
+from opensiddur.release.changelog import ChangelogError, roll
+from opensiddur.release.version import Version
+
+CHANGELOG = """\
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- A new synthetic feature, for testing.
+
+### Fixed
+- A synthetic bug.
+
+## [0.1.0] - 2026-05-26
+
+Initial public release.
+"""
+
+EMPTY_UNRELEASED = """\
+# Changelog
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-26
+
+Initial public release.
+"""
+
+NO_UNRELEASED = """\
+# Changelog
+
+## [0.1.0] - 2026-05-26
+
+Initial public release.
+"""
+
+
+class TestRoll(unittest.TestCase):
+    def test_entries_move_under_the_new_version(self):
+        rolled = roll(CHANGELOG, Version(0, 2, 0), "2026-08-17")
+        self.assertIn("## [0.2.0] - 2026-08-17", rolled.text)
+        self.assertIn("A new synthetic feature, for testing.", rolled.notes)
+        self.assertIn("A synthetic bug.", rolled.notes)
+
+    def test_new_section_precedes_the_old_release(self):
+        rolled = roll(CHANGELOG, Version(0, 2, 0), "2026-08-17")
+        self.assertLess(
+            rolled.text.index("## [0.2.0]"), rolled.text.index("## [0.1.0]")
+        )
+
+    def test_unreleased_section_is_left_empty(self):
+        rolled = roll(CHANGELOG, Version(0, 2, 0), "2026-08-17")
+        unreleased_start = rolled.text.index("## [Unreleased]")
+        next_start = rolled.text.index("## [0.2.0]")
+        between = rolled.text[unreleased_start + len("## [Unreleased]") : next_start]
+        self.assertEqual(between.strip(), "")
+
+    def test_empty_unreleased_raises(self):
+        with self.assertRaises(ChangelogError):
+            roll(EMPTY_UNRELEASED, Version(0, 2, 0), "2026-08-17")
+
+    def test_missing_unreleased_heading_raises(self):
+        with self.assertRaises(ChangelogError):
+            roll(NO_UNRELEASED, Version(0, 2, 0), "2026-08-17")
+
+    def test_pinned_sources_are_recorded(self):
+        rolled = roll(
+            CHANGELOG,
+            Version(0, 2, 0),
+            "2026-08-17",
+            pinned={
+                "sourcetexts": "abc1234",
+                "opensiddur-projects": "def5678",
+            },
+        )
+        self.assertIn("### Pinned sources", rolled.notes)
+        self.assertIn("`opensiddur-projects`: def5678", rolled.notes)
+        self.assertIn("`sourcetexts`: abc1234", rolled.notes)
+
+    def test_no_pinned_sources_omits_the_section(self):
+        rolled = roll(CHANGELOG, Version(0, 2, 0), "2026-08-17")
+        self.assertNotIn("Pinned sources", rolled.notes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/release/test_release.py
+++ b/opensiddur/tests/release/test_release.py
@@ -1,0 +1,212 @@
+"""End-to-end release orchestration, against synthetic git repositories.
+
+Every fixture repo here is created fresh under a TemporaryDirectory and is never the real
+opensiddur-ai/sourcetexts/opensiddur-projects checkouts, per project convention: tests must
+not depend on real project data.
+"""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from opensiddur.release.release import ReleaseError, Repository, release
+from opensiddur.release.version import Version
+
+# The fixtures use file:// remotes for the synthetic submodules; git's submodule commands
+# refuse those by default (CVE-2022-39253). Allow it for this test process only — the real
+# submodules use ssh:// remotes and are unaffected.
+os.environ.setdefault("GIT_ALLOW_PROTOCOL", "file:git:https:ssh")
+
+PYPROJECT = """\
+[project]
+name = "synthetic-project"
+version = "0.1.0"
+"""
+
+CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+### Added
+- A synthetic feature.
+
+## [0.1.0] - 2026-01-01
+
+Initial release.
+"""
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "-b", "main", cwd=path)
+    _git("config", "user.email", "test@example.com", cwd=path)
+    _git("config", "user.name", "Test", cwd=path)
+    # The fixtures use file:// remotes for the synthetic submodules; git submodule commands
+    # refuse those by default (CVE-2022-39253), so allow it for this sandbox repo only.
+    _git("config", "protocol.file.allow", "always", cwd=path)
+
+
+def _commit_all(path: Path, message: str) -> None:
+    _git("add", "-A", cwd=path)
+    _git("commit", "-q", "-m", message, cwd=path)
+
+
+class ReleaseSandbox:
+    """A synthetic opensiddur-ai checkout with two synthetic submodules, all local git repos."""
+
+    def __init__(self, tmp: Path):
+        self.tmp = tmp
+        self.sub_a_remote = tmp / "remotes" / "sub-a.git"
+        self.sub_b_remote = tmp / "remotes" / "sub-b.git"
+        self.main = tmp / "main"
+
+        for remote, branch in ((self.sub_a_remote, "master"), (self.sub_b_remote, "main")):
+            work = tmp / f"{remote.stem}-work"
+            _init_repo(work)
+            if branch != "main":
+                _git("branch", "-m", branch, cwd=work)
+            (work / "README.md").write_text("synthetic submodule\n")
+            _commit_all(work, "Initial commit")
+            subprocess.run(
+                ["git", "init", "-q", "--bare", "-b", branch, str(remote)],
+                check=True, capture_output=True, text=True,
+            )
+            _git("push", "-q", str(remote), branch, cwd=work)
+
+        _init_repo(self.main)
+        (self.main / "pyproject.toml").write_text(PYPROJECT)
+        (self.main / "CHANGELOG.md").write_text(CHANGELOG)
+        _git(
+            "-c", "protocol.file.allow=always",
+            "submodule", "add", "-b", "master", str(self.sub_a_remote), "sub-a",
+            cwd=self.main,
+        )
+        _git(
+            "-c", "protocol.file.allow=always",
+            "submodule", "add", "-b", "main", str(self.sub_b_remote), "sub-b",
+            cwd=self.main,
+        )
+        _commit_all(self.main, "Initial commit")
+
+        origin = tmp / "remotes" / "main.git"
+        subprocess.run(
+            ["git", "init", "-q", "--bare", "-b", "main", str(origin)],
+            check=True, capture_output=True, text=True,
+        )
+        _git("remote", "add", "origin", str(origin), cwd=self.main)
+        _git("config", "protocol.file.allow", "always", cwd=self.main)
+        _git("push", "-q", "-u", "origin", "main", cwd=self.main)
+
+    def advance_submodule(self, remote: Path, branch: str) -> str:
+        """Push a new commit to a submodule's remote and return its id."""
+        work = self.tmp / f"{remote.stem}-work"
+        (work / "README.md").write_text("an update from upstream\n")
+        _commit_all(work, "An upstream update")
+        _git("push", "-q", str(remote), branch, cwd=work)
+        return subprocess.run(
+            ["git", "rev-parse", branch], cwd=work, check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+    def repository(self, dry_run: bool = False) -> Repository:
+        return Repository(root=self.main, dry_run=dry_run)
+
+
+class TestReleaseDryRun(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.sandbox = ReleaseSandbox(Path(self._tmp.name))
+
+    def test_dry_run_reports_the_bump_but_writes_nothing(self):
+        repo = self.sandbox.repository(dry_run=True)
+        plan = release(repo, publish=False)
+
+        self.assertEqual(plan.current, Version(0, 1, 0))
+        self.assertEqual(plan.version, Version(0, 2, 0))
+        self.assertEqual((self.sandbox.main / "pyproject.toml").read_text(), PYPROJECT)
+        self.assertEqual((self.sandbox.main / "CHANGELOG.md").read_text(), CHANGELOG)
+
+    def test_dry_run_touches_no_remote(self):
+        repo = self.sandbox.repository(dry_run=True)
+        release(repo, publish=False)
+
+        origin = self.sandbox.tmp / "remotes" / "main.git"
+        tags = subprocess.run(
+            ["git", "tag", "--list"], cwd=origin, check=True, capture_output=True, text=True
+        ).stdout
+        self.assertEqual(tags.strip(), "")
+
+    def test_dry_run_records_the_intended_commands_in_order(self):
+        repo = self.sandbox.repository(dry_run=True)
+        release(repo, publish=True)
+
+        commands = [cmd[:2] for cmd in repo.performed]
+        self.assertEqual(
+            commands,
+            [
+                ["git", "submodule"],
+                ["git", "add"],
+                ["git", "commit"],
+                ["git", "tag"],
+                ["git", "push"],
+                ["git", "push"],
+                ["gh", "release"],
+            ],
+        )
+
+    def test_dry_run_pins_the_real_remote_commits(self):
+        new_head = self.sandbox.advance_submodule(self.sandbox.sub_a_remote, "master")
+        repo = self.sandbox.repository(dry_run=True)
+        plan = release(repo, publish=False)
+        self.assertEqual(plan.pinned["sub-a"], new_head)
+
+
+class TestReleaseReal(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.sandbox = ReleaseSandbox(Path(self._tmp.name))
+
+    def test_release_bumps_pins_tags_and_pushes(self):
+        new_head = self.sandbox.advance_submodule(self.sandbox.sub_a_remote, "master")
+        repo = self.sandbox.repository(dry_run=False)
+        plan = release(repo, publish=False)
+
+        self.assertEqual(plan.version, Version(0, 2, 0))
+        self.assertIn('version = "0.2.0"', (self.sandbox.main / "pyproject.toml").read_text())
+
+        changelog = (self.sandbox.main / "CHANGELOG.md").read_text()
+        self.assertIn("## [0.2.0]", changelog)
+        self.assertIn("A synthetic feature.", changelog)
+        self.assertIn(f"`sub-a`: {new_head}", changelog)
+
+        origin = self.sandbox.tmp / "remotes" / "main.git"
+        tags = subprocess.run(
+            ["git", "tag", "--list"], cwd=origin, check=True, capture_output=True, text=True
+        ).stdout
+        self.assertIn("v0.2.0", tags)
+
+        sub_a_pointer = subprocess.run(
+            ["git", "rev-parse", "HEAD:sub-a"],
+            cwd=self.sandbox.main, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        self.assertEqual(sub_a_pointer, new_head)
+
+    def test_refuses_to_reuse_an_existing_tag(self):
+        # Simulate the version the release would compute (0.1.0 -> 0.2.0, the default minor
+        # bump) already having a tag, e.g. from a release that was cut and not cleaned up.
+        _git("tag", "v0.2.0", cwd=self.sandbox.main)
+        repo = self.sandbox.repository(dry_run=False)
+        with self.assertRaisesRegex(ReleaseError, "v0.2.0"):
+            release(repo, publish=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/release/test_version.py
+++ b/opensiddur/tests/release/test_version.py
@@ -1,0 +1,92 @@
+"""Version parsing, the 0.x bump policy, and the pyproject.toml rewrite."""
+
+import unittest
+
+from opensiddur.release.version import (
+    Version,
+    next_version,
+    read_pyproject_version,
+    write_pyproject_version,
+)
+
+PYPROJECT = """\
+[project]
+name = "opensiddur-ai"
+version = "0.1.0"
+description = "A synthetic pyproject for tests"
+dependencies = [
+    "requests>=2.32.4",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["opensiddur"]
+"""
+
+
+class TestVersion(unittest.TestCase):
+    def test_parse_and_str(self):
+        self.assertEqual(Version.parse("1.2.3"), Version(1, 2, 3))
+        self.assertEqual(str(Version(1, 2, 3)), "1.2.3")
+        self.assertEqual(Version(1, 2, 3).tag, "v1.2.3")
+
+    def test_parse_rejects_non_versions(self):
+        for text in ("1.2", "v1.2.3", "1.2.3-rc1", "", "one.two.three"):
+            with self.subTest(text=text), self.assertRaises(ValueError):
+                Version.parse(text)
+
+    def test_ordering(self):
+        self.assertLess(Version(0, 9, 9), Version(1, 0, 0))
+        self.assertLess(Version(0, 1, 0), Version(0, 2, 0))
+
+    def test_bump(self):
+        version = Version(1, 2, 3)
+        self.assertEqual(version.bump("major"), Version(2, 0, 0))
+        self.assertEqual(version.bump("minor"), Version(1, 3, 0))
+        self.assertEqual(version.bump("patch"), Version(1, 2, 4))
+
+
+class TestNextVersion(unittest.TestCase):
+    def test_zero_series_defaults_to_minor(self):
+        self.assertEqual(next_version(Version(0, 1, 0)), Version(0, 2, 0))
+
+    def test_one_and_above_requires_an_explicit_level(self):
+        with self.assertRaises(ValueError):
+            next_version(Version(1, 0, 0))
+        self.assertEqual(next_version(Version(1, 0, 0), level="patch"), Version(1, 0, 1))
+
+    def test_explicit_version(self):
+        self.assertEqual(
+            next_version(Version(0, 1, 0), explicit=Version(1, 0, 0)), Version(1, 0, 0)
+        )
+
+    def test_explicit_version_must_move_forward(self):
+        for explicit in (Version(0, 1, 0), Version(0, 0, 9)):
+            with self.subTest(explicit=explicit), self.assertRaises(ValueError):
+                next_version(Version(0, 1, 0), explicit=explicit)
+
+    def test_level_and_explicit_version_conflict(self):
+        with self.assertRaises(ValueError):
+            next_version(Version(0, 1, 0), level="minor", explicit=Version(0, 5, 0))
+
+
+class TestPyproject(unittest.TestCase):
+    def test_read(self):
+        self.assertEqual(read_pyproject_version(PYPROJECT), Version(0, 1, 0))
+
+    def test_read_without_a_version_raises(self):
+        with self.assertRaises(ValueError):
+            read_pyproject_version('[project]\nname = "opensiddur-ai"\n')
+
+    def test_write_changes_only_the_version_line(self):
+        written = write_pyproject_version(PYPROJECT, Version(0, 2, 0))
+        self.assertEqual(written, PYPROJECT.replace('version = "0.1.0"', 'version = "0.2.0"'))
+
+    def test_write_leaves_dependency_pins_alone(self):
+        text = '[project]\nversion = "0.1.0"\ndependencies = ["requests>=2.32.4"]\n'
+        written = write_pyproject_version(text, Version(0, 2, 0))
+        self.assertIn("requests>=2.32.4", written)
+        self.assertEqual(read_pyproject_version(written), Version(0, 2, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Mount `sourcetexts` (tracking `master`) and `opensiddur-projects` (tracking `main`) as git submodules, so a release tag pins the exact commits of the source and derived-project repositories it was built against.
- Repoint every importer/exporter default path (`SOURCETEXTS_ROOT`, `PROJECT_DIRECTORY`, and the per-importer helpers that used to build their own `<repo>/sources` / `<repo>/project`) at the new submodule locations, and update `.gitignore`, `AGENTS.md`, `README.md`, and the importer READMEs to match. Replace the `CLAUDE.md` symlink with a single-line `@AGENTS.md` include.
- Add `opensiddur/release`, a tested CLI (`uv run python -m opensiddur.release [--major|--minor|--patch|--version X.Y.Z] [--dry-run]`) that bumps the version in `pyproject.toml`, advances both submodules to the tip of their tracked branch, rolls `CHANGELOG.md`'s `[Unreleased]` section into a new version entry (recording the pinned submodule commits), commits, tags, pushes, and publishes a GitHub release via `gh`.
- Add `RELEASE_PROCEDURE.md` documenting the versioning policy (0.x bumps minor; semver from 1.0.0), the preflight checklist, what the CLI does step by step, and how to undo a bad release.

## Test plan
- [x] `bash scripts/build-schema.sh` succeeds
- [x] `uv run coverage run -m unittest discover -s opensiddur/tests -v` — 1443 tests, all pass (12 skipped, same as before — those need a real sourcetexts checkout)
- [x] `opensiddur/tests/release/` (26 tests, entirely against synthetic local git fixtures) — all pass
- [x] `uv run python -m opensiddur.release --dry-run` against the real checkout — correctly reports the `0.1.0 -> 0.2.0` bump and the current submodule tips, writes nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)