### PR TITLE
Add optional auto-generated table of contents to PDF export

### DIFF
--- a/opensiddur/exporter/README.md
+++ b/opensiddur/exporter/README.md
@@ -94,6 +94,9 @@ typography:
   layout: pages                      # "pages" → facing pages; "pairs" → two columns/page
   paper: a4paper                     # any \documentclass paper option
   fontsize: 11pt                     # 10pt | 11pt | 12pt
+  table_of_contents:
+    enabled: false                   # true → print a table of contents page
+    depth: 4                         # 1-4; heading levels shown in the printed TOC
 ```
 
 The `typography` section is read by the PDF/TeX stage only; the linear-XML
@@ -101,6 +104,10 @@ compiler ignores it. Every key is optional — when the section (or any single
 key) is omitted, the defaults shown above are used. Fonts that aren't found
 on the system fall back to a sensible default automatically (`Ezra SIL` →
 `SBL Hebrew` → `FreeSerif` for Hebrew).
+
+`table_of_contents.depth` controls only the printed table of contents; it is
+independent of the PDF bookmark/outline depth, which is always 4 levels deep
+regardless of this setting.
 
 ## Settings file versioning
 Note that this file is likely to change slightly in format as more output

--- a/opensiddur/exporter/settings.py
+++ b/opensiddur/exporter/settings.py
@@ -91,6 +91,16 @@ class PaperType(StrEnum):
     EXECUTIVEPAPER = "executivepaper"
 
 
+class TableOfContentsConfig(BaseModel):
+    """ Auto-generated table of contents (PDF/TeX stage only).
+
+    ``depth`` is independent of the PDF bookmark depth, which is always 4
+    levels deep regardless of this setting.
+    """
+    enabled: bool = False
+    depth: int = Field(default=4, ge=1, le=4)
+
+
 class TypographyConfig(BaseModel):
     """ Output-format settings consumed by the TeX/PDF stage only.
 
@@ -103,6 +113,7 @@ class TypographyConfig(BaseModel):
     layout: ParallelLayout = ParallelLayout.PAIRS
     paper: PaperType = PaperType.LETTERPAPER
     fontsize: str = "11pt"
+    table_of_contents: TableOfContentsConfig = Field(default_factory=TableOfContentsConfig)
 
 
 class SettingsYaml(BaseModel):

--- a/opensiddur/exporter/tex/latex.py
+++ b/opensiddur/exporter/tex/latex.py
@@ -388,6 +388,8 @@ def transform_xml_to_tex(
                 "layout": typography.layout.value,
                     "paper": typography.paper.value,
                 "fontsize": typography.fontsize,
+                "table-of-contents": typography.table_of_contents.enabled,
+                "table-of-contents-depth": typography.table_of_contents.depth,
             },
         )
 

--- a/opensiddur/exporter/tex/reledmac.xslt
+++ b/opensiddur/exporter/tex/reledmac.xslt
@@ -47,6 +47,12 @@
     <xsl:param name="paper" as="xs:string">a4paper</xsl:param>
     <xsl:param name="fontsize" as="xs:string">11pt</xsl:param>
 
+    <!-- Auto-generated table of contents (driven by settings.yaml
+         `typography.table_of_contents`). Depth is independent of the PDF
+         bookmark depth below, which is always 4 levels deep. -->
+    <xsl:param name="table-of-contents" as="xs:boolean" select="false()"/>
+    <xsl:param name="table-of-contents-depth" as="xs:integer" select="4"/>
+
     <!-- How many parallel blocks one \Pages/\Columns typesets at a time. reledpar holds
          every chunk of a group in memory as a pair of boxes and refuses more than
          \maxchunks (5120) of them, so a whole humash — ~49000 blocks — cannot be one
@@ -330,11 +336,20 @@
 
     <xsl:template match="tei:text">
         <!-- \frontmatter/\mainmatter are book-class page-numbering switches (roman for the
-             front matter, restarting at arabic for the body). Emit them only when there is
-             front matter to number, so a document without one is unaffected. -->
-        <xsl:if test="tei:front">
+             front matter, restarting at arabic for the body). Emit them when there is front
+             matter to number, or when a table of contents needs the roman-numeral front-matter
+             pagination, so a document without either is unaffected. -->
+        <xsl:variable name="needs-frontmatter" select="exists(tei:front) or $table-of-contents"/>
+        <xsl:if test="$needs-frontmatter">
             <xsl:text>\frontmatter&#10;</xsl:text>
             <xsl:apply-templates select="tei:front"/>
+            <xsl:if test="$table-of-contents">
+                <!-- Scoped in a TeX group so tocdepth reverts afterward and does not affect
+                     \hypersetup{bookmarksdepth=4} or the global tocdepth set in the preamble. -->
+                <xsl:text>{\setcounter{tocdepth}{</xsl:text>
+                <xsl:value-of select="$table-of-contents-depth"/>
+                <xsl:text>}\tableofcontents}&#10;</xsl:text>
+            </xsl:if>
             <xsl:text>\mainmatter&#10;</xsl:text>
         </xsl:if>
         <xsl:apply-templates select="tei:body"/>

--- a/opensiddur/tests/exporter/test_latex.py
+++ b/opensiddur/tests/exporter/test_latex.py
@@ -417,6 +417,9 @@ typography:
   layout: pairs
   paper: letterpaper
   fontsize: 12pt
+  table_of_contents:
+    enabled: true
+    depth: 2
 """
         )
         cfg = load_typography(settings_path)
@@ -425,6 +428,13 @@ typography:
         self.assertEqual(cfg.layout, ParallelLayout.PAIRS)
         self.assertEqual(cfg.paper, PaperType.LETTERPAPER)
         self.assertEqual(cfg.fontsize, "12pt")
+        self.assertTrue(cfg.table_of_contents.enabled)
+        self.assertEqual(cfg.table_of_contents.depth, 2)
+
+    def test_table_of_contents_defaults_to_disabled(self):
+        cfg = TypographyConfig()
+        self.assertFalse(cfg.table_of_contents.enabled)
+        self.assertEqual(cfg.table_of_contents.depth, 4)
 
     def test_defaults_when_typography_section_missing(self):
         settings_path = self.test_dir / "settings.yaml"
@@ -533,6 +543,20 @@ class TestTransformXmlToTex(unittest.TestCase):
             out = transform_xml_to_tex(f, typography=typography)
         self.assertIn(r"\begin{pairs}", out)
         self.assertIn(r"\Columns", out)
+
+    def test_table_of_contents_setting_is_threaded_into_xslt_params(self):
+        xml = b"""<?xml version="1.0"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body><tei:p>x</tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        f = self._create("p", "input.xml", xml)
+        typography = TypographyConfig(
+            table_of_contents={"enabled": True, "depth": 2}
+        )
+        with patch.object(latex_module, "projects_source_root", self.test_dir):
+            out = transform_xml_to_tex(f, typography=typography)
+        self.assertIn(r"\tableofcontents", out)
+        self.assertIn(r"\setcounter{tocdepth}{2}", out)
 
     def test_integrates_licenses_into_postamble(self):
         xml = b"""<?xml version="1.0"?>

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -1204,6 +1204,70 @@ class TestFrontMatter(unittest.TestCase):
         self.assertNotIn("Stray", body)
 
 
+class TestTableOfContents(unittest.TestCase):
+    """``table-of-contents`` optionally prints a TOC page (\\tableofcontents), reusing the
+    \\addcontentsline entries the heading template already writes for PDF bookmarks."""
+
+    NESTED_HEADS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+    <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en">
+      <tei:text><tei:body>
+        <tei:div><tei:head>Section One</tei:head>
+          <tei:div><tei:head>Subsection</tei:head><tei:p>Hi</tei:p></tei:div>
+        </tei:div>
+      </tei:body></tei:text>
+    </tei:TEI>"""
+
+    def test_table_of_contents_omitted_by_default(self):
+        out = _transform(self.NESTED_HEADS_XML)
+        self.assertNotIn(r"\tableofcontents", out)
+
+    def test_table_of_contents_printed_when_enabled(self):
+        out = _transform(self.NESTED_HEADS_XML, **{"table-of-contents": True})
+        self.assertIn(r"\tableofcontents", out)
+
+    def test_table_of_contents_comes_after_frontmatter_and_before_mainmatter(self):
+        out = _transform(self.NESTED_HEADS_XML, **{"table-of-contents": True})
+        self.assertLess(out.index(r"\frontmatter"), out.index(r"\tableofcontents"))
+        self.assertLess(out.index(r"\tableofcontents"), out.index(r"\mainmatter"))
+
+    def test_addcontentsline_entries_still_present_when_enabled(self):
+        """The TOC page must not replace the existing bookmark plumbing."""
+        out = _transform(self.NESTED_HEADS_XML, **{"table-of-contents": True})
+        self.assertIn(r"\addcontentsline{toc}{section}", out)
+        self.assertIn(r"\addcontentsline{toc}{subsection}", out)
+
+    def test_frontmatter_emitted_even_without_tei_front(self):
+        """A document with no tei:front still needs \\frontmatter/\\mainmatter so the TOC
+        gets roman-numeral front-matter pagination."""
+        out = _transform(self.NESTED_HEADS_XML, **{"table-of-contents": True})
+        self.assertIn(r"\frontmatter", out)
+        self.assertIn(r"\mainmatter", out)
+
+    def test_document_without_table_of_contents_has_no_frontmatter_switch(self):
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en">
+          <tei:text><tei:body><tei:p>In the beginning.</tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml)
+        self.assertNotIn(r"\frontmatter", out)
+        self.assertNotIn(r"\mainmatter", out)
+
+    def test_table_of_contents_depth_is_scoped_locally(self):
+        """A custom depth must not leak into the global tocdepth that drives bookmarks."""
+        out = _transform(
+            self.NESTED_HEADS_XML,
+            **{"table-of-contents": True, "table-of-contents-depth": 2},
+        )
+        self.assertIn(r"{\setcounter{tocdepth}{2}\tableofcontents}", out)
+        # The preamble's global tocdepth (drives bookmarksdepth) is unaffected.
+        self.assertIn(r"\setcounter{tocdepth}{4}", out)
+        self.assertIn("bookmarksdepth=4", out)
+
+    def test_table_of_contents_depth_defaults_to_four(self):
+        out = _transform(self.NESTED_HEADS_XML, **{"table-of-contents": True})
+        self.assertIn(r"{\setcounter{tocdepth}{4}\tableofcontents}", out)
+
+
 class TestParshaMilestones(unittest.TestCase):
     """A parsha is a division containing the chapters and verses that follow it, so its
     milestone legitimately sits between paragraphs rather than inside one. It used to be

--- a/uv.lock
+++ b/uv.lock
@@ -283,7 +283,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1893,7 +1893,7 @@ wheels = [
 
 [[package]]
 name = "opensiddur-ai"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
- Adds `typography.table_of_contents` (`enabled`, `depth`) to `settings.yaml`, following the existing typography-option convention.
- When enabled, `reledmac.xslt` emits `\tableofcontents` (scoped to the configured `depth`), reusing the `\addcontentsline` entries the heading template already writes for PDF bookmarks — no change to the underlying bookmark/outline depth (always 4 levels).
- Documents the new setting in `opensiddur/exporter/README.md`.

Fixes #69

## Test plan
- [x] `uv run pytest opensiddur/tests` — 1448 passed, 12 skipped, no regressions
- [x] New XSLT tests in `test_reledmac_xslt.py::TestTableOfContents` (default off, enabled, depth scoping, frontmatter/mainmatter handling)
- [x] New/extended tests in `test_latex.py` (settings YAML round-trip, `xslt_params` forwarding)
- [x] Manual end-to-end: compiled `original-example` project → TeX → PDF via LuaLaTeX with `table_of_contents.enabled: true, depth: 2`; confirmed the printed TOC page lists only the top 2 heading levels while PDF bookmarks remain full depth, and that the default (disabled) output is byte-identical to prior behavior (no `\tableofcontents`/`\frontmatter`/`\mainmatter` emitted for a doc with no front matter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)