### PR TITLE
Sub-verse URNs: address a point inside a verse (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Sub-verse URNs. A URN reached no further than a whole verse, so a reading that begins or ends
+  inside one could not be said: Emor's third-year haftarah is Nachum 2:2b–3a, the Thirteen
+  Attributes open partway through Exodus 34:6, and kiddush opens on the last words of Genesis
+  1:31. Two milestone units now divide a verse, each hanging its URN one path component below
+  the verse's, so no URN grammar changes: `half-verse` (`…/1/31/a`, `…/1/31/b`), the accentual
+  division at the etnachta, placed mechanically on every verse the accents divide; and
+  `verse-part` (`…/34/6/adonai_adonai`), any other break at a word boundary, named by its
+  transliterated incipit and declared in `opensiddur/common/subverse.py`. See JLPTEI-3.md,
+  "Sub-verse scope", for what the two cover and what they deliberately do not.
+- Ranges may state their end absolutely: an end beginning with `/` replaces the whole path below
+  the work, so `…:nahum/2/2/b-/2/5` runs from a half-verse to the end of a whole one. The
+  relative form always lands at the start's own depth and cannot express that.
+- `validate_urn_references` reports references that resolve only after a division is dropped
+  from the end of them, so that reading a whole verse where half was asked for is never silent.
+
+### Fixed
+- A range whose relative end was deeper than the start it replaced — `…:nahum/2/2-2/3/a` —
+  silently built a URN with the scheme sliced off it, which then resolved to nothing. It is now
+  rejected, with the absolute spelling named in the message.
+- Parallel alignment joined on exact URN equality, so an edition that divided the text more
+  finely than the one beside it put its subdivisions in rows facing empty cells. Rows are now
+  formed at the divisions both sides carry.
+
 ## [0.2.0] - 2026-08-17
 
 ### Added

--- a/opensiddur/common/subverse.py
+++ b/opensiddur/common/subverse.py
@@ -1,0 +1,555 @@
+"""Sub-verse milestones: the accentual half-verse, and named parts of a verse.
+
+A URN reaches no further than a whole verse unless something inside the verse carries one.
+Two milestone units divide a verse, and both hang a URN one component below the verse's:
+
+``half-verse``
+    The accentual division, at the etnachta. `a` runs from the start of the verse to the
+    accent, `b` from there to the end. Derived from the text itself, so it can be placed
+    everywhere without anyone declaring anything.
+
+``verse-part``
+    A break the accents do not make — the Thirteen Attributes open at the second יהוה of
+    Exodus 34:6, three words before its etnachta, and close one word past the etnachta of
+    34:7. These cannot be derived, so they are declared in `VERSE_PARTS` and named by their
+    transliterated incipit, the same way JLPTEI-3.md already names divisions of a poem.
+
+The two divisions cut at different points and are separate unit-spaces: neither ends the
+other's scope (see `UNIT_CONTAINED_BY` in opensiddur/exporter/refdb.py).
+
+Both are inserted by a pass over converted TEI rather than by each importer's XSLT, because
+Miqra al pi ha-Masorah and the WLC emit the same shape by the time they are TEI — running
+text with inline elements in it — while their sources do not resemble each other at all.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+TEI_NS = "http://www.tei-c.org/ns/1.0"
+JLPTEI_NS = "http://jewishliturgy.org/ns/jlptei/2"
+
+#: U+0591 HEBREW ACCENT ETNAHTA, the main disjunctive of the twenty-one books: the accent
+#: that divides a verse in two, and the point a citation means by "2:2b".
+ETNAHTA = "֑"
+
+#: U+05AB HEBREW ACCENT OLE. In Psalms, Proverbs and Job the primary division of a verse may
+#: fall at ole-we-yored rather than at the etnachta, in which case the etnachta divides only
+#: the second part. Rather than guess which of the two governs, verses carrying ole are left
+#: undivided — see `_half_verse_boundary`.
+OLE = "֫"
+
+#: The three books read with the poetic accents.
+POETIC_BOOKS = frozenset({"psalms", "proverbs", "job"})
+
+#: U+05BE HEBREW PUNCTUATION MAQAF joins words into one accentual unit. It separates words
+#: for the purpose of *matching* an incipit, but it is not a place a milestone may go: the
+#: words it joins are read as one, and a break inside one is not expressible here.
+MAQAF = "־"
+
+#: U+05C0 HEBREW PUNCTUATION PASEQ separates. Miqra al pi ha-Masorah sets it tight against
+#: the words on either side and the WLC sets it with spaces, so it has to be a token
+#: separator in its own right or the two editions would tokenize differently.
+PASEQ = "׀"
+
+#: Milestone units that close a verse's scope, and so bound the text a sub-verse milestone
+#: may be placed in. This is the containment table of opensiddur/exporter/refdb.py, reduced
+#: to the two units that matter in a Tanakh file; the importers must not depend on the
+#: exporter.
+_VERSE_TERMINATING_UNITS = frozenset({"verse", "chapter"})
+
+
+class UnplaceableVersePartError(ValueError):
+    """A verse part that `VERSE_PARTS` declares could not be put anywhere in the text."""
+
+
+@dataclass(frozen=True)
+class Unplaceable:
+    """A sub-verse boundary that was asked for and could not be put anywhere."""
+
+    urn: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.urn}: {self.reason}"
+
+
+#: Verse parts that liturgy needs and the accents do not give, by (book, chapter, verse).
+#:
+#: Each part is a name — used as the last component of its URN, so it may not contain '-',
+#: which marks a range — and the incipit that locates it, per language. The incipit is
+#: matched on consonants alone, so it is not disturbed by an edition's vowels or accents,
+#: and it must begin at a word boundary. A language a verse declares nothing for simply gets
+#: no parts, which is how translations carry none.
+#:
+#: A part's scope runs to the next sub-verse milestone or to the end of the verse, so a
+#: passage that stops in the middle of a verse needs a part declared at the point the
+#: *remainder* begins as well: `lo_yenakeh` exists to end `venakeh`.
+VERSE_PARTS: dict[tuple[str, int, int], tuple[tuple[str, dict[str, str]], ...]] = {
+    # Kiddush opens on the last two words of the sixth day rather than on the half-verse,
+    # so that it does not begin with "and there was evening".
+    ("genesis", 1, 31): (
+        ("yom_hashishi", {"he": "יום הששי"}),
+    ),
+    # The Thirteen Attributes. They begin at the second יהוה — the first belongs to
+    # "and the LORD passed by before him and proclaimed" — and end at ונקה, since
+    # "he will by no means clear the guilty" is not among the attributes recited.
+    ("exodus", 34, 6): (
+        ("adonai_adonai", {"he": "יהוה יהוה אל"}),
+    ),
+    ("exodus", 34, 7): (
+        ("venakeh", {"he": "ונקה"}),
+        ("lo_yenakeh", {"he": "לא ינקה"}),
+    ),
+}
+
+
+def add_subverse_milestones(xml: str, *, language: str, project: str = "") -> str:
+    """`xml` with both kinds of sub-verse milestone added to every verse that can take one.
+
+    This is what an importer calls. It is applied to already-serialised TEI rather than
+    written into each importer's XSLT because the two Hebrew editions produce the same shape
+    once they are TEI — running text with elements through it — and nothing alike before
+    that.
+
+    It works on the text rather than on a parsed tree, and splices the milestones in, so that
+    a file comes back byte-for-byte as it went in apart from what was added. Re-serialising
+    instead would rewrite every file the WLC importer produces: Saxon sets each attribute on
+    its own line and lxml does not, so a regeneration would bury the milestones in a whole-
+    project reformat.
+
+    Raises:
+        UnplaceableVersePartError: if a part `VERSE_PARTS` declares for `language` is not
+            where it says it is. A part that quietly failed to appear would leave its URN
+            resolving to the whole verse, silently reading more than was asked for, which is
+            the failure this whole mechanism exists to prevent. The halves are not checked
+            this way: no one declares them individually, and a verse the accents do not
+            divide simply has no halves.
+    """
+    xml, _ = insert_half_verses(xml, project=project)
+    xml, unplaceable = insert_verse_parts(xml, language=language, project=project)
+    if unplaceable:
+        raise UnplaceableVersePartError(
+            f"{project or 'project'}: declared verse parts not found in the text: "
+            + "; ".join(str(item) for item in unplaceable)
+        )
+
+    return xml
+
+
+def add_subverse_milestones_to_file(path, *, language: str, project: str = "") -> None:
+    """`add_subverse_milestones`, applied to a file in place."""
+    path = Path(path)
+    path.write_text(
+        add_subverse_milestones(
+            path.read_text(encoding="utf-8"), language=language, project=project
+        ),
+        encoding="utf-8",
+    )
+
+
+def _consonants(text: str) -> str:
+    """`text` reduced to its Hebrew consonants, dropping vowels, accents and punctuation.
+
+    Comparing on consonants lets one declared incipit match every edition: the WLC and
+    Miqra al pi ha-Masorah differ in vowels and accents constantly, and in the spelling of
+    the divine name.
+    """
+    return "".join(c for c in unicodedata.normalize("NFD", text) if "א" <= c <= "ת")
+
+
+# One item of XML markup, or the run of character data between two of them. Attribute values
+# may legally contain '>', so the tag pattern steps over quoted values rather than stopping at
+# the first '>'.
+_MARKUP = re.compile(
+    r"""
+      <!--.*?-->
+    | <\?.*?\?>
+    | <!\[CDATA\[.*?\]\]>
+    | <!DOCTYPE(?:[^<>\[]|\[.*?\])*>
+    | <(?P<close>/?)(?P<name>[^\s/>]+)(?P<attrs>(?:"[^"]*"|'[^']*'|[^>"'])*)(?P<empty>/?)>
+    """,
+    re.S | re.X,
+)
+
+_ATTRIBUTE = re.compile(r"""([\w:.-]+)\s*=\s*("([^"]*)"|'([^']*)')""")
+
+# The scanner works on source text, so it matches elements by the prefixed names both
+# importers write. TEI_NS and JLPTEI_NS below are the namespaces those prefixes are bound to.
+_CHOICE_TAG = "tei:choice"
+_READ_TAG = "j:read"
+_OPTION_TAG = "j:option"
+_VERSE_MILESTONE_UNITS = _VERSE_TERMINATING_UNITS
+
+
+def _attributes(attrs: str) -> dict[str, str]:
+    return {m.group(1): m.group(3) if m.group(3) is not None else m.group(4)
+            for m in _ATTRIBUTE.finditer(attrs)}
+
+
+@dataclass
+class _Run:
+    """One run of character data in the source, and where it came from."""
+
+    source: int      # offset of this run in the source text
+    offset: int      # offset of this run within the verse's assembled text
+    text: str
+    # Where a boundary at this run's very start must go instead, when the run sits inside an
+    # element that may not be split: the offset of that element's start tag. None otherwise.
+    before: int | None = None
+    splittable: bool = True
+
+
+class _VerseText:
+    """A verse's running text, assembled from the source, with a map back into it.
+
+    The text of one verse is broken over elements — Miqra al pi ha-Masorah splits words, as in
+    ``<tei:hi rend="large">נֹ</tei:hi>צֵר``, and drops anchors between them — and a verse may
+    run across a paragraph boundary where a parashah break falls inside it. So it is read as
+    one string and written back through the offsets each run came from.
+    """
+
+    def __init__(self, urn: str, opens_at: int, runs: list[_Run]):
+        self.urn = urn
+        self.opens_at = opens_at  # source offset just after the verse milestone
+        self.runs = runs
+        self.text = "".join(run.text for run in runs)
+        self.has_variant_reading = False
+
+    def tokens(self) -> list[tuple[int, str]]:
+        """(offset, token) for each whitespace/paseq-delimited token, in reading order."""
+        return [(m.start(), m.group()) for m in re.finditer(f"[^\\s{PASEQ}]+", self.text)]
+
+    def source_offset(self, offset: int) -> int:
+        """Where in the source a boundary at `offset` in the verse's text goes.
+
+        Raises:
+            ValueError: if the boundary falls somewhere no milestone may be placed.
+        """
+        run = self.runs[0] if self.runs else None
+        for candidate in self.runs:
+            if candidate.offset <= offset:
+                run = candidate
+            else:
+                break
+        if run is None:
+            raise ValueError("the verse has no text to divide")
+
+        local = offset - run.offset
+        if run.splittable:
+            return run.source + local
+        if local == 0 and run.before is not None:
+            # The point just before the element is the same point, and it is always available:
+            # a ketiv/qere at the head of the second half of a verse arrives here.
+            return run.before
+        raise ValueError(
+            "the boundary falls inside a choice, which is a single word or a single reading"
+        )
+
+
+def _choice_extent(xml: str, choice_start: int, after_open_tag: int) -> tuple[int, int, int]:
+    """(end of the choice, start of its read text, end of its read text).
+
+    A ketiv and a qere are two readings of one word, not two words: taking both would put the
+    unpointed ketiv into the running text beside the qere, doubling the word and — since only
+    the qere carries the accents — moving every boundary measured after it. The qere is what
+    is read. A variant (`j:option`) has no one reading, so the first stands in; a verse that
+    contains one is not divided at all (`_has_variant_reading`).
+    """
+    depth = 1
+    keep: tuple[int, int] | None = None
+    open_at: dict[str, int] = {}
+    position = after_open_tag
+
+    for match in _MARKUP.finditer(xml, after_open_tag):
+        name = match.group("name")
+        if name is None:  # comment, PI, CDATA
+            continue
+        if match.group("empty"):
+            continue
+        if not match.group("close"):
+            depth += 1
+            if keep is None and name in (_READ_TAG, _OPTION_TAG):
+                open_at[name] = match.end()
+        else:
+            depth -= 1
+            if depth == 0:
+                position = match.start()
+                break
+            if keep is None and name in open_at:
+                keep = (open_at[name], match.start())
+                if name == _READ_TAG:
+                    break
+
+    end = position
+    for match in _MARKUP.finditer(xml, position):
+        if match.group("name") == _CHOICE_TAG and match.group("close"):
+            end = match.end()
+            break
+
+    if keep is None:
+        keep = (after_open_tag, position)
+    return end, keep[0], keep[1]
+
+
+def _verses(xml: str) -> list[_VerseText]:
+    """Every verse in the document, with the text that belongs to it.
+
+    A verse runs from its milestone to the next milestone that closes it — the next verse, or
+    the next chapter. Only the milestones inside `tei:text` count: a header may quote a verse,
+    and quoting one is not carrying it.
+    """
+    verses: list[_VerseText] = []
+    current: _VerseText | None = None
+    runs: list[_Run] = []
+    urn = ""
+    opens_at = 0
+    length = 0
+    in_text = False
+    variant = False
+    skip_until = 0
+    choice: tuple[int, int, int] | None = None  # (choice start, keep start, keep end)
+    position = 0
+
+    def close():
+        nonlocal current, runs, length, variant
+        if urn:
+            verse = _VerseText(urn, opens_at, runs)
+            verse.has_variant_reading = variant
+            verses.append(verse)
+        runs, length, variant = [], 0, False
+
+    for match in _MARKUP.finditer(xml):
+        data_start, data_end = position, match.start()
+        position = match.end()
+
+        if urn and data_end > data_start:
+            text = xml[data_start:data_end]
+            keep = True
+            before = None
+            splittable = True
+            if choice is not None:
+                choice_start, keep_start, keep_end = choice
+                keep = keep_start <= data_start < keep_end
+                splittable = False
+                before = choice_start if not runs or runs[-1].source < choice_start else None
+            if keep:
+                runs.append(_Run(source=data_start, offset=length, text=text,
+                                 before=before, splittable=splittable))
+                length += len(text)
+
+        name = match.group("name")
+        if name is None:
+            continue
+
+        if not match.group("close") and not match.group("empty"):
+            if name == "tei:text":
+                in_text = True
+            elif name == _CHOICE_TAG and choice is None:
+                end, keep_start, keep_end = _choice_extent(xml, match.start(), match.end())
+                choice = (match.start(), keep_start, keep_end)
+                skip_until = end
+                if _OPTION_TAG in xml[match.end():end]:
+                    variant = True
+        elif match.group("close") and name == _CHOICE_TAG:
+            choice = None
+
+        if choice is not None and position >= skip_until:
+            choice = None
+
+        if not in_text or name != "tei:milestone":
+            continue
+
+        attributes = _attributes(match.group("attrs") or "")
+        unit = attributes.get("unit")
+        if unit not in _VERSE_MILESTONE_UNITS:
+            continue
+        close()
+        if unit == "verse" and attributes.get("corresp"):
+            urn, opens_at = attributes["corresp"], match.end()
+        else:
+            urn = ""
+
+    if urn:
+        data = xml[position:]
+        if data:
+            runs.append(_Run(source=position, offset=length, text=data))
+        close()
+
+    return verses
+
+
+def _has_variant_reading(verse: _VerseText) -> bool:
+    """Whether the verse's text depends on which variant a setting selects."""
+    return verse.has_variant_reading
+
+
+def _milestone_xml(unit: str, n: str, corresp: str) -> str:
+    return f'<tei:milestone unit="{unit}" n="{n}" corresp="{corresp}"/>'
+
+
+def _splice(xml: str, insertions: list[tuple[int, str]]) -> str:
+    """`xml` with each string put at its offset, leaving everything else exactly as it was.
+
+    Applied from the end backwards so that earlier offsets stay valid, and stably within one
+    offset so that two milestones at the same point keep the order they were added in.
+    """
+    result = xml
+    for source, text in sorted(insertions, key=lambda item: item[0], reverse=True):
+        result = result[:source] + text + result[source:]
+    return result
+
+
+def _verse_urn_parts(corresp: str) -> tuple[str, int, int] | None:
+    """(book, chapter, verse) from a verse milestone's URN, or None if it is not one."""
+    match = re.fullmatch(r"urn:x-opensiddur:text:bible:([^/]+)/(\d+)/(\d+)", corresp or "")
+    if match is None:
+        return None
+    return match.group(1), int(match.group(2)), int(match.group(3))
+
+
+def _half_verse_boundary(verse: _VerseText, book: str) -> int | None:
+    """The offset the second half of the verse begins at, or None if it has no halves.
+
+    The boundary is the start of the word after the one carrying the etnachta, so the
+    accent stays with the half it closes.
+    """
+    if _has_variant_reading(verse):
+        # The two cantillations of the Decalogue put the etnachta in different places —
+        # under ta'am elyon Exodus 20:2 divides after אלהיך, under ta'am tachton after
+        # עבדים — so the verse has no one accentual division. A URN must denote the same
+        # words wherever it is resolved, so it gets no halves rather than ambiguous ones.
+        return None
+
+    tokens = verse.tokens()
+    accented = [i for i, (_, token) in enumerate(tokens) if ETNAHTA in token]
+    if not accented:
+        return None
+    if book in POETIC_BOOKS and OLE in verse.text:
+        # Ole-we-yored outranks the etnachta where it occurs, so in these verses the
+        # etnachta is not the primary division and dividing there would misname the halves.
+        return None
+    index = accented[0]
+    if index + 1 >= len(tokens):
+        return None  # nothing after the accent, so there is no second half
+    return tokens[index + 1][0]
+
+
+def insert_half_verses(xml: str, *, project: str = "") -> tuple[str, list[Unplaceable]]:
+    """`xml` with a `half-verse` milestone at the etnachta of every verse that has one.
+
+    A verse with no etnachta, or one whose primary division the accents leave ambiguous,
+    simply gets none: the halves are an addition to what a verse already says, so their
+    absence costs nothing but the ability to address them.
+
+    Returns:
+        The new text, and the verses whose accentual boundary could not be expressed. The
+        latter is not an error — no one asked for these individually — but is worth logging.
+    """
+    unplaceable: list[Unplaceable] = []
+    insertions: list[tuple[int, str]] = []
+
+    for verse in _verses(xml):
+        parts = _verse_urn_parts(verse.urn)
+        if parts is None:
+            continue
+        book, _chapter, _verse = parts
+
+        boundary = _half_verse_boundary(verse, book)
+        if boundary is None:
+            continue
+
+        try:
+            source = verse.source_offset(boundary)
+        except ValueError as error:
+            unplaceable.append(Unplaceable(urn=f"{verse.urn}/b", reason=str(error)))
+            continue
+
+        insertions.append((verse.opens_at, _milestone_xml("half-verse", "a", f"{verse.urn}/a")))
+        insertions.append((source, _milestone_xml("half-verse", "b", f"{verse.urn}/b")))
+
+    logger.info(
+        "%s: divided %d verses at the etnachta%s", project or "sub-verse",
+        len(insertions) // 2,
+        f", {len(unplaceable)} not expressible" if unplaceable else "",
+    )
+    return _splice(xml, insertions), unplaceable
+
+
+def insert_verse_parts(
+    xml: str, *, language: str, project: str = "",
+) -> tuple[str, list[Unplaceable]]:
+    """`xml` with the `verse-part` milestones `VERSE_PARTS` declares for `language`.
+
+    Unlike the halves, every one of these was asked for by name. A declared part that cannot
+    be placed is returned for the caller to fail on: a part that is silently absent is a URN
+    that silently resolves to the whole verse, which is the over-reading this whole mechanism
+    exists to stop.
+    """
+    unplaceable: list[Unplaceable] = []
+    insertions: list[tuple[int, str]] = []
+
+    for verse in _verses(xml):
+        key = _verse_urn_parts(verse.urn)
+        if key is None or key not in VERSE_PARTS:
+            continue
+
+        declared = [
+            (name, incipits[language])
+            for name, incipits in VERSE_PARTS[key]
+            if language in incipits
+        ]
+
+        for name, incipit in declared:
+            offset = _incipit_offset(verse, incipit)
+            if offset is None:
+                unplaceable.append(Unplaceable(
+                    urn=f"{verse.urn}/{name}",
+                    reason=f"no word boundary in the verse begins {incipit!r}",
+                ))
+                continue
+            try:
+                source = verse.source_offset(offset)
+            except ValueError as error:
+                unplaceable.append(Unplaceable(urn=f"{verse.urn}/{name}", reason=str(error)))
+                continue
+            insertions.append((source, _milestone_xml("verse-part", name, f"{verse.urn}/{name}")))
+
+    logger.info("%s: placed %d declared verse parts", project or "sub-verse", len(insertions))
+    return _splice(xml, insertions), unplaceable
+
+
+def _incipit_offset(verse: _VerseText, incipit: str) -> int | None:
+    """Where `incipit` begins in the verse, or None if no word boundary begins it.
+
+    Matching runs over consonants, and over words rather than tokens, so that a maqqef
+    inside the incipit or inside the text does not defeat it. The match must begin at the
+    start of a token: the words a maqqef joins are read as one and a milestone may not be
+    put between them.
+    """
+    wanted = [_consonants(word) for word in incipit.split() if _consonants(word)]
+    if not wanted:
+        return None
+
+    # (offset, consonants, starts_a_token) for every word in the verse.
+    words: list[tuple[int, str, bool]] = []
+    for token_offset, token in verse.tokens():
+        offset = token_offset
+        for index, piece in enumerate(token.split(MAQAF)):
+            consonants = _consonants(piece)
+            if consonants:
+                words.append((offset, consonants, index == 0))
+            offset += len(piece) + len(MAQAF)
+
+    for start in range(len(words) - len(wanted) + 1):
+        if not words[start][2]:
+            continue  # the incipit would begin inside a maqqef-joined unit
+        if all(words[start + i][1] == wanted[i] for i in range(len(wanted))):
+            return words[start][0]
+    return None

--- a/opensiddur/exporter/compiler.py
+++ b/opensiddur/exporter/compiler.py
@@ -18,6 +18,7 @@ import argparse
 from contextlib import contextmanager
 from enum import Enum
 import hashlib
+import logging
 from pathlib import Path
 import re
 import sys
@@ -49,8 +50,10 @@ from opensiddur.exporter.condition_eval import (
     parse_condition_element,
 )
 from opensiddur.exporter.refdb import ReferenceDatabase
-from opensiddur.exporter.urn import ResolvedUrnRange, UrnResolver
+from opensiddur.exporter.urn import ResolvedUrnRange, UrnResolver, coarsen
 from opensiddur.common.constants import PROJECT_DIRECTORY
+
+logger = logging.getLogger(__name__)
 
 class _ProcessingCommand(Enum):
     """ Possible ways the compiler can process an element """
@@ -522,15 +525,34 @@ class CompilerProcessor:
         start, end = None, None
         resolver = self._urn_resolver
         
-        range_start = resolver.resolve_range(target)
-        if not range_start:
-            raise ValueError(f"Target URN {target=} not found")
         project_priority = self.linear_data.project_priority
-        
-        range_start = UrnResolver.prioritize_range(range_start, project_priority)
+
+        resolved = resolver.resolve_range(target)
+        range_start = UrnResolver.prioritize_range(resolved, project_priority)
         if not range_start:
-            raise ValueError(f"No prioritized URNs found: {target=} {project_priority=}")
-        
+            # No prioritized project carries this reference. If it names a point below a
+            # division they all do carry — a half-verse, a named part of a verse — take the
+            # division that contains it instead. The compiled text then covers more than was
+            # asked for, which is what happened before sub-verse URNs existed; the warning
+            # is what is new, and validate_urn_references reports the same thing ahead of a
+            # build.
+            coarser = coarsen(target)
+            coarsened = (
+                UrnResolver.prioritize_range(resolver.resolve_range(coarser), project_priority)
+                if coarser else None
+            )
+            if coarsened:
+                logger.warning(
+                    "%s/%s: no project in %s carries %s; falling back to %s, which covers "
+                    "more text than the reference asks for",
+                    self.project, self.file_name, project_priority, target, coarser,
+                )
+                range_start, target = coarsened, coarser
+            elif not resolved:
+                raise ValueError(f"Target URN {target=} not found")
+            else:
+                raise ValueError(f"No prioritized URNs found: {target=} {project_priority=}")
+
         if isinstance(range_start, ResolvedUrnRange):
             if target_end is not None:
                 raise ValueError(f"If target {target=} is a range, target_end {target_end=} cannot be provided")

--- a/opensiddur/exporter/external_compiler.py
+++ b/opensiddur/exporter/external_compiler.py
@@ -23,7 +23,7 @@ from opensiddur.exporter.constants import (
 )
 from opensiddur.exporter.linear import LinearData
 from opensiddur.exporter.refdb import UNIT_CONTAINED_BY, ReferenceDatabase
-from opensiddur.exporter.urn import ResolvedUrnRange, UrnResolver
+from opensiddur.exporter.urn import ResolvedUrnRange, UrnResolver, coarsen
 from lxml import etree
 
 from opensiddur.exporter.marker_reconstruct import (
@@ -32,6 +32,51 @@ from opensiddur.exporter.marker_reconstruct import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _urn_prefixes(urn: str) -> list[str]:
+    """The URNs of the divisions containing `urn`, innermost first.
+
+    Path components only: the first component carries the scheme, the namespace and the
+    work, and nothing above the work is a division of it.
+    """
+    prefixes = []
+    head = urn
+    while '/' in head:
+        head = head.rpartition('/')[0]
+        prefixes.append(head)
+    return prefixes
+
+
+def _milestone_corresps(elements: list[ElementBase]) -> set[str]:
+    """The URNs of the milestones in a flat marker stream."""
+    tei_milestone_tag = f"{{{TEI_NS}}}milestone"
+    return {
+        el.get('corresp') for el in elements
+        if el.tag == tei_milestone_tag and el.get('corresp')
+    }
+
+
+def _common_split_points(ours: set[str], theirs: set[str]) -> set[str]:
+    """Which of `ours` are boundaries when the text is set beside a stream marking `theirs`.
+
+    Two editions need not divide the text alike below the verse: the Hebrew is divided at
+    its accents and a translation cannot be. A division the other side does not carry is not
+    a row boundary — its text belongs in the row of the nearest division that both carry, or
+    the halves of a Hebrew verse would face an empty English cell and the English verse an
+    empty Hebrew one.
+
+    A division with no such container is kept as a boundary of its own. It gets a row facing
+    nothing, which is what a URN only one side has did before any of this.
+
+    Only a division *both* sides mark can absorb another's text: falling back on one this
+    side does not itself mark would put the text under a URN it never claimed.
+    """
+    common = ours & theirs
+    return common | {
+        corresp for corresp in ours - common
+        if not any(prefix in common for prefix in _urn_prefixes(corresp))
+    }
 
 
 def _attrs_structural_original(source: ElementBase) -> dict[str, str]:
@@ -271,6 +316,7 @@ class ExternalCompilerProcessor(CompilerProcessor):
     def _split_at_milestones(
         elements: list[ElementBase],
         ns_map: dict,
+        split_at: Optional[set[str]] = None,
     ) -> list[tuple[Optional[str], list[ElementBase]]]:
         """Split a flat marker stream at tei:milestone[@corresp] boundaries.
 
@@ -278,6 +324,9 @@ class ExternalCompilerProcessor(CompilerProcessor):
         corresp_or_None is None for content before the first milestone.
         At each milestone, open structural markers are suspended (LIFO) into the
         current sub-segment and resumed (FIFO) into the new sub-segment.
+
+        `split_at` limits which URNs are boundaries; a milestone outside it stays where it
+        is, inside the sub-segment it falls in. None means every milestone with a @corresp.
         """
         p_ns = PROCESSING_NAMESPACE
         tei_milestone_tag = f"{{{TEI_NS}}}milestone"
@@ -291,7 +340,8 @@ class ExternalCompilerProcessor(CompilerProcessor):
             p_suspend = el.get(f"{{{p_ns}}}suspend")
             p_resume = el.get(f"{{{p_ns}}}resume")
 
-            if el.tag == tei_milestone_tag and el.get('corresp'):
+            if (el.tag == tei_milestone_tag and el.get('corresp')
+                    and (split_at is None or el.get('corresp') in split_at)):
                 corresp = el.get('corresp')
 
                 # Close current sub-segment: emit suspends LIFO (carry TEI/XML attrs)
@@ -409,8 +459,16 @@ class ExternalCompilerProcessor(CompilerProcessor):
             return transclude_el.get(xml_lang) or default_lang
 
         def make_rows(prim_flat, par_flat, prim_src, par_src, prim_lang, par_lang):
-            prim_sub = ExternalCompilerProcessor._split_at_milestones(prim_flat, ns_map)
-            par_sub = ExternalCompilerProcessor._split_at_milestones(par_flat, ns_map)
+            # Only divisions both sides carry are row boundaries — see _common_split_points.
+            # Deciding this before splitting rather than merging the rows afterwards matters:
+            # every split suspends and resumes the structure open across it, and those
+            # carriers would survive a merge and break the verse into pieces inside its row.
+            prim_corresps = _milestone_corresps(prim_flat)
+            par_corresps = _milestone_corresps(par_flat)
+            prim_sub = ExternalCompilerProcessor._split_at_milestones(
+                prim_flat, ns_map, _common_split_points(prim_corresps, par_corresps))
+            par_sub = ExternalCompilerProcessor._split_at_milestones(
+                par_flat, ns_map, _common_split_points(par_corresps, prim_corresps))
 
             prim_by_c: dict[Optional[str], list] = {}
             for c, els in prim_sub:
@@ -507,12 +565,25 @@ class ExternalCompilerProcessor(CompilerProcessor):
         """
         parallel_target = self._build_parallel_urn(target, parallel_project)
         try:
-            p_list = self._urn_resolver.resolve_range(parallel_target)
-            if not p_list:
-                return None
-            p_resolved = UrnResolver.prioritize_range(p_list, [parallel_project])
+            p_resolved = UrnResolver.prioritize_range(
+                self._urn_resolver.resolve_range(parallel_target), [parallel_project])
             if not p_resolved:
-                return None
+                # This project does not divide the text this finely — a translation has no
+                # accents and so carries no half-verses. Set the containing division beside
+                # the primary rather than leaving the column empty; make_rows pairs the two
+                # up at whatever division they have in common.
+                coarser = coarsen(parallel_target)
+                p_resolved = UrnResolver.prioritize_range(
+                    self._urn_resolver.resolve_range(coarser), [parallel_project]
+                ) if coarser else None
+                if not p_resolved:
+                    return None
+                logger.warning(
+                    "parallel: %s does not carry %s; setting %s beside it, which covers "
+                    "more text than the reference asks for",
+                    parallel_project, parallel_target, coarser,
+                )
+                parallel_target = coarser
 
             if isinstance(p_resolved, ResolvedUrnRange):
                 if target_end is not None:
@@ -528,12 +599,23 @@ class ExternalCompilerProcessor(CompilerProcessor):
                 p_start = p_resolved.element_path
                 if target_end is not None:
                     parallel_target_end = self._build_parallel_urn(target_end, parallel_project)
-                    pe_list = self._urn_resolver.resolve_range(parallel_target_end)
-                    if not pe_list:
-                        return None
-                    pe_resolved = UrnResolver.prioritize_range(pe_list, [parallel_project])
+                    pe_resolved = UrnResolver.prioritize_range(
+                        self._urn_resolver.resolve_range(parallel_target_end),
+                        [parallel_project])
                     if not pe_resolved:
-                        return None
+                        # The end of the range may name a division this project lacks just
+                        # as the start may; close on the division that contains it.
+                        coarser_end = coarsen(parallel_target_end)
+                        pe_resolved = UrnResolver.prioritize_range(
+                            self._urn_resolver.resolve_range(coarser_end), [parallel_project]
+                        ) if coarser_end else None
+                        if not pe_resolved:
+                            return None
+                        logger.warning(
+                            "parallel: %s does not carry %s; ending at %s instead, which "
+                            "covers more text than the reference asks for",
+                            parallel_project, parallel_target_end, coarser_end,
+                        )
                     p_end = (pe_resolved.end_element_path or pe_resolved.element_path
                              if not isinstance(pe_resolved, ResolvedUrnRange)
                              else pe_resolved.end.end_element_path or pe_resolved.end.element_path)

--- a/opensiddur/exporter/refdb.py
+++ b/opensiddur/exporter/refdb.py
@@ -32,8 +32,17 @@ class DuplicateUrnError(ValueError):
 # Reading divisions deliberately overlap and so are absent from each other's containment sets:
 # maftir re-reads the close of the seventh aliyah, weekday aliyot subdivide the Shabbat ones,
 # and triennial breaks cut across the annual ones. Each is contained only by the parsha.
+#
+# The two sub-verse units divide a verse and are contained by it, but never by each other: the
+# accentual halves and the named parts cut the verse at different points, and a named part may
+# well straddle the etnachta — the Thirteen Attributes end one word past the etnachta of Exodus
+# 34:7. Neither contains the other, so neither ends the other's scope. Note also that `verse`
+# does not name them among *its* containers, so a sub-verse milestone never truncates the verse
+# it sits inside.
 UNIT_CONTAINED_BY: dict[str, frozenset[str]] = {
     "verse": frozenset({"chapter"}),
+    "half-verse": frozenset({"verse", "chapter"}),
+    "verse-part": frozenset({"verse", "chapter"}),
     "chapter": frozenset(),
     "parsha": frozenset(),
     "parsha.annual": frozenset(),

--- a/opensiddur/exporter/urn.py
+++ b/opensiddur/exporter/urn.py
@@ -22,6 +22,127 @@ class ResolvedUrnRange(BaseModel):
     end: ResolvedUrn
 
 
+def split_range(ranged_urn: str) -> Optional[tuple[str, str]]:
+    """Split a ranged URN into its start and end URNs.
+
+    A range is written with '-' in a path component. The part before the dash closes the
+    start URN; what follows names the end. There are two ways to name the end:
+
+    **Relative** — the end replaces that many trailing components of the start, which leaves
+    it at the same depth::
+
+        genesis/1/1-2      → genesis/1/1  … genesis/1/2
+        genesis/1/1-2/3    → genesis/1/1  … genesis/2/3
+        nahum/2/2/b-2/3/a  → nahum/2/2/b  … nahum/2/3/a
+
+    **Absolute** — an end that begins with '/' replaces the whole path below the component
+    carrying the namespace and the work, so the two ends need not be at the same depth::
+
+        nahum/2/2/b-/2/5   → nahum/2/2/b  … nahum/2/5
+        genesis/1/1-/3     → genesis/1/1  … genesis/3
+
+    Write the absolute form whenever the ends are at different depths: a sub-verse start
+    with a whole-verse end has no relative spelling, since a relative end always lands at
+    the start's own depth. This is also why a range cannot cross works — the absolute form
+    keeps the start's namespace-and-work component, and the relative form never touches it.
+
+    Args:
+        ranged_urn: A URN, with or without range notation. Any '@project' suffix must
+                    already have been stripped.
+
+    Returns:
+        (start_urn, end_urn), or None if `ranged_urn` names no range at all.
+
+    Raises:
+        ValueError: if it names a range but not a well-formed one.
+    """
+    parts = ranged_urn.split('/')
+
+    # Index 0 holds the scheme, namespace and work ("urn:x-opensiddur:text:bible:genesis"),
+    # whose dashes ("x-opensiddur") never mark a range. Only the path components below it
+    # are candidates, and the last dash-bearing one wins.
+    range_start_idx = None
+    for i in range(len(parts) - 1, 0, -1):
+        if '-' in parts[i]:
+            range_start_idx = i
+            break
+
+    if range_start_idx is None:
+        return None
+
+    start_value, end_spec_start = parts[range_start_idx].split('-', 1)
+    if not start_value:
+        raise ValueError(f"Range has no start: {ranged_urn!r}")
+    start_urn = '/'.join(parts[:range_start_idx] + [start_value])
+
+    remaining_parts = parts[range_start_idx + 1:]
+    end_spec = end_spec_start
+    if remaining_parts:
+        end_spec += '/' + '/'.join(remaining_parts)
+
+    if end_spec.startswith('/'):
+        end_components = end_spec[1:].split('/')
+        if not all(end_components):
+            raise ValueError(f"Absolute range end is empty: {ranged_urn!r}")
+        end_parts = [parts[0]] + end_components
+    else:
+        if not end_spec:
+            raise ValueError(f"Range has no end: {ranged_urn!r}")
+        end_components = end_spec.split('/')
+        # A relative end replaces trailing components of the start, so it can never be
+        # deeper than the start is. Before the absolute form existed this case built an end
+        # URN with the scheme sliced off it, which then resolved to nothing, silently.
+        base = range_start_idx - len(end_components) + 1
+        if base < 1:
+            raise ValueError(
+                f"Relative range end {end_spec!r} is deeper than the start it replaces in "
+                f"{ranged_urn!r}; state it absolutely as -/{end_spec}"
+            )
+        end_parts = parts[:base] + end_components
+
+    return start_urn, '/'.join(end_parts)
+
+
+def coarsen(urn: str) -> Optional[str]:
+    """`urn` with its last path component dropped, or None if it has only one.
+
+    A project need not carry every division another project does: a translation has no
+    accents, so it can place no half-verses, and a reference to one has to fall back on the
+    verse that contains it or the translation drops out of the page altogether. Reading a
+    whole verse where half was asked for is the behaviour that was there before sub-verse
+    URNs existed; what is new is that the caller knows it happened and can say so.
+
+    Ranges are coarsened at both ends, and the result is stated absolutely so that ends
+    which no longer sit at the same depth still resolve.
+    """
+    project_specifier = None
+    if '@' in urn:
+        urn, project_specifier = urn.rsplit('@', 1)
+
+    try:
+        split = split_range(urn)
+    except ValueError:
+        return None
+
+    def drop(one: str) -> Optional[str]:
+        head, _, tail = one.rpartition('/')
+        return head if head and tail else None
+
+    if split is None:
+        coarsened = drop(urn)
+    else:
+        start, end = (drop(part) for part in split)
+        if start is None or end is None:
+            return None
+        # The absolute form, since the two ends may no longer be at the same depth.
+        _work, _, below = end.partition('/')
+        coarsened = f"{start}-/{below}" if below else None
+
+    if coarsened is None:
+        return None
+    return f"{coarsened}@{project_specifier}" if project_specifier else coarsened
+
+
 class UrnResolver:
     """Resolves URNs to their corresponding project and file paths."""
     
@@ -68,103 +189,42 @@ class UrnResolver:
     def resolve_range(self, ranged_urn: str) -> list[ResolvedUrnRange | ResolvedUrn]:
         """Resolve a ranged URN to start and end URNs, or a non-ranged URN.
         
-        A range URN uses '-' to indicate a range in the final components:
-        - 'urn:.../genesis/1/1-2' resolves to start='...genesis/1/1', end='...genesis/1/2'
-        - 'urn:.../genesis/1/1-2/3' resolves to start='...genesis/1/1', end='...genesis/2/3'
-        
-        The end specification replaces the last N components of the start URN, where N is
-        the number of components (slash-delimited) in the end specification.
-        
-        If the URN does not contain a dash in the last path component, it is treated as a
-        non-ranged URN and resolve() is called instead.
-        
+        The range notation itself is parsed by `split_range`, which documents the relative
+        and absolute forms of a range end.
+
+        If the URN names no range, it is treated as a non-ranged URN and resolve() is
+        called instead.
+
         Args:
-            ranged_urn: A URN with range notation (e.g., 'urn:.../1/1-2' or 'urn:.../1/1-2/3@project')
-                       or a non-ranged URN (e.g., 'urn:.../genesis/1/1')
-        
+            ranged_urn: A URN with range notation (e.g., 'urn:.../1/1-2', 'urn:.../1/1-2/3@project'
+                       or 'urn:.../2/2/b-/2/5') or a non-ranged URN (e.g., 'urn:.../genesis/1/1')
+
         Returns:
             List of ResolvedUrnRange objects for ranged URNs, or list of ResolvedUrn objects
             for non-ranged URNs. May contain multiple entries if the URN exists in multiple
             projects (when no project specifier is provided).
-            Returns empty list if the URN cannot be parsed as a range, or if start and end 
-            don't resolve to any matching project/file combinations.
+            Returns empty list if start and end don't resolve to any matching project/file
+            combinations.
+
+        Raises:
+            ValueError: if the URN names a range but not a well-formed one.
         """
         # Handle @project notation
         project_specifier = None
         if '@' in ranged_urn:
             ranged_urn, project_specifier = ranged_urn.rsplit('@', 1)
-        
-        # Find the '-' that indicates the range
-        # It should be in the path portion (after the scheme and initial parts)
-        # Split to find where the range starts
-        # We look for '-' that's in a path component (contains '/')
-        
-        # Find the first '-' that appears after a '/' or at the start of a path component
-        parts = ranged_urn.split('/')
-        
-        # Only check path components (not the scheme part) for a dash
-        # For example, "urn:x-opensiddur:test:doc" splits to ["urn:x-opensiddur:test:doc"]
-        # and we should NOT treat the dash in "x-opensiddur" as a range indicator
-        # But "urn:x-opensiddur:test:doc/1-2" splits to ["urn:x-opensiddur:test:doc", "1-2"]
-        # and we SHOULD treat the dash in "1-2" as a range indicator
-        
-        # For a URN to be ranged, we need at least 2 parts when split by '/' 
-        # (meaning there's at least one '/' in the URN, so we have actual path components)
-        
-        if len(parts) < 2:
-            # No '/' in the URN, so no range possible (dash would be in scheme part)
-            # Call resolve() instead and return the results
+
+        split = split_range(ranged_urn)
+
+        if split is None:
+            # Not a range. Add back the project specifier if present and resolve it alone.
             urn_to_resolve = ranged_urn
             if project_specifier:
                 urn_to_resolve = f"{ranged_urn}@{project_specifier}"
             return self.resolve(urn_to_resolve)
-        
-        # Search from the end backwards through path components (not the first component which is the scheme)
-        # to find the first component containing a dash
-        # Start from parts[1:] to skip the scheme component
-        range_start_idx = None
-        for i in range(len(parts) - 1, 0, -1):  # Search from the end, but skip index 0 (scheme)
-            if '-' in parts[i]:
-                range_start_idx = i
-                break
-        
-        # If no dash found in any path component, this is not a ranged URN
-        # Call resolve() instead and return the results
-        if range_start_idx is None:
-            # Add back the project specifier if present
-            urn_to_resolve = ranged_urn
-            if project_specifier:
-                urn_to_resolve = f"{ranged_urn}@{project_specifier}"
-            return self.resolve(urn_to_resolve)
-        
-        # Split at the '-' within that component
-        range_part = parts[range_start_idx]
-        if '-' not in range_part:
-            return []
-        
-        start_value, end_spec_start = range_part.split('-', 1)
-        
-        # Build the start URN
-        start_parts = parts[:range_start_idx] + [start_value]
-        start_urn = '/'.join(start_parts)
-        
-        # Build the end URN
-        # The end spec includes everything after '-', plus remaining path components
-        # For "genesis/1/1-2/3", after finding "1-2", we need end_spec = "2/3"
-        remaining_parts = parts[range_start_idx + 1:]
-        if remaining_parts:
-            end_spec = end_spec_start + '/' + '/'.join(remaining_parts)
-        else:
-            end_spec = end_spec_start
-        
-        # Split end_spec to get individual components
-        end_spec_parts = end_spec.split('/')
-        num_components = len(end_spec_parts)
-        
-        # Replace the last num_components components with end_spec_parts
-        end_parts = parts[:range_start_idx - num_components + 1] + end_spec_parts
-        end_urn = '/'.join(end_parts)
-        
+
+        start_urn, end_urn = split
+
         # Add back the project specifier if present
         if project_specifier:
             start_urn = f"{start_urn}@{project_specifier}"

--- a/opensiddur/exporter/validate_urn_references.py
+++ b/opensiddur/exporter/validate_urn_references.py
@@ -15,7 +15,7 @@ from lxml import etree
 
 from opensiddur.common.constants import PROJECT_DIRECTORY
 from opensiddur.exporter.refdb import INDEX_DB_FILE, ReferenceDatabase
-from opensiddur.exporter.urn import UrnResolver
+from opensiddur.exporter.urn import UrnResolver, coarsen
 
 
 TEI_NS = "http://www.tei-c.org/ns/1.0"
@@ -138,8 +138,99 @@ def validate_project_urn_references(
     return failures
 
 
+@dataclass(frozen=True)
+class CoarsenedUrnReference:
+    """A reference that resolves only once a division is dropped from the end of it."""
+
+    project: str
+    file_name: str
+    element_path: str
+    attribute_name: str
+    urn: str
+    resolves_as: str
+
+
+def find_coarsened_urn_references(
+    project: str,
+    *,
+    project_directory: Path = PROJECT_DIRECTORY,
+    reference_db_path: Path = INDEX_DB_FILE,
+) -> list[CoarsenedUrnReference]:
+    """References that no project carries as written, but whose containing division exists.
+
+    A reference to a point inside a verse — a half-verse, a named part of one — resolves to
+    the whole verse in any project that does not divide the text that finely, so the
+    compiled text covers more than the reference asks for. That is deliberate: a translation
+    has no accents and can place no half-verses, and dropping its column entirely would be
+    worse. But it is exactly the silent over-reading that sub-verse URNs exist to end, so it
+    is reported here, before a build, rather than only in the compiler's log during one.
+    """
+    project_path = Path(project_directory) / project
+    if not project_path.exists() or not project_path.is_dir():
+        raise ValueError(f"Project directory does not exist: {project_path}")
+
+    refdb = ReferenceDatabase(reference_db_path)
+    try:
+        resolver = UrnResolver(refdb)
+        ns = {"tei": TEI_NS, "j": JLPTEI_NS}
+        coarsened: list[CoarsenedUrnReference] = []
+
+        for xml_file in _iter_project_xml_files(project_path):
+            tree = etree.parse(str(xml_file))
+            root = tree.getroot()
+            references = [
+                (el, attribute)
+                for xpath, attribute in (
+                    ("//tei:ptr[@target]", "target"),
+                    ("//tei:ref[@target]", "target"),
+                    ("//j:transclude[@target]", "target"),
+                    ("//j:transclude[@targetEnd]", "targetEnd"),
+                )
+                for el in root.xpath(xpath, namespaces=ns)
+            ]
+
+            for el, attribute in references:
+                urn = el.get(attribute)
+                if not urn or not urn.startswith("urn:x-opensiddur:"):
+                    continue
+                try:
+                    if resolver.resolve_range(urn):
+                        continue
+                except ValueError:
+                    continue  # malformed, which the resolvability check already reports
+                coarser = coarsen(urn)
+                if not coarser:
+                    continue
+                try:
+                    if not resolver.resolve_range(coarser):
+                        continue
+                except ValueError:
+                    continue
+                coarsened.append(
+                    CoarsenedUrnReference(
+                        project=project,
+                        file_name=xml_file.name,
+                        element_path=tree.getpath(el),
+                        attribute_name=attribute,
+                        urn=urn,
+                        resolves_as=coarser,
+                    )
+                )
+    finally:
+        refdb.close()
+
+    return coarsened
+
+
 def _format_failure(f: UnresolvableUrnReference) -> str:
     return f"{f.project}/{f.file_name}: {f.element_path} @{f.attribute_name}={f.urn}"
+
+
+def _format_coarsened(c: CoarsenedUrnReference) -> str:
+    return (
+        f"{c.project}/{c.file_name}: {c.element_path} @{c.attribute_name}={c.urn} "
+        f"resolves only as {c.resolves_as}, which covers more text"
+    )
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -171,6 +262,15 @@ def main(argv: Optional[list[str]] = None) -> int:
         reference_db_path=Path(args.reference_db),
         index_before_validate=args.index,
     )
+    # Reported but not fatal: a reference that coarsens still compiles, and for a project
+    # that cannot carry the finer division there is nothing to fix in the reference itself.
+    for c in find_coarsened_urn_references(
+        args.project,
+        project_directory=Path(args.project_directory),
+        reference_db_path=Path(args.reference_db),
+    ):
+        print(_format_coarsened(c))
+
     if failures:
         for f in failures:
             print(_format_failure(f))

--- a/opensiddur/importer/humash/build.py
+++ b/opensiddur/importer/humash/build.py
@@ -219,11 +219,16 @@ def _instruction(text: str) -> str:
     return f'<tei:note type="instruction" xml:lang="he">{_escape(text)}</tei:note>'
 
 
+def _verse_citation(ref: VerseRef) -> str:
+    """"<chapter>:<verse>", with the half after it where the reading names one — "2:2b"."""
+    return f"{ref.chapter}:{ref.verse}{ref.half or ''}"
+
+
 def _citation_range(book: str, start: VerseRef, end: VerseRef) -> str:
     """"<book> <chapter>:<verse>[–<chapter>:<verse>]" for one contiguous range."""
     book_he = SLUG_TO_HEBREW_ANY_BOOK.get(book, book)
-    start_ref = f"{start.chapter}:{start.verse}"
-    end_ref = f"{end.chapter}:{end.verse}"
+    start_ref = _verse_citation(start)
+    end_ref = _verse_citation(end)
     return f"{book_he} {start_ref if start == end else f'{start_ref}–{end_ref}'}"
 
 
@@ -237,8 +242,8 @@ def _citation(spans: list[ReadingSpan]) -> str:
     prev_book: str | None = None
     for span in spans:
         if span.book == prev_book:
-            start_ref = f"{span.start.chapter}:{span.start.verse}"
-            end_ref = f"{span.end.chapter}:{span.end.verse}"
+            start_ref = _verse_citation(span.start)
+            end_ref = _verse_citation(span.end)
             clauses.append(start_ref if span.start == span.end else f"{start_ref}–{end_ref}")
         else:
             clauses.append(_citation_range(span.book, span.start, span.end))
@@ -258,7 +263,10 @@ def _is_contiguous(
     a change of book — see readings.Passage."""
     if prev.book != following.book:
         return False
-    return next_verse(prev.end, sourcetexts_root) == following.start
+    # A span that stops at the etnachta runs straight on into one that starts there.
+    if prev.end.half == "a" and following.start == replace(prev.end, half="b"):
+        return True
+    return next_verse(prev.end.whole_verse, sourcetexts_root) == following.start
 
 
 _CONDITION_INDEX = {"value": 0}

--- a/opensiddur/importer/humash/readings.py
+++ b/opensiddur/importer/humash/readings.py
@@ -31,7 +31,6 @@ from opensiddur.importer.humash.refs import (
     VerseRef,
     NUMBERING_COMMON,
     canonical_ref,
-    hebcal_ref_half,
     parse_hebcal_ref,
 )
 from opensiddur.importer.util.pages import hebcal_leyning_data_directory
@@ -145,8 +144,6 @@ def _haftarah_spans(raw, unit: str = "haftarah") -> list[ReadingSpan]:
             start=parse_hebcal_ref(book, part["b"]),
             end=parse_hebcal_ref(book, part["e"], at_end=True),
             note=part.get("note"),
-            start_half=hebcal_ref_half(part["b"]),
-            end_half=hebcal_ref_half(part["e"]),
         ))
     return spans
 

--- a/opensiddur/importer/humash/refs.py
+++ b/opensiddur/importer/humash/refs.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import functools
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from opensiddur.common import versification
@@ -184,31 +184,82 @@ BOOK_NUMBER_TO_SLUG = {number: slug for number, (_, slug, _) in enumerate(TORAH_
 # so that nothing downstream has to carry a numbering at all.
 
 
-@dataclass(frozen=True, order=True)
+# Ordered by _sort_key rather than by field order, so `order=True` is deliberately absent:
+# the halves do not sort the way the string "a" < "b" would place them against a whole verse.
+@dataclass(frozen=True)
 class VerseRef:
-    """One verse, identified the way the Tanakh projects' URNs identify it."""
+    """One verse, or one half of one, identified the way the Tanakh projects' URNs do.
+
+    A reading that begins or ends inside a verse names the accentual half it means, the way
+    the sources cite it: hebcal writes the third-year haftarah of Emor as Nachum 2:2b-3a, and
+    the Hebrew Tanakh projects carry a `half-verse` milestone at the etnachta of every verse
+    the accents divide (opensiddur/common/subverse.py).
+
+    Ordering puts the first half before the whole and the whole before the second, which is
+    document order: `a` closes where `b` opens, and a bare reference to the verse covers
+    both. `readings._without_anchor_verses` compares refs this way when it decides whether
+    one span lies inside another.
+    """
 
     book: str  # opensiddur slug, e.g. "genesis"
     chapter: int
     verse: int
+    half: str | None = None  # "a", "b", or None for the whole verse
+
+    def __post_init__(self):
+        if self.half not in (None, "a", "b"):
+            raise ValueError(f"A verse has halves 'a' and 'b', not {self.half!r}")
 
     def __str__(self) -> str:
-        return f"{self.book} {self.chapter}:{self.verse}"
+        return f"{self.book} {self.chapter}:{self.verse}{self.half or ''}"
+
+    @property
+    def _sort_key(self) -> tuple:
+        return (self.book, self.chapter, self.verse, {"a": 0, None: 1, "b": 2}[self.half])
+
+    def __lt__(self, other: "VerseRef") -> bool:
+        return self._sort_key < other._sort_key
+
+    def __le__(self, other: "VerseRef") -> bool:
+        return self._sort_key <= other._sort_key
+
+    def __gt__(self, other: "VerseRef") -> bool:
+        return self._sort_key > other._sort_key
+
+    def __ge__(self, other: "VerseRef") -> bool:
+        return self._sort_key >= other._sort_key
+
+    @property
+    def whole_verse(self) -> "VerseRef":
+        """This reference with any half dropped — the verse that contains it."""
+        return replace(self, half=None) if self.half else self
 
     @property
     def urn(self) -> str:
-        """The unsuffixed verse URN, which resolves in whichever project has priority."""
-        return f"urn:x-opensiddur:text:bible:{self.book}/{self.chapter}/{self.verse}"
+        """The unsuffixed URN, which resolves in whichever project has priority."""
+        urn = f"urn:x-opensiddur:text:bible:{self.book}/{self.chapter}/{self.verse}"
+        return f"{urn}/{self.half}" if self.half else urn
+
+    @property
+    def _path_below_book(self) -> str:
+        """The URN's path components below the book, which the absolute range form takes."""
+        return self.urn.partition("/")[2]
 
     def range_urn(self, end: "VerseRef") -> str:
-        """A ranged transclusion target from this verse to `end`.
+        """A ranged transclusion target from this reference to `end`.
 
-        The range syntax replaces the trailing components of the start, so the end is written
-        as ``chapter/verse`` — see UrnResolver.resolve_range.
+        A relative range end replaces the trailing components of the start and so always
+        lands at the start's own depth, which reaches only where both ends are the same kind
+        of thing — two verses, or two halves. Where one end is a half of a verse and the
+        other a whole verse, the end is stated absolutely instead. See
+        `opensiddur.exporter.urn.split_range` for both forms.
         """
         if end.book != self.book:
             raise ValueError(f"A range may not cross books: {self} to {end}")
-        return f"{self.urn}-{end.chapter}/{end.verse}"
+        if (self.half is None) == (end.half is None):
+            end_spec = f"{end.chapter}/{end.verse}" + (f"/{end.half}" if end.half else "")
+            return f"{self.urn}-{end_spec}"
+        return f"{self.urn}-/{end._path_below_book}"
 
 
 @dataclass(frozen=True)
@@ -225,12 +276,15 @@ class ReadingSpan:
     # for the two parshiyot of a pair, which share a file but keep their own URN spaces:
     # without it their identically numbered aliyot would both be .../vayakhel_pekudei/1.
     owner: str | None = None
-    # Where the span really begins or ends, when that is inside a verse rather than at its
-    # edge: "b" on `start_half` means it begins at the second half of `start`, and "a" on
-    # `end_half` that it ends at the first half of `end`. The whole verse is transcluded either
-    # way — a URN addresses no less than a verse — and the reading says where to stop.
-    start_half: str | None = None
-    end_half: str | None = None
+    @property
+    def start_half(self) -> str | None:
+        """"b" when the span begins at the second half of its first verse, else None."""
+        return self.start.half
+
+    @property
+    def end_half(self) -> str | None:
+        """"a" when the span ends at the first half of its last verse, else None."""
+        return self.end.half
 
     @property
     def book(self) -> str:
@@ -332,21 +386,14 @@ def parse_hebcal_ref(book: str, spec: str, at_end: bool = False) -> VerseRef:
     """Parse hebcal's ``"chapter:verse"`` form against an opensiddur book slug.
 
     hebcal numbers by the common printed editions, so the result is converted to the canonical
-    division the URN space uses. A half-verse marker is read as the whole verse containing it,
-    since a URN addresses whole verses; ``hebcal_ref_half`` recovers which half was meant so
-    the reading can say so.
+    division the URN space uses. A half-verse marker is kept: the Hebrew Tanakh projects carry
+    a milestone at the etnachta of every verse the accents divide, so "2:2b" names a point the
+    URN space can reach.
     """
     match = _HEBCAL_REF.match(spec)
     if match is None:
         raise ValueError(f"Unparseable hebcal reference {spec!r} in {book}")
-    return canonical_ref(
+    canonical = canonical_ref(
         NUMBERING_COMMON, VerseRef(book, int(match.group(1)), int(match.group(2))), at_end
     )
-
-
-def hebcal_ref_half(spec: str) -> str | None:
-    """Which half of the verse a reference names — ``"a"``, ``"b"``, or None for the whole."""
-    match = _HEBCAL_REF.match(spec)
-    if match is None:
-        raise ValueError(f"Unparseable hebcal reference {spec!r}")
-    return match.group(3) or None
+    return replace(canonical, half=match.group(3) or None)

--- a/opensiddur/importer/miqra_al_pi_hamasorah/convert_tsv.py
+++ b/opensiddur/importer/miqra_al_pi_hamasorah/convert_tsv.py
@@ -12,6 +12,7 @@ from typing import Any, Iterable, Optional
 import mwparserfromhell
 
 from opensiddur.common.constants import PROJECT_DIRECTORY
+from opensiddur.common.subverse import add_subverse_milestones
 from opensiddur.common.xslt import xslt_transform_string
 from opensiddur.importer.util.pages import (
     default_sourcetexts_root,
@@ -239,10 +240,21 @@ def tei_file(
 """
 
 
-def validate_and_write_tei_file(tei_content: str, file_name: str, project_dir: Path | None) -> Path:
+def validate_and_write_tei_file(
+    tei_content: str,
+    file_name: str,
+    project_dir: Path | None,
+    add_subverse: bool = False,
+) -> Path:
     directory = project_dir.resolve() if project_dir is not None else _default_project_directory()
     out_path = directory / f"{file_name}.xml"
     pretty_xml = prettify_xml(tei_content, remove_xml_declaration=True)
+    if add_subverse:
+        # After prettifying, not before: the pass splits text nodes to place its milestones,
+        # and re-indenting afterwards would put whitespace inside the words it split.
+        pretty_xml = add_subverse_milestones(
+            pretty_xml, language="he", project="miqra_al_pi_hamasorah"
+        )
     is_valid, errors = validate(pretty_xml)
     if not is_valid:
         raise Exception(f"Errors in {file_name}: {errors}")
@@ -517,7 +529,7 @@ def book_file(book: Book, *, sourcetexts_root: Path | None, project_dir: Path | 
     header_xml = header(book.book_name_he, book.book_name_en, qualifier=f":{book.file_name}")
     tei_content = tei_file(header_xml, **xml_dict)
     make_project_directory(project_dir)
-    validate_and_write_tei_file(tei_content, book.file_name, project_dir)
+    validate_and_write_tei_file(tei_content, book.file_name, project_dir, add_subverse=True)
 
 
 def _readme_front_matter(sourcetexts_root: Path | None) -> str:

--- a/opensiddur/importer/wlc/wlc.py
+++ b/opensiddur/importer/wlc/wlc.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 from opensiddur.common.constants import PROJECT_DIRECTORY, SOURCETEXTS_ROOT
+from opensiddur.common.subverse import add_subverse_milestones_to_file
 from opensiddur.common.xslt import xslt_transform
 from opensiddur.importer.util.validation import validate
 
@@ -84,6 +85,9 @@ def main(argv: list[str] | None = None) -> int:
                 xslt_directory / "transform_book.xslt",
                 wlc_directory / "Books" / book,
                 project_directory / book.lower(),
+            )
+            add_subverse_milestones_to_file(
+                project_directory / book.lower(), language="he", project="wlc"
             )
 
     for book in os.listdir(project_directory):

--- a/opensiddur/tests/common/test_subverse.py
+++ b/opensiddur/tests/common/test_subverse.py
@@ -1,0 +1,495 @@
+"""Tests for sub-verse milestone placement.
+
+Every fixture here is hand-written. The point of these tests is the placement rule, which
+must not move when a project is re-imported.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from lxml import etree
+
+from opensiddur.common.subverse import (
+    VERSE_PARTS,
+    insert_half_verses,
+    insert_verse_parts,
+)
+
+TEI = "http://www.tei-c.org/ns/1.0"
+JLPTEI = "http://jewishliturgy.org/ns/jlptei/2"
+URN = "urn:x-opensiddur:text:bible:"
+
+
+def document(body: str) -> str:
+    """A minimal TEI document whose body is `body`, as source text."""
+    return (
+        f'<tei:TEI xmlns:tei="{TEI}" xmlns:j="{JLPTEI}" xml:lang="he">'
+        f"<tei:text><tei:body>{body}</tei:body></tei:text></tei:TEI>"
+    )
+
+
+def verse(corresp: str, n: str = "1") -> str:
+    return f'<tei:milestone unit="verse" n="{n}" corresp="{corresp}"/>'
+
+
+class SubverseTestCase(unittest.TestCase):
+    def half_verses(self, xml: str, *, project: str = "") -> str:
+        """`insert_half_verses`, asserting that nothing was left unplaceable."""
+        result, unplaceable = insert_half_verses(xml, project=project)
+        self.assertEqual(unplaceable, [])
+        return result
+
+    def verse_parts(self, xml: str, *, language: str = "he") -> str:
+        """`insert_verse_parts`, asserting that nothing was left unplaceable."""
+        result, unplaceable = insert_verse_parts(xml, language=language)
+        self.assertEqual(unplaceable, [])
+        return result
+
+    def milestones(self, xml: str, unit: str) -> list[tuple[str, str]]:
+        """(n, corresp) of every milestone of `unit`, in document order."""
+        return [
+            (m.get("n"), m.get("corresp"))
+            for m in etree.fromstring(xml.encode()).iter(f"{{{TEI}}}milestone")
+            if m.get("unit") == unit
+        ]
+
+    def scope(self, xml: str, corresp: str) -> str:
+        """The text from the milestone carrying `corresp` to the next milestone with a URN."""
+        root = etree.fromstring(xml.encode())
+        found = [m for m in root.iter(f"{{{TEI}}}milestone") if m.get("corresp") == corresp]
+        self.assertEqual(len(found), 1, f"expected exactly one {corresp}")
+        milestone = found[0]
+
+        collected: list[str] = []
+        started = False
+        for node in root.iter():
+            if node is milestone:
+                started = True
+                collected.append(node.tail or "")
+                continue
+            if not started:
+                continue
+            if node.tag == f"{{{TEI}}}milestone" and node.get("corresp"):
+                break
+            collected.append(node.text or "")
+            collected.append(node.tail or "")
+        return "".join(collected).strip()
+
+    def assertTextUnchanged(self, xml: str, before: str):
+        """The running text must come through untouched; only markup may be added."""
+        self.assertEqual("".join(etree.fromstring(xml.encode()).itertext()), before)
+
+    def text_of(self, xml: str) -> str:
+        return "".join(etree.fromstring(xml.encode()).itertext())
+
+
+class TestHalfVerses(SubverseTestCase):
+    def test_divides_at_the_etnachta(self):
+        """The accent closes the first half; the second half opens at the next word."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/31', '31')}"
+            "וַיַּרְא אֱלֹהִים אֶת־כׇּל־אֲשֶׁר עָשָׂה וְהִנֵּה־טוֹב מְאֹ֑ד "
+            "וַיְהִי־עֶרֶב וַיְהִי־בֹקֶר יוֹם הַשִּׁשִּׁי׃</tei:p>"
+        )
+        before = self.text_of(xml)
+
+        xml = self.half_verses(xml)
+
+        self.assertEqual(
+            self.milestones(xml, "half-verse"),
+            [("a", f"{URN}genesis/1/31/a"), ("b", f"{URN}genesis/1/31/b")],
+        )
+        self.assertTrue(self.scope(xml, f"{URN}genesis/1/31/a").endswith("מְאֹ֑ד"))
+        self.assertTrue(self.scope(xml, f"{URN}genesis/1/31/b").startswith("וַיְהִי־עֶרֶב"))
+        self.assertTextUnchanged(xml, before)
+
+    def test_a_verse_with_no_etnachta_is_not_divided(self):
+        xml = document(f"<tei:p>{verse(f'{URN}genesis/1/1')}בְּרֵאשִׁית בָּרָא׃</tei:p>")
+
+        xml = self.half_verses(xml)
+        self.assertEqual(self.milestones(xml, "half-verse"), [])
+
+    def test_an_etnachta_on_the_last_word_divides_nothing(self):
+        """There is no second half, so there are no halves."""
+        xml = document(f"<tei:p>{verse(f'{URN}genesis/1/1')}בְּרֵאשִׁית בָּרָ֑א</tei:p>")
+
+        xml = self.half_verses(xml)
+        self.assertEqual(self.milestones(xml, "half-verse"), [])
+
+    def test_the_boundary_does_not_split_a_maqqef_group(self):
+        """Words joined by maqqef are read as one and the boundary goes before all of them."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/31', '31')}"
+            "טוֹב מְאֹ֑ד וַיְהִי־עֶרֶב וַיְהִי־בֹקֶר׃</tei:p>"
+        )
+
+        xml = self.half_verses(xml)
+
+        self.assertEqual(
+            self.scope(xml, f"{URN}genesis/1/31/b"), "וַיְהִי־עֶרֶב וַיְהִי־בֹקֶר׃"
+        )
+
+    def test_a_verse_broken_over_two_paragraphs_is_one_verse(self):
+        """A parashah break in the middle of a verse does not end it."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/35/22', '22')}וַיֵּלֶךְ רְאוּבֵ֑ן </tei:p>"
+            "<tei:p>וַיִּהְיוּ בְנֵי־יַעֲקֹב שְׁנֵים עָשָׂר׃</tei:p>"
+        )
+        before = self.text_of(xml)
+
+        xml = self.half_verses(xml)
+
+        self.assertEqual(
+            self.scope(xml, f"{URN}genesis/35/22/b"), "וַיִּהְיוּ בְנֵי־יַעֲקֹב שְׁנֵים עָשָׂר׃"
+        )
+        self.assertTextUnchanged(xml, before)
+
+    def test_a_word_broken_over_an_element_is_one_word(self):
+        """Miqra al pi ha-Masorah sets an enlarged first letter as its own element."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}exodus/34/7', '7')}"
+            '<tei:hi rend="large">נֹ</tei:hi>צֵר חֶסֶד וְחַטָּאָ֑ה וְנַקֵּה לֹא יְנַקֶּה׃</tei:p>'
+        )
+        before = self.text_of(xml)
+
+        xml = self.half_verses(xml)
+
+        self.assertEqual(self.scope(xml, f"{URN}exodus/34/7/a"), "נֹצֵר חֶסֶד וְחַטָּאָ֑ה")
+        self.assertTextUnchanged(xml, before)
+
+    def test_a_ketiv_is_not_read_as_a_word_of_its_own(self):
+        """Descending into both readings would put the unpointed ketiv into the text.
+
+        Here the etnachta is on the word before the ketiv/qere, so counting the ketiv as a
+        word would put the boundary one word late — inside the choice rather than before it.
+        """
+        xml = document(
+            f"<tei:p>{verse(f'{URN}psalms/5/9', '9')}"
+            "לְמַעַן שׁוֹרְרָ֑י "
+            "<tei:choice><j:written>הושר</j:written><j:read>הַיְשַׁר</j:read></tei:choice>"
+            " לְפָנַי דַּרְכֶּךָ׃</tei:p>"
+        )
+        before = self.text_of(xml)
+
+        xml = self.half_verses(xml)
+
+        self.assertEqual(self.scope(xml, f"{URN}psalms/5/9/a"), "לְמַעַן שׁוֹרְרָ֑י")
+        # The milestone goes before the choice, not inside either reading of it.
+        root = etree.fromstring(xml.encode())
+        half = [
+            m for m in root.iter(f"{{{TEI}}}milestone")
+            if m.get("corresp") == f"{URN}psalms/5/9/b"
+        ][0]
+        self.assertEqual(half.getnext().tag, f"{{{TEI}}}choice")
+        self.assertTextUnchanged(xml, before)
+
+    def test_a_verse_with_variant_accentuation_is_not_divided(self):
+        """The two cantillations of the Decalogue put the etnachta in different places.
+
+        A URN must denote the same words wherever it resolves, so a verse whose division
+        depends on which variant is selected gets none.
+        """
+        tachton = "אָנֹכִי יְהֹוָה אֱלֹהֶיךָ אֲשֶׁר הוֹצֵאתִיךָ מִבֵּית עֲבָדִ֑ים"
+        elyon = "אָנֹכִי יְהֹוָה אֱלֹהֶ֑יךָ אֲשֶׁר הוֹצֵאתִיךָ מִבֵּית עֲבָדִים׃"
+        xml = document(
+            f"<tei:p>{verse(f'{URN}exodus/20/2', '2')}<tei:choice>"
+            f'<j:option corresp="urn:x-opensiddur:condition:bible:taam-tachton">{tachton}</j:option>'
+            f'<j:option corresp="urn:x-opensiddur:condition:bible:taam-elyon">{elyon}</j:option>'
+            "</tei:choice></tei:p>"
+        )
+
+        xml = self.half_verses(xml)
+        self.assertEqual(self.milestones(xml, "half-verse"), [])
+
+    def test_a_poetic_verse_with_ole_is_not_divided(self):
+        """Where ole-we-yored governs, the etnachta is not the primary division."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}psalms/1/1')}"
+            "אַשְׁרֵ֥י הָאִ֗֫ישׁ אֲשֶׁר לֹא הָלַ֑ךְ בַּעֲצַת רְשָׁעִים׃</tei:p>"
+        )
+
+        xml = self.half_verses(xml)
+        self.assertEqual(self.milestones(xml, "half-verse"), [])
+
+    def test_a_poetic_verse_without_ole_is_divided_at_the_etnachta(self):
+        xml = document(
+            f"<tei:p>{verse(f'{URN}psalms/1/2')}"
+            "כִּי אִם בְּתוֹרַת יְהֹוָה חֶפְצ֑וֹ וּבְתוֹרָתוֹ יֶהְגֶּה׃</tei:p>"
+        )
+
+        xml = self.half_verses(xml)
+
+        self.assertEqual(self.scope(xml, f"{URN}psalms/1/2/b"), "וּבְתוֹרָתוֹ יֶהְגֶּה׃")
+
+    def test_ole_in_a_prose_book_does_not_prevent_division(self):
+        """Only the three books read with the poetic accents are held back."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/1')}"
+            "בְּרֵאשִׁ֗֫ית בָּרָ֑א אֱלֹהִים אֵת הַשָּׁמַיִם׃</tei:p>"
+        )
+
+        xml = self.half_verses(xml)
+
+        self.assertEqual(self.scope(xml, f"{URN}genesis/1/1/b"), "אֱלֹהִים אֵת הַשָּׁמַיִם׃")
+
+    def test_each_verse_is_divided_independently(self):
+        xml = document(
+            f"<tei:p>{verse(f'{URN}nahum/2/2', '2')}"
+            "עָלָה מֵפִיץ נָצוֹר מְצוּרָ֑ה צַפֵּה־דֶרֶךְ חַזֵּק מׇתְנַיִם׃"
+            f"{verse(f'{URN}nahum/2/3', '3')}"
+            "כִּי שָׁב יְהֹוָה כִּגְאוֹן יִשְׂרָאֵ֑ל כִּי בְקָקוּם בֹּקְקִים׃</tei:p>"
+        )
+        before = self.text_of(xml)
+
+        xml = self.half_verses(xml)
+
+        self.assertEqual(self.scope(xml, f"{URN}nahum/2/2/b"), "צַפֵּה־דֶרֶךְ חַזֵּק מׇתְנַיִם׃")
+        self.assertEqual(self.scope(xml, f"{URN}nahum/2/3/a"), "כִּי שָׁב יְהֹוָה כִּגְאוֹן יִשְׂרָאֵ֑ל")
+        self.assertTextUnchanged(xml, before)
+
+    def test_a_chapter_milestone_ends_the_verse_before_it(self):
+        """The last verse of a chapter must not run on into the next chapter's text."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/31', '31')}טוֹב מְאֹ֑ד יוֹם הַשִּׁשִּׁי׃</tei:p>"
+            f'<tei:p><tei:milestone unit="chapter" n="2" corresp="{URN}genesis/2"/>'
+            f"{verse(f'{URN}genesis/2/1')}וַיְכֻלּ֑וּ הַשָּׁמַיִם וְהָאָרֶץ׃</tei:p>"
+        )
+
+        xml = self.half_verses(xml)
+
+        self.assertEqual(self.scope(xml, f"{URN}genesis/1/31/b"), "יוֹם הַשִּׁשִּׁי׃")
+        self.assertEqual(self.scope(xml, f"{URN}genesis/2/1/b"), "הַשָּׁמַיִם וְהָאָרֶץ׃")
+
+    def test_milestones_outside_tei_text_are_ignored(self):
+        """A header may quote a verse; only the text carries the division."""
+        xml = (
+            f'<tei:TEI xmlns:tei="{TEI}" xml:lang="he"><tei:teiHeader>'
+            f'<tei:milestone unit="verse" n="1" corresp="{URN}genesis/1/1"/>'
+            "בְּרֵאשִׁ֑ית בָּרָא</tei:teiHeader>"
+            "<tei:text><tei:body><tei:p/></tei:body></tei:text></tei:TEI>"
+        )
+        xml = self.half_verses(xml)
+        self.assertEqual(self.milestones(xml, "half-verse"), [])
+
+
+class TestSourceIsPreserved(SubverseTestCase):
+    """The pass splices into the source; it must not rewrite anything it did not add.
+
+    The WLC importer serialises through Saxon, which sets each attribute on its own line.
+    Re-serialising with lxml would reformat every file it produces, and a regeneration would
+    bury the milestones in a whole-project diff.
+    """
+
+    WLC_STYLE = (
+        f'<?xml version="1.0" encoding="UTF-8"?>\n'
+        f'<tei:TEI xmlns:j="{JLPTEI}"\n         xmlns:tei="{TEI}"\n         xml:lang="he">\n'
+        "   <tei:text xml:lang=\"he\">\n      <tei:body>\n         <tei:p>\n"
+        '            <tei:milestone unit="verse"\n'
+        f'                           corresp="{URN}genesis/1/1"\n'
+        '                           n="1"/>בְּרֵאשִׁ֑ית בָּרָא אֱלֹהִים׃\n'
+        "         </tei:p>\n      </tei:body>\n   </tei:text>\n</tei:TEI>\n"
+    )
+
+    def test_everything_but_the_insertions_survives_verbatim(self):
+        result = self.half_verses(self.WLC_STYLE)
+
+        self.assertNotEqual(result, self.WLC_STYLE, "nothing was inserted")
+        without = result
+        for milestone in self.milestones(result, "half-verse"):
+            without = without.replace(
+                f'<tei:milestone unit="half-verse" n="{milestone[0]}" '
+                f'corresp="{milestone[1]}"/>',
+                "",
+            )
+        self.assertEqual(without, self.WLC_STYLE)
+
+    def test_the_xml_declaration_and_attribute_wrapping_are_kept(self):
+        result = self.half_verses(self.WLC_STYLE)
+
+        self.assertTrue(result.startswith('<?xml version="1.0" encoding="UTF-8"?>'))
+        self.assertIn('<tei:milestone unit="verse"\n', result)
+
+    def test_the_boundary_lands_in_the_right_place_all_the_same(self):
+        result = self.half_verses(self.WLC_STYLE)
+
+        self.assertEqual(self.scope(result, f"{URN}genesis/1/1/a"), "בְּרֵאשִׁ֑ית")
+        self.assertEqual(self.scope(result, f"{URN}genesis/1/1/b"), "בָּרָא אֱלֹהִים׃")
+
+
+class TestVerseParts(SubverseTestCase):
+    PARTS = {
+        ("genesis", 1, 31): (("yom_hashishi", {"he": "יום הששי"}),),
+    }
+
+    def test_places_a_declared_part_at_its_incipit(self):
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/31', '31')}"
+            "וַיְהִי־עֶרֶב וַיְהִי־בֹקֶר יוֹם הַשִּׁשִּׁי׃</tei:p>"
+        )
+        before = self.text_of(xml)
+
+        with patch.dict(VERSE_PARTS, self.PARTS, clear=True):
+            xml = self.verse_parts(xml)
+
+        self.assertEqual(
+            self.milestones(xml, "verse-part"),
+            [("yom_hashishi", f"{URN}genesis/1/31/yom_hashishi")],
+        )
+        self.assertEqual(self.scope(xml, f"{URN}genesis/1/31/yom_hashishi"), "יוֹם הַשִּׁשִּׁי׃")
+        self.assertTextUnchanged(xml, before)
+
+    def test_matches_on_consonants_alone(self):
+        """One declared incipit has to find the same words in every edition's pointing."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/31', '31')}"
+            "וַיְהִי־בֹ֖קֶר י֥וֹם הַשִּׁשִּֽׁי׃</tei:p>"
+        )
+
+        with patch.dict(VERSE_PARTS, self.PARTS, clear=True):
+            xml = self.verse_parts(xml)
+
+        self.assertEqual(
+            self.scope(xml, f"{URN}genesis/1/31/yom_hashishi"), "י֥וֹם הַשִּׁשִּֽׁי׃"
+        )
+
+    def test_an_incipit_that_is_not_there_is_reported(self):
+        """A declared part that cannot be placed is the caller's problem to fail on."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/31', '31')}וַיְהִי־עֶרֶב וַיְהִי־בֹקֶר׃</tei:p>"
+        )
+
+        with patch.dict(VERSE_PARTS, self.PARTS, clear=True):
+            _result, unplaceable = insert_verse_parts(xml, language="he")
+
+        self.assertEqual(len(unplaceable), 1)
+        self.assertEqual(unplaceable[0].urn, f"{URN}genesis/1/31/yom_hashishi")
+        self.assertEqual(self.milestones(xml, "verse-part"), [])
+
+    def test_an_incipit_beginning_inside_a_maqqef_group_is_reported(self):
+        """The words a maqqef joins are read as one; nothing may be put between them.
+
+        The incipit is found in the text — but only starting at the second word of a
+        maqqef group, which is not a point a milestone can go.
+        """
+        parts = {("genesis", 1, 31): (("hashishi", {"he": "הששי"}),)}
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/31', '31')}"
+            "וַיְהִי־בֹקֶר יוֹם־הַשִּׁשִּׁי׃</tei:p>"
+        )
+
+        with patch.dict(VERSE_PARTS, parts, clear=True):
+            _result, unplaceable = insert_verse_parts(xml, language="he")
+
+        self.assertEqual(len(unplaceable), 1)
+        self.assertIn("word boundary", unplaceable[0].reason)
+
+    def test_a_language_that_declares_nothing_gets_nothing(self):
+        """A translation carries no parts rather than failing for want of an incipit."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/31', '31')}"
+            "And there was evening and there was morning, the sixth day.</tei:p>"
+        )
+
+        with patch.dict(VERSE_PARTS, self.PARTS, clear=True):
+            xml = self.verse_parts(xml, language="en")
+
+        self.assertEqual(self.milestones(xml, "verse-part"), [])
+
+    def test_several_parts_in_one_verse_are_all_placed(self):
+        """A part's scope runs to the next one, so ending a passage needs two of them."""
+        parts = {
+            ("exodus", 34, 7): (
+                ("venakeh", {"he": "ונקה"}),
+                ("lo_yenakeh", {"he": "לא ינקה"}),
+            ),
+        }
+        xml = document(
+            f"<tei:p>{verse(f'{URN}exodus/34/7', '7')}"
+            "נֹצֵר חֶסֶד וְחַטָּאָה וְנַקֵּה לֹא יְנַקֶּה פֹּקֵד עָוֺן׃</tei:p>"
+        )
+        before = self.text_of(xml)
+
+        with patch.dict(VERSE_PARTS, parts, clear=True):
+            xml = self.verse_parts(xml)
+
+        self.assertEqual(
+            [n for n, _ in self.milestones(xml, "verse-part")], ["venakeh", "lo_yenakeh"]
+        )
+        self.assertEqual(self.scope(xml, f"{URN}exodus/34/7/venakeh"), "וְנַקֵּה")
+        self.assertTextUnchanged(xml, before)
+
+
+class TestDeclaredVerseParts(SubverseTestCase):
+    """The parts VERSE_PARTS actually declares, against hand-written text for those verses."""
+
+    def test_the_thirteen_attributes(self):
+        """They open at the second יהוה and close at ונקה, neither of them an accent."""
+        xml = document(
+            f"<tei:p>{verse(f'{URN}exodus/34/6', '6')}"
+            "וַיַּעֲבֹר יְהֹוָה׀עַל־פָּנָיו וַיִּקְרָא יְהֹוָה׀יְהֹוָה אֵל רַחוּם וְחַנּ֑וּן "
+            "אֶרֶךְ אַפַּיִם וְרַב־חֶסֶד וֶאֱמֶת׃"
+            f"{verse(f'{URN}exodus/34/7', '7')}"
+            "נֹצֵר חֶסֶד לָאֲלָפִים נֹשֵׂא עָוֺן וָפֶשַׁע וְחַטָּאָ֑ה וְנַקֵּה "
+            "לֹא יְנַקֶּה פֹּקֵד עֲוֺן אָבוֹת׃</tei:p>"
+        )
+        before = self.text_of(xml)
+
+        xml = self.verse_parts(xml)
+
+        # The recitation opens here, three words before the etnachta of 34:6 ...
+        self.assertTrue(
+            self.scope(xml, f"{URN}exodus/34/6/adonai_adonai").startswith("יְהֹוָה׀יְהֹוָה אֵל")
+        )
+        # ... and closes here, one word past the etnachta of 34:7.
+        self.assertEqual(self.scope(xml, f"{URN}exodus/34/7/venakeh"), "וְנַקֵּה")
+        self.assertTrue(
+            self.scope(xml, f"{URN}exodus/34/7/lo_yenakeh").startswith("לֹא יְנַקֶּה")
+        )
+        self.assertTextUnchanged(xml, before)
+
+    def test_a_paseq_separates_words_however_it_is_spaced(self):
+        """Miqra al pi ha-Masorah sets the paseq tight and the WLC sets it with spaces.
+
+        Either way the two divine names are two words, and the part opens on the first of
+        them rather than in the middle of a token.
+        """
+        for label, text in [
+            ("tight", "וַיִּקְרָא יְהוָה׀יְהוָה אֵל רַחוּם וְחַנּוּן׃"),
+            ("spaced", "וַיִּקְרָא יְהוָה ׀ יְהוָה אֵל רַחוּם וְחַנּוּן׃"),
+        ]:
+            with self.subTest(label):
+                xml = document(
+                    f"<tei:p>{verse(f'{URN}exodus/34/6', '6')}{text}</tei:p>"
+                )
+
+                xml = self.verse_parts(xml)
+                self.assertTrue(
+                    self.scope(xml, f"{URN}exodus/34/6/adonai_adonai").startswith("יְהוָה")
+                )
+                # It opens after "and he proclaimed", not at the head of the verse.
+                self.assertNotIn(
+                    "וַיִּקְרָא", self.scope(xml, f"{URN}exodus/34/6/adonai_adonai")
+                )
+
+    def test_kiddush_opens_inside_the_second_half_of_genesis_1_31(self):
+        xml = document(
+            f"<tei:p>{verse(f'{URN}genesis/1/31', '31')}"
+            "וְהִנֵּה־טוֹב מְאֹ֑ד וַיְהִי־עֶרֶב וַיְהִי־בֹקֶר יוֹם הַשִּׁשִּׁי׃</tei:p>"
+        )
+
+        xml = self.half_verses(xml)
+        xml = self.verse_parts(xml)
+
+        # The part sits inside the second half, which it neither ends nor is ended by.
+        self.assertEqual(self.scope(xml, f"{URN}genesis/1/31/b"), "וַיְהִי־עֶרֶב וַיְהִי־בֹקֶר")
+        self.assertEqual(self.scope(xml, f"{URN}genesis/1/31/yom_hashishi"), "יוֹם הַשִּׁשִּׁי׃")
+
+    def test_no_declared_part_name_contains_a_dash(self):
+        """A dash in the last component of a URN is what marks a range."""
+        for key, parts in VERSE_PARTS.items():
+            for name, _incipits in parts:
+                self.assertNotIn("-", name, f"{key} declares {name!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/exporter/test_compiler.py
+++ b/opensiddur/tests/exporter/test_compiler.py
@@ -5,14 +5,14 @@ from typing import Optional
 import unittest
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 from lxml import etree
 from opensiddur.exporter.compiler import CompilerProcessor, JLPTEI_NAMESPACE
 from opensiddur.exporter.external_compiler import ExternalCompilerProcessor
 from opensiddur.exporter.inline_compiler import InlineCompilerProcessor
 from opensiddur.exporter.linear import LinearData, reset_linear_data, get_linear_data
 from opensiddur.exporter.refdb import Reference, ReferenceDatabase, UrnMapping
-from opensiddur.exporter.urn import ResolvedUrn, ResolvedUrnRange
+from opensiddur.exporter.urn import ResolvedUrn, ResolvedUrnRange, split_range
 
 
 class TestCompilerProcessorWithFiles(unittest.TestCase):
@@ -2069,6 +2069,81 @@ class TestCompilerTranscludeTextOnly(unittest.TestCase):
         children_tags = [c.tag for c in list(out)]
         self.assertIn(f"{{{self.TEI_NS}}}p", [gc.tag for c in list(out) for gc in list(c.iter())])
         self.assertNotIn(f"{{{self.TEI_NS}}}TEI", children_tags)
+
+
+class TestSubverseCoarsening(unittest.TestCase):
+    """A reference below the verse falls back on the verse where no project divides finer."""
+
+    TEI_NS = "http://www.tei-c.org/ns/1.0"
+    VERSE = "urn:x-opensiddur:text:bible:genesis/1/31"
+
+    def _processor(self):
+        root = etree.Element(f"{{{self.TEI_NS}}}TEI", nsmap={"tei": self.TEI_NS, "j": JLPTEI_NAMESPACE})
+        return CompilerProcessor("p", "root.xml", linear_data=_linear_data_with_root(root))
+
+    def _resolver_carrying(self, *urns):
+        """A resolver that knows only `urns`, all in project 'p'."""
+        known = set(urns)
+
+        def resolve(urn):
+            actual = urn.rsplit("@", 1)[0] if "@" in urn else urn
+            if actual not in known:
+                return []
+            return [ResolvedUrn(project="p", file_name="genesis.xml", urn=actual,
+                                element_path="/a", end_element_path="/b")]
+
+        resolver = Mock()
+        resolver.resolve_range.side_effect = lambda urn: (
+            resolve(urn) if split_range(urn) is None else self._resolve_range(urn, resolve)
+        )
+        return resolver
+
+    @staticmethod
+    def _resolve_range(urn, resolve):
+        start_urn, end_urn = split_range(urn)
+        start, end = resolve(start_urn), resolve(end_urn)
+        if not start or not end:
+            return []
+        return [ResolvedUrnRange(start=start[0], end=end[0])]
+
+    def test_falls_back_to_the_verse_when_no_project_has_the_half(self):
+        proc = self._processor()
+        proc._urn_resolver = self._resolver_carrying(self.VERSE)
+
+        with self.assertLogs("opensiddur.exporter.compiler", level="WARNING") as logs:
+            result = proc._get_start_and_end_from_ranges(f"{self.VERSE}/b")
+
+        self.assertEqual(result.start.urn, self.VERSE)
+        self.assertIn(f"{self.VERSE}/b", "".join(logs.output))
+        self.assertIn("more text than the reference asks for", "".join(logs.output))
+
+    def test_uses_the_half_when_a_project_has_it(self):
+        proc = self._processor()
+        proc._urn_resolver = self._resolver_carrying(self.VERSE, f"{self.VERSE}/b")
+
+        result = proc._get_start_and_end_from_ranges(f"{self.VERSE}/b")
+
+        self.assertEqual(result.start.urn, f"{self.VERSE}/b")
+
+    def test_a_range_below_the_verse_coarsens_at_both_ends(self):
+        proc = self._processor()
+        proc._urn_resolver = self._resolver_carrying(
+            "urn:x-opensiddur:text:bible:nahum/2/2", "urn:x-opensiddur:text:bible:nahum/2/3")
+
+        with self.assertLogs("opensiddur.exporter.compiler", level="WARNING"):
+            result = proc._get_start_and_end_from_ranges(
+                "urn:x-opensiddur:text:bible:nahum/2/2/b-2/3/a")
+
+        self.assertEqual(result.start.urn, "urn:x-opensiddur:text:bible:nahum/2/2")
+        self.assertEqual(result.end.urn, "urn:x-opensiddur:text:bible:nahum/2/3")
+
+    def test_a_reference_to_nothing_at_all_still_raises(self):
+        """Coarsening is for a division a project lacks, not for a URN that does not exist."""
+        proc = self._processor()
+        proc._urn_resolver = self._resolver_carrying("urn:x-opensiddur:text:bible:exodus/1/1")
+
+        with self.assertRaises(ValueError):
+            proc._get_start_and_end_from_ranges(f"{self.VERSE}/b")
 
 
 class TestCompilerMain(unittest.TestCase):

--- a/opensiddur/tests/exporter/test_parallel_compiler.py
+++ b/opensiddur/tests/exporter/test_parallel_compiler.py
@@ -269,6 +269,128 @@ class TestAssembleParallelStreams(unittest.TestCase):
             items = list(row)
             self.assertEqual([i.get("role") for i in items], ["primary", "parallel"])
 
+    def _milestone(self, corresp, unit="verse"):
+        el = etree.Element(f"{{{TEI_NS}}}milestone", nsmap=self.ns)
+        el.set("corresp", corresp)
+        el.set("unit", unit)
+        return el
+
+    def _rows_by_corresp(self, result):
+        """The corresp each parallel row is keyed on, with its two columns' text."""
+        rows = []
+        for row in result[0].iter(f"{{{P_NS}}}parallel") if result else []:
+            items = list(row)
+            texts = ["".join(item.itertext()) for item in items]
+            rows.append(texts)
+        return rows
+
+    def test_half_verses_fold_into_the_verse_the_other_side_has(self):
+        """The Hebrew divides at its accents; a translation cannot, and must not lose its
+        text to an empty row because of it."""
+        prim = self._transclude(
+            "urn:o@orig",
+            self._milestone("urn:v/1"),
+            self._milestone("urn:v/1/a", unit="half-verse"),
+            self._div("first-half"),
+            self._milestone("urn:v/1/b", unit="half-verse"),
+            self._div("second-half"),
+        )
+        par = self._transclude(
+            "urn:o@trans", self._milestone("urn:v/1"), self._div("whole-verse"))
+
+        result = self._assemble([prim], [par])
+
+        assert_parallel_invariants(self, result)
+        rows = self._rows_by_corresp(result)
+        # One row for the verse, with both halves of the Hebrew against the whole English.
+        self.assertEqual(len(rows), 1, rows)
+        primary_text, parallel_text = rows[0]
+        self.assertIn("first-half", primary_text)
+        self.assertIn("second-half", primary_text)
+        self.assertIn("whole-verse", parallel_text)
+
+    def test_folding_happens_in_both_directions(self):
+        """Whichever side is divided more finely is the one that folds."""
+        prim = self._transclude(
+            "urn:o@orig", self._milestone("urn:v/1"), self._div("whole-verse"))
+        par = self._transclude(
+            "urn:o@trans",
+            self._milestone("urn:v/1"),
+            self._milestone("urn:v/1/a", unit="half-verse"),
+            self._div("first-half"),
+            self._milestone("urn:v/1/b", unit="half-verse"),
+            self._div("second-half"),
+        )
+
+        result = self._assemble([prim], [par])
+
+        rows = self._rows_by_corresp(result)
+        self.assertEqual(len(rows), 1, rows)
+        self.assertIn("whole-verse", rows[0][0])
+        self.assertIn("first-half", rows[0][1])
+        self.assertIn("second-half", rows[0][1])
+
+    def test_both_sides_divided_alike_still_align_at_the_finer_division(self):
+        """Folding is a fallback, not a ceiling: matching halves keep their own rows."""
+        def stream(prefix):
+            return self._transclude(
+                f"urn:o@{prefix}",
+                self._milestone("urn:v/1"),
+                self._milestone("urn:v/1/a", unit="half-verse"),
+                self._div(f"{prefix}-a"),
+                self._milestone("urn:v/1/b", unit="half-verse"),
+                self._div(f"{prefix}-b"),
+            )
+
+        result = self._assemble([stream("orig")], [stream("trans")])
+
+        rows = self._rows_by_corresp(result)
+        self.assertEqual(len(rows), 3, rows)  # the verse milestone, then each half
+        self.assertIn("orig-a", rows[1][0])
+        self.assertIn("trans-a", rows[1][1])
+        self.assertIn("orig-b", rows[2][0])
+        self.assertIn("trans-b", rows[2][1])
+
+    def test_a_verse_the_other_side_does_not_subdivide_stays_in_one_piece(self):
+        """Folding must happen before the split, not after it.
+
+        Every split suspends the structure open across it and resumes it on the far side.
+        Splitting at a half-verse and merging the rows afterwards would leave those carriers
+        behind, breaking the verse into three pieces inside its own row.
+        """
+        prim = self._transclude(
+            "urn:o@orig",
+            self._milestone("urn:v/1"),
+            self._milestone("urn:v/1/a", unit="half-verse"),
+            self._div("first-half"),
+            self._milestone("urn:v/1/b", unit="half-verse"),
+            self._div("second-half"),
+        )
+        par = self._transclude(
+            "urn:o@trans", self._milestone("urn:v/1"), self._div("whole-verse"))
+
+        result = self._assemble([prim], [par])
+
+        primary = list(result[0].iter(f"{{{P_NS}}}parallel"))[0][0]
+        self.assertEqual(
+            [el.get(f"{{{P_NS}}}suspend") for el in primary.iter()
+             if el.get(f"{{{P_NS}}}suspend")],
+            [],
+            "the half-verses should not have suspended anything",
+        )
+
+    def test_a_division_with_no_container_in_common_keeps_its_own_row(self):
+        """Folding only ever moves text onto a URN this side actually marks."""
+        prim = self._transclude(
+            "urn:o@orig", self._milestone("urn:v/9/a", unit="half-verse"), self._div("orphan"))
+        par = self._transclude(
+            "urn:o@trans", self._milestone("urn:v/1"), self._div("elsewhere"))
+
+        result = self._assemble([prim], [par])
+
+        rows = self._rows_by_corresp(result)
+        self.assertTrue(any("orphan" in row[0] for row in rows), rows)
+
     def test_mismatched_transclude_counts(self):
         t1 = self._transclude()
         prim = [self._div("a"), t1, self._div("b")]  # 1 transclude

--- a/opensiddur/tests/exporter/test_refdb.py
+++ b/opensiddur/tests/exporter/test_refdb.py
@@ -1119,6 +1119,51 @@ class TestMilestoneScoping(unittest.TestCase):
         # Ends just before chapter 2, i.e. after the second seg, not the first.
         self.assertTrue(self._scope_end(chapter).endswith("seg[2]"))
 
+    def test_verse_does_not_end_at_a_half_verse_inside_it(self):
+        """A verse holding sub-verse milestones still runs to the next verse.
+
+        If the halves closed the verse, every verse carrying them would silently shrink to
+        its first half wherever it were transcluded.
+        """
+        verse, _a, _b, _next_verse = self._document(
+            ("verse", "31", "urn:x-opensiddur:text:bible:genesis/1/31"),
+            ("half-verse", "a", "urn:x-opensiddur:text:bible:genesis/1/31/a"),
+            ("half-verse", "b", "urn:x-opensiddur:text:bible:genesis/1/31/b"),
+            ("verse", "1", "urn:x-opensiddur:text:bible:genesis/2/1"),
+        )
+        self.assertTrue(self._scope_end(verse).endswith("seg[3]"))
+
+    def test_half_verse_ends_at_the_next_half_verse(self):
+        verse_a = self._document(
+            ("verse", "31", "urn:x-opensiddur:text:bible:genesis/1/31"),
+            ("half-verse", "a", "urn:x-opensiddur:text:bible:genesis/1/31/a"),
+            ("half-verse", "b", "urn:x-opensiddur:text:bible:genesis/1/31/b"),
+        )[1]
+        self.assertTrue(self._scope_end(verse_a).endswith("seg[2]"))
+
+    def test_half_verse_ends_at_the_next_verse(self):
+        """The second half runs to the end of its verse and no further."""
+        verse_b = self._document(
+            ("verse", "31", "urn:x-opensiddur:text:bible:genesis/1/31"),
+            ("half-verse", "b", "urn:x-opensiddur:text:bible:genesis/1/31/b"),
+            ("verse", "1", "urn:x-opensiddur:text:bible:genesis/2/1"),
+        )[1]
+        self.assertTrue(self._scope_end(verse_b).endswith("seg[2]"))
+
+    def test_a_verse_part_is_not_ended_by_a_half_verse(self):
+        """The two sub-verse divisions cut at different points and must not close each other.
+
+        The Thirteen Attributes end one word past the etnachta of Exodus 34:7, so a named
+        part really does straddle the accentual boundary.
+        """
+        venakeh = self._document(
+            ("verse", "7", "urn:x-opensiddur:text:bible:exodus/34/7"),
+            ("verse-part", "venakeh", "urn:x-opensiddur:text:bible:exodus/34/7/venakeh"),
+            ("half-verse", "b", "urn:x-opensiddur:text:bible:exodus/34/7/b"),
+            ("verse-part", "lo_yenakeh", "urn:x-opensiddur:text:bible:exodus/34/7/lo_yenakeh"),
+        )[1]
+        self.assertTrue(self._scope_end(venakeh).endswith("seg[3]"))
+
     def test_maftir_does_not_end_the_seventh_aliyah(self):
         """Maftir re-reads the close of aliyah 7; it opens inside it rather than ending it."""
         aliyah7, _maftir, _parsha = self._document(

--- a/opensiddur/tests/exporter/test_urn.py
+++ b/opensiddur/tests/exporter/test_urn.py
@@ -3,7 +3,7 @@
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
-from opensiddur.exporter.urn import UrnResolver, ResolvedUrn, ResolvedUrnRange
+from opensiddur.exporter.urn import UrnResolver, ResolvedUrn, ResolvedUrnRange, split_range
 from opensiddur.exporter.refdb import UrnMapping
 
 
@@ -312,6 +312,61 @@ class TestUrnResolverRange(unittest.TestCase):
         
         self.assertEqual(results, [])
 
+    def test_resolve_range_absolute_end(self):
+        """A range from a half-verse to a whole verse, stated absolutely."""
+        def mock_get_urn_mappings(urn, project=None):
+            if urn in ("urn:x-opensiddur:test:bible:nahum/2/2/b",
+                       "urn:x-opensiddur:test:bible:nahum/2/5"):
+                return [make_urn_mapping(project="mam", file_name="nahum.xml", urn=urn, element_type="verse")]
+            return []
+
+        self.mock_db.get_urn_mappings.side_effect = mock_get_urn_mappings
+
+        results = self.resolver.resolve_range("urn:x-opensiddur:test:bible:nahum/2/2/b-/2/5")
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], ResolvedUrnRange)
+        self.assertEqual(results[0].start.urn, "urn:x-opensiddur:test:bible:nahum/2/2/b")
+        self.assertEqual(results[0].end.urn, "urn:x-opensiddur:test:bible:nahum/2/5")
+
+    def test_resolve_range_absolute_end_with_project(self):
+        """The @project suffix lands on both ends of an absolute range."""
+        def mock_get_urn_mappings(urn, project=None):
+            if project == "mam" and urn in (
+                "urn:x-opensiddur:test:bible:nahum/2/2/b",
+                "urn:x-opensiddur:test:bible:nahum/2/5",
+            ):
+                return [make_urn_mapping(project="mam", file_name="nahum.xml", urn=urn, element_type="verse")]
+            return []
+
+        self.mock_db.get_urn_mappings.side_effect = mock_get_urn_mappings
+
+        results = self.resolver.resolve_range("urn:x-opensiddur:test:bible:nahum/2/2/b-/2/5@mam")
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].start.project, "mam")
+        self.assertEqual(results[0].end.project, "mam")
+
+    def test_resolve_range_absolute_end_not_found(self):
+        """An absolute end that no project carries is an empty result, not an exception."""
+        def mock_get_urn_mappings(urn, project=None):
+            if urn == "urn:x-opensiddur:test:bible:nahum/2/2/b":
+                return [make_urn_mapping(project="mam", file_name="nahum.xml", urn=urn, element_type="verse")]
+            return []
+
+        self.mock_db.get_urn_mappings.side_effect = mock_get_urn_mappings
+
+        results = self.resolver.resolve_range("urn:x-opensiddur:test:bible:nahum/2/2/b-/2/99")
+
+        self.assertEqual(results, [])
+
+    def test_resolve_range_malformed_range_raises(self):
+        """A relative end deeper than its start is rejected rather than silently missed."""
+        self.mock_db.get_urn_mappings.return_value = []
+
+        with self.assertRaises(ValueError):
+            self.resolver.resolve_range("urn:x-opensiddur:test:bible:nahum/2/2-2/3/a")
+
     def test_resolve_range_not_a_range(self):
         """Test resolving URN without dash calls resolve() and returns results."""
         # Mock database
@@ -397,6 +452,79 @@ class TestUrnResolverRange(unittest.TestCase):
         # Verify resolve() was called
         mock_resolve.assert_called_once_with("urn:x-opensiddur:text:some-book/1")
         self.assertEqual(result, expected_result)
+
+
+class TestSplitRange(unittest.TestCase):
+    """Test the range notation itself, without a database behind it."""
+
+    BASE = "urn:x-opensiddur:test:bible:"
+
+    def assertSplits(self, ranged: str, start: str, end: str):
+        self.assertEqual(
+            split_range(self.BASE + ranged),
+            (self.BASE + start, self.BASE + end),
+            f"splitting {ranged!r}",
+        )
+
+    def test_relative_end_single_component(self):
+        self.assertSplits("genesis/1/1-2", "genesis/1/1", "genesis/1/2")
+
+    def test_relative_end_multi_component(self):
+        self.assertSplits("genesis/1/1-2/3", "genesis/1/1", "genesis/2/3")
+
+    def test_relative_end_at_chapter_level(self):
+        self.assertSplits("genesis/1-2", "genesis/1", "genesis/2")
+
+    def test_relative_end_between_half_verses(self):
+        """Both ends below the verse, at the same depth, so the relative form reaches."""
+        self.assertSplits("nahum/2/2/b-2/3/a", "nahum/2/2/b", "nahum/2/3/a")
+
+    def test_relative_end_between_verse_parts(self):
+        self.assertSplits(
+            "exodus/34/6/adonai_adonai-34/7/venakeh",
+            "exodus/34/6/adonai_adonai",
+            "exodus/34/7/venakeh",
+        )
+
+    def test_absolute_end_from_half_verse_to_whole_verse(self):
+        """The ends are at different depths, which only the absolute form can state."""
+        self.assertSplits("nahum/2/2/b-/2/5", "nahum/2/2/b", "nahum/2/5")
+
+    def test_absolute_end_from_verse_to_whole_chapter(self):
+        self.assertSplits("genesis/1/1-/3", "genesis/1/1", "genesis/3")
+
+    def test_absolute_end_from_verse_to_half_verse(self):
+        self.assertSplits("nahum/2/2-/2/3/a", "nahum/2/2", "nahum/2/3/a")
+
+    def test_absolute_end_deeper_than_start(self):
+        """Relative notation cannot reach downward; absolute notation can."""
+        self.assertSplits("genesis/1-/2/3", "genesis/1", "genesis/2/3")
+
+    def test_not_a_range(self):
+        self.assertIsNone(split_range(self.BASE + "genesis/1/1"))
+
+    def test_dash_in_the_work_component_is_not_a_range(self):
+        """'x-opensiddur' and a hyphenated book name both live in component 0."""
+        self.assertIsNone(split_range("urn:x-opensiddur:text:some-book/1"))
+        self.assertIsNone(split_range("urn:x-opensiddur:test:doc"))
+
+    def test_relative_end_deeper_than_start_raises(self):
+        """The case that used to build a URN with the scheme sliced off it."""
+        with self.assertRaises(ValueError) as caught:
+            split_range(self.BASE + "nahum/2/2-2/3/a")
+        self.assertIn("-/2/3/a", str(caught.exception))
+
+    def test_missing_end_raises(self):
+        with self.assertRaises(ValueError):
+            split_range(self.BASE + "genesis/1/1-")
+
+    def test_missing_start_raises(self):
+        with self.assertRaises(ValueError):
+            split_range(self.BASE + "genesis/1/-2")
+
+    def test_empty_component_in_absolute_end_raises(self):
+        with self.assertRaises(ValueError):
+            split_range(self.BASE + "genesis/1/1-//3")
 
 
 class TestUrnResolverGetPathFromUrn(unittest.TestCase):

--- a/opensiddur/tests/exporter/test_validate_urn_references.py
+++ b/opensiddur/tests/exporter/test_validate_urn_references.py
@@ -12,6 +12,7 @@ from opensiddur.exporter.refdb import ReferenceDatabase
 from opensiddur.exporter.validate_urn_references import (
     UnresolvableUrnReference,
     _format_failure,
+    find_coarsened_urn_references,
     main,
     validate_project_urn_references,
 )
@@ -303,6 +304,87 @@ class TestValidateUrnReferences(unittest.TestCase):
             "proj1/a.xml: /TEI/text/body/ptr[1] @target=urn:x-opensiddur:test:missing",
         )
 
+
+
+class TestCoarsenedUrnReferences(unittest.TestCase):
+    """A reference to a division a project does not carry still resolves, one level up."""
+
+    VERSE = "urn:x-opensiddur:text:bible:genesis/1/31"
+
+    def _project_referring_to(self, base: Path, target: str) -> Path:
+        xml = etree.Element(f"{{{TEI_NS}}}TEI", nsmap=NSMAP)
+        text = etree.SubElement(xml, f"{{{TEI_NS}}}text")
+        body = etree.SubElement(text, f"{{{TEI_NS}}}body")
+        etree.SubElement(body, f"{{{JLPTEI_NS}}}transclude", target=target)
+        return _write_project_xml(base, "humash", "a.xml", xml)
+
+    def test_reports_a_half_verse_no_project_carries(self):
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            self._project_referring_to(base, f"{self.VERSE}/b")
+
+            db_path = base / "ref.db"
+            _add_urn_mapping(db_path, "jps1917", "genesis.xml", self.VERSE)
+
+            coarsened = find_coarsened_urn_references(
+                "humash", project_directory=base, reference_db_path=db_path
+            )
+
+            self.assertEqual(len(coarsened), 1)
+            self.assertEqual(coarsened[0].urn, f"{self.VERSE}/b")
+            self.assertEqual(coarsened[0].resolves_as, self.VERSE)
+
+    def test_says_nothing_when_the_reference_resolves_as_written(self):
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            self._project_referring_to(base, f"{self.VERSE}/b")
+
+            db_path = base / "ref.db"
+            _add_urn_mapping(db_path, "mam", "genesis.xml", f"{self.VERSE}/b")
+
+            self.assertEqual(
+                find_coarsened_urn_references(
+                    "humash", project_directory=base, reference_db_path=db_path
+                ),
+                [],
+            )
+
+    def test_says_nothing_when_neither_the_reference_nor_its_container_resolves(self):
+        """That is an unresolvable reference, which the other check reports."""
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            self._project_referring_to(base, f"{self.VERSE}/b")
+
+            db_path = base / "ref.db"
+            _add_urn_mapping(db_path, "mam", "exodus.xml", "urn:x-opensiddur:text:bible:exodus/1/1")
+
+            self.assertEqual(
+                find_coarsened_urn_references(
+                    "humash", project_directory=base, reference_db_path=db_path
+                ),
+                [],
+            )
+
+    def test_reports_a_range_whose_ends_are_both_below_the_verse(self):
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            self._project_referring_to(
+                base, "urn:x-opensiddur:text:bible:nahum/2/2/b-2/3/a"
+            )
+
+            db_path = base / "ref.db"
+            for urn in ("urn:x-opensiddur:text:bible:nahum/2/2",
+                        "urn:x-opensiddur:text:bible:nahum/2/3"):
+                _add_urn_mapping(db_path, "jps1917", "nahum.xml", urn)
+
+            coarsened = find_coarsened_urn_references(
+                "humash", project_directory=base, reference_db_path=db_path
+            )
+
+            self.assertEqual(len(coarsened), 1)
+            self.assertEqual(
+                coarsened[0].resolves_as, "urn:x-opensiddur:text:bible:nahum/2/2-/2/3"
+            )
 
 
 if __name__ == "__main__":

--- a/opensiddur/tests/importer/humash/test_build.py
+++ b/opensiddur/tests/importer/humash/test_build.py
@@ -274,9 +274,15 @@ class TestHaftarahFile(unittest.TestCase):
         self.assertEqual(len(opened), 4)  # the annual one, and one per year
         self.assertEqual(sorted(opened), sorted(closed))
 
-    def test_a_boundary_inside_a_verse_reads_the_whole_verse_and_says_where_to_stop(self):
+    def test_a_boundary_inside_a_verse_is_transcluded_and_said(self):
+        """Emor's third-year haftarah runs from Nachum 2:2b to 2:3a.
+
+        The transclusion now stops where the reading stops, and the instruction beside it
+        stays: a volume whose text comes from a project that marks no half-verses falls back
+        on the whole verse, and there the printed instruction is all a reader has.
+        """
         tree = self._tree("emor", {
-            3: _passage("nahum", (2, 2), (2, 3), start_half="b", end_half="a"),
+            3: _passage("nahum", (2, 2, "b"), (2, 3, "a")),
         })
         division = tree.findall(f".//{TEI}div[@n='triennial_3']")[0]
         self.assertEqual(
@@ -285,7 +291,16 @@ class TestHaftarahFile(unittest.TestCase):
         )
         self.assertEqual(
             division.find(f"{J}transclude").get("target"),
-            "urn:x-opensiddur:text:bible:nahum/2/2-2/3",
+            "urn:x-opensiddur:text:bible:nahum/2/2/b-2/3/a",
+        )
+
+    def test_a_range_from_a_half_verse_to_a_whole_verse_is_stated_absolutely(self):
+        """A relative range end always lands at the start's depth, so it cannot say this."""
+        tree = self._tree("emor", {3: _passage("nahum", (2, 2, "b"), (2, 5))})
+        division = tree.findall(f".//{TEI}div[@n='triennial_3']")[0]
+        self.assertEqual(
+            division.find(f"{J}transclude").get("target"),
+            "urn:x-opensiddur:text:bible:nahum/2/2/b-/2/5",
         )
 
 

--- a/opensiddur/tests/importer/humash/test_readings.py
+++ b/opensiddur/tests/importer/humash/test_readings.py
@@ -195,10 +195,14 @@ class TestTriennialHaftarot(unittest.TestCase):
             [("isaiah 54:1", "isaiah 54:10"), ("isaiah 53:1", "isaiah 53:2")],
         )
 
-    def test_a_half_verse_boundary_reads_the_whole_verse_and_says_so(self):
+    def test_a_half_verse_boundary_is_kept_on_the_reference(self):
+        """The Tanakh projects mark the etnachta, so "30:1b" names a point a URN can reach."""
         span = self.haftarot["tazria"][2].spans[0]
-        self.assertEqual((str(span.start), str(span.end)), ("jeremiah 30:1", "jeremiah 30:9"))
+        self.assertEqual((str(span.start), str(span.end)), ("jeremiah 30:1b", "jeremiah 30:9a"))
         self.assertEqual((span.start_half, span.end_half), ("b", "a"))
+        self.assertEqual(
+            span.start.urn, "urn:x-opensiddur:text:bible:jeremiah/30/1/b"
+        )
 
     def test_a_parshah_read_alone_in_two_years_has_only_those(self):
         self.assertEqual(sorted(self.haftarot["tazria"]), [1, 2])

--- a/opensiddur/tests/importer/wlc/test_wlc.py
+++ b/opensiddur/tests/importer/wlc/test_wlc.py
@@ -74,6 +74,7 @@ class TestWLCPathFunctions(unittest.TestCase):
 class TestWLCMain(unittest.TestCase):
     """Test the main function that orchestrates the WLC transformation"""
     
+    @patch('opensiddur.importer.wlc.wlc.add_subverse_milestones_to_file')
     @patch('opensiddur.importer.wlc.wlc.validate')
     @patch('opensiddur.importer.wlc.wlc.os.listdir')
     @patch('opensiddur.importer.wlc.wlc.xslt_transform')
@@ -85,7 +86,8 @@ class TestWLCMain(unittest.TestCase):
         mock_get_xslt_dir,
         mock_xslt_transform,
         mock_listdir,
-        mock_validate
+        mock_validate,
+        mock_add_subverse,
     ):
         """Test that main transforms index and books, then validates all output files"""
         
@@ -184,7 +186,17 @@ class TestWLCMain(unittest.TestCase):
         
         # Verify validate was called for each file
         self.assertEqual(mock_validate.call_count, 4)
-    
+
+        # Every transformed book gets its sub-verse milestones; the index has no verses.
+        self.assertEqual(
+            mock_add_subverse.call_args_list,
+            [
+                call(mock_project_dir / book, language="he", project="wlc")
+                for book in ("genesis.xml", "exodus.xml", "leviticus.xml")
+            ],
+        )
+
+    @patch('opensiddur.importer.wlc.wlc.add_subverse_milestones_to_file')
     @patch('opensiddur.importer.wlc.wlc.validate')
     @patch('opensiddur.importer.wlc.wlc.os.listdir')
     @patch('opensiddur.importer.wlc.wlc.xslt_transform')
@@ -196,7 +208,8 @@ class TestWLCMain(unittest.TestCase):
         mock_get_xslt_dir,
         mock_xslt_transform,
         mock_listdir,
-        mock_validate
+        mock_validate,
+        mock_add_subverse,
     ):
         """Test that main handles validation errors gracefully"""
         

--- a/opensiddur/tests/schema/test_jlptei_odd.py
+++ b/opensiddur/tests/schema/test_jlptei_odd.py
@@ -67,6 +67,18 @@ class TestJlpteiOddConstraints(unittest.TestCase):
         )
         self.assertTrue(reports, "Expected a schematron report for duplicate @corresp")
 
+    def test_subverse_constraints_exist(self):
+        """The two sub-verse units are constrained, not merely allowed."""
+        asserts = self.tree.xpath(
+            "//tei:constraintSpec[@ident='subverse-constraints']//sch:assert/@test",
+            namespaces=self.ns,
+        )
+        self.assertIn("@n = 'a' or @n = 'b'", asserts)
+        self.assertTrue(
+            any("ends-with(@corresp" in a for a in asserts),
+            "Expected @n and @corresp to be checked against each other",
+        )
+
     def test_edition_verse_milestone_must_not_carry_a_urn(self):
         """unit='edition-verse' records an edition's own numbering, never an identity."""
         asserts = self.tree.xpath(
@@ -76,3 +88,85 @@ class TestJlpteiOddConstraints(unittest.TestCase):
         self.assertIn("not(@corresp)", asserts)
         self.assertIn("@n", asserts)
 
+
+
+class TestSubverseValidation(unittest.TestCase):
+    """The compiled schema's behaviour on sub-verse milestones, not just the ODD's wording.
+
+    Requires the compiled schema artifacts (`bash scripts/build-schema.sh`).
+    """
+
+    SKELETON = (
+        '<tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0"'
+        ' xmlns:j="http://jewishliturgy.org/ns/jlptei/2" xml:lang="he">'
+        "<tei:teiHeader><tei:fileDesc>"
+        '<tei:titleStmt><tei:title type="main" xml:lang="en">t</tei:title></tei:titleStmt>'
+        "<tei:publicationStmt><tei:distributor>d</tei:distributor></tei:publicationStmt>"
+        "<tei:sourceDesc><tei:bibl><tei:title>s</tei:title></tei:bibl></tei:sourceDesc>"
+        "</tei:fileDesc></tei:teiHeader>"
+        '<tei:text xml:lang="he"><tei:body><tei:p>{body}</tei:p></tei:body></tei:text>'
+        "</tei:TEI>"
+    )
+    VERSE = "urn:x-opensiddur:text:bible:nahum/2/2"
+
+    def assertValidity(self, valid: bool, body: str, message: str):
+        from opensiddur.importer.util.validation import validate
+
+        is_valid, errors = validate(self.SKELETON.format(body=body))
+        self.assertEqual(is_valid, valid, f"{message}\n{errors if is_valid != valid else ''}")
+
+    def test_a_well_formed_half_verse_validates(self):
+        for n in ("a", "b"):
+            with self.subTest(n):
+                self.assertValidity(
+                    True,
+                    f'<tei:milestone unit="half-verse" n="{n}" corresp="{self.VERSE}/{n}"/>x',
+                    f"half-verse {n} should validate",
+                )
+
+    def test_a_half_verse_numbered_anything_else_is_rejected(self):
+        self.assertValidity(
+            False,
+            f'<tei:milestone unit="half-verse" n="c" corresp="{self.VERSE}/c"/>x',
+            "a verse has two halves, not a third",
+        )
+
+    def test_a_half_verse_whose_n_and_urn_disagree_is_rejected(self):
+        self.assertValidity(
+            False,
+            f'<tei:milestone unit="half-verse" n="a" corresp="{self.VERSE}/b"/>x',
+            "@n and the last component of @corresp must agree",
+        )
+
+    def test_a_sub_verse_milestone_without_a_urn_is_rejected(self):
+        """A division nothing can refer to is the one thing these must never be."""
+        for unit, n in (("half-verse", "a"), ("verse-part", "tzapeh")):
+            with self.subTest(unit):
+                self.assertValidity(
+                    False, f'<tei:milestone unit="{unit}" n="{n}"/>x', f"{unit} needs @corresp"
+                )
+
+    def test_a_well_formed_verse_part_validates(self):
+        self.assertValidity(
+            True,
+            f'<tei:milestone unit="verse-part" n="tzapeh" corresp="{self.VERSE}/tzapeh"/>x',
+            "a named verse part should validate",
+        )
+
+    def test_a_verse_part_named_with_a_dash_is_rejected(self):
+        """A dash in the last component of a URN is what marks a range."""
+        self.assertValidity(
+            False,
+            f'<tei:milestone unit="verse-part" n="a_b" corresp="{self.VERSE}/a-b"/>x',
+            "a verse part name may not contain a dash",
+        )
+
+    def test_a_verse_part_may_not_be_named_a_or_b(self):
+        """Those are reserved for the accentual halves."""
+        for name in ("a", "b"):
+            with self.subTest(name):
+                self.assertValidity(
+                    False,
+                    f'<tei:milestone unit="verse-part" n="{name}" corresp="{self.VERSE}/{name}"/>x',
+                    f"{name!r} is reserved",
+                )

--- a/schema/JLPTEI-3.md
+++ b/schema/JLPTEI-3.md
@@ -188,6 +188,73 @@ only at `@corresp` — ignore it entirely. Which numbering a reader sees is a re
   divergence, not something to be shifted into alignment.
 - `opensiddur/exporter/validate_versification.py` checks both of these across the Tanakh projects.
 
+### Sub-verse scope
+
+Liturgy quotes less than a verse constantly. Kiddush opens on the second half of Genesis 1:31;
+the third-year haftarah of Emor runs from Nachum 2:2b to 2:3a; the Thirteen Attributes begin
+partway through Exodus 34:6 and stop partway through 34:7. A verse URN cannot say any of that,
+and `tei:anchor` does not reach — anchored points have no canonical references.
+
+Two milestone units divide a verse. Each hangs its URN one path component below the verse's, so
+no new URN grammar is needed: `urn:x-opensiddur:text:bible:genesis/1/31/b` is an ordinary URN
+one level deeper.
+
+| unit | `@corresp` | `@n` | placed |
+|---|---|---|---|
+| `half-verse` | verse URN + `/a` or `/b` | `a` or `b` | from the accents, mechanically |
+| `verse-part` | verse URN + `/<name>` | the name | from a declared table |
+
+```xml
+<tei:milestone unit="verse" n="31" corresp="urn:x-opensiddur:text:bible:genesis/1/31"/>
+<tei:milestone unit="half-verse" n="a" corresp="urn:x-opensiddur:text:bible:genesis/1/31/a"/>
+וַיַּרְא אֱלֹהִים אֵת כׇּל אֲשֶׁר עָשָׂה וְהִנֵּה טוֹב מְאֹ֑ד
+<tei:milestone unit="half-verse" n="b" corresp="urn:x-opensiddur:text:bible:genesis/1/31/b"/>
+וַיְהִי עֶרֶב וַיְהִי בֹקֶר
+<tei:milestone unit="verse-part" n="yom_hashishi"
+               corresp="urn:x-opensiddur:text:bible:genesis/1/31/yom_hashishi"/>
+יוֹם הַשִּׁשִּׁי׃
+```
+
+**A half-verse is the accentual division of the verse**, at the etnachta: `a` from the head of
+the verse to the accent inclusive, `b` from the next word to the end. This is what a citation
+means by "2:2b", and because it is read off the text it needs no curation — every accented
+Hebrew Tanakh project carries it on every verse that has one.
+
+**A verse-part is any other break**, at a word boundary the accents do not mark. It is named by
+the transliterated first word of the part, exactly as a division of a poem is
+(`yonah_matzah/hayom` above), and the name **may not contain `-`**, which marks a range. Parts
+cannot be derived, so they are declared in `opensiddur/common/subverse.py` and every Tanakh
+importer places them. Because a part's scope runs to the next sub-verse milestone, a passage
+that stops in the middle of a verse needs a part declared where the *remainder* begins too:
+`exodus/34/7/lo_yenakeh` exists so that `exodus/34/7/venakeh` ends where the recitation does.
+
+The two units are separate unit-spaces and neither ends the other's scope: the Thirteen
+Attributes close one word past the etnachta of Exodus 34:7, so a named part really does straddle
+the accentual boundary. Neither ends the verse containing it either.
+
+#### What sub-verse URNs do not cover
+
+- **A break inside a word or inside a maqqef-joined unit.** The words a maqqef joins are read as
+  one, and nothing may be placed between them.
+- **A break inside a `tei:choice`.** A ketiv and a qere are two readings of one word, not two
+  words. A boundary at the *head* of a choice is fine — the milestone goes before the element.
+- **A verse whose division differs by variant.** Exodus 20:2 has its etnachta in one place under
+  ta'am tachton and another under ta'am elyon, so it has no one accentual division and gets no
+  halves. A URN must denote the same words wherever it resolves.
+- **A verse with no etnachta**, which simply has no halves. Declare a verse-part if such a verse
+  ever needs a break.
+- **Psalms, Proverbs and Job where ole-we-yored governs.** There the etnachta is not the primary
+  division, so verses carrying an ole are left undivided rather than divided at the wrong point.
+
+**A project need not carry them.** A translation has no accents and can place no half-verses. A
+reference to a division a project lacks resolves to the division containing it — the whole verse
+— so the compiled text covers more than the reference asks for. That is deliberate, and it is
+the behaviour there was before sub-verse URNs existed; what is new is that it is never silent.
+The compiler logs it and `opensiddur/exporter/validate_urn_references.py` reports every such
+reference ahead of a build. Where a reading is printed for a human, keep the instruction beside
+the text as well ("מתחילים מאמצע הפסוק"): in a volume set from a project with no half-verses, it
+is the only thing that says where to stop.
+
 #### Contributors and contributor URNs
 Contributions are credited in the file header using `tei:respStmt` entries, with a contributor URN stored in `tei:name/@ref`.
 
@@ -574,7 +641,31 @@ Two types of inclusions are supported. The intended type is indicated by the `ty
 `target` attributes may reference ranges, such as `urn:x-opensiddur:text:bible:genesis/1/1-1/3`, as long as the reference
 does not cross hierarchical boundaries or files. The refererence may entirely contain XML hierarchy or other files.
 
-Note for range references that the start of the range is interpreted at the same hierarchical level as the end of the range. In the example above `1/1` refers to chapter 1, verse 1 and `1/3` therefore refers to chapter 1, verse 3. The following is illegal: `urn:x-opensiddur:text:bible:genesis/1-2/3`. If you want to express "from chapter 1 to chapter 2, verse 3", the correct reference would be: `urn:x-opensiddur:text:bible:genesis/1/1-2/3`.
+A range is written `START-END`, and the end has two forms.
+
+**Relative** — an end that does not begin with `/` replaces that many trailing components of the
+start, which leaves it at the start's own level. In
+`urn:x-opensiddur:text:bible:genesis/1/1-2/3`, `1/1` is chapter 1, verse 1 and `2/3` is
+therefore chapter 2, verse 3.
+
+**Absolute** — an end that begins with `/` replaces the whole path below the namespace-and-work
+component, so the two ends need not sit at the same level:
+
+| range | means |
+|---|---|
+| `…:genesis/1/1-2` | Genesis 1:1 through 1:2 |
+| `…:genesis/1/1-2/3` | Genesis 1:1 through 2:3 |
+| `…:nahum/2/2/b-2/3/a` | the second half of Nahum 2:2 through the first half of 2:3 |
+| `…:nahum/2/2/b-/2/5` | the second half of Nahum 2:2 through the end of 2:5 |
+| `…:genesis/1/1-/3` | Genesis 1:1 through the end of chapter 3 |
+
+**Use the absolute form whenever the two ends are at different levels.** The relative form
+cannot express that and will name a different point instead: `…:nahum/2/2/b-2/5` reads as
+"Nahum 2:2, half 5", not "Nahum 2:2b through 2:5". A relative end *deeper* than the start it
+replaces — `…:nahum/2/2-2/3/a` — is rejected outright; state it as `…:nahum/2/2-/2/3/a`.
+
+Since the absolute form keeps the start's namespace-and-work component, neither form can cross
+works, which is what keeps a range inside one file.
 
 ### Annotations
 

--- a/schema/jlptei.odd.xml
+++ b/schema/jlptei.odd.xml
@@ -586,6 +586,43 @@
             </sch:rule>
           </constraint>
         </constraintSpec>
+        <constraintSpec ident="subverse-constraints" scheme="schematron">
+          <desc>
+            The two sub-verse units divide a verse and hang their URN one component below it.
+          </desc>
+          <constraint>
+            <sch:rule context="tei:milestone[@unit = 'half-verse']"
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+              <sch:assert test="@n = 'a' or @n = 'b'">
+                A milestone with unit="half-verse" must carry @n of "a" or "b": a verse has a
+                first half and a second, divided at the etnachta.
+              </sch:assert>
+              <sch:assert test="@corresp">
+                A milestone with unit="half-verse" must carry @corresp. A half no URN names
+                is a division nothing can refer to, which is the whole point of marking it.
+              </sch:assert>
+              <sch:assert test="not(@corresp) or ends-with(@corresp, concat('/', @n))">
+                A half-verse's @corresp must be the verse's URN with "/a" or "/b" after it,
+                matching @n.
+              </sch:assert>
+            </sch:rule>
+            <sch:rule context="tei:milestone[@unit = 'verse-part']"
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+              <sch:assert test="@corresp">
+                A milestone with unit="verse-part" must carry @corresp.
+              </sch:assert>
+              <sch:assert test="not(@corresp) or not(contains(tokenize(@corresp, '/')[last()], '-'))">
+                A verse part's name may not contain "-": a dash in the last component of a
+                URN is what marks a range. Transliterations use "_".
+              </sch:assert>
+              <sch:assert test="not(@corresp) or (tokenize(@corresp, '/')[last()] != 'a'
+                                                 and tokenize(@corresp, '/')[last()] != 'b')">
+                "a" and "b" are reserved for the accentual halves; a verse part must be named
+                for the word it begins on.
+              </sch:assert>
+            </sch:rule>
+          </constraint>
+        </constraintSpec>
     </elementSpec>
 
     </schemaSpec>


### PR DESCRIPTION
Closes #64. Regenerated projects: opensiddur/opensiddur-projects#13.

A URN reached no further than a whole verse, so a reading that begins or ends inside one could
not be said. The humash carried the mark and printed an instruction beside a transclusion of the
**whole** verse: a reader following the page read correctly, a machine consuming the URN
over-read by half a verse, silently.

The gap is wider than the three haftarot in the issue. Kiddush opens on the second half of
Genesis 1:31; the Thirteen Attributes begin at the second יהוה of Exodus 34:6 — three words
before its etnachta — and end one word past the etnachta of 34:7.

## The mechanism

No URN *grammar* change: a sub-verse point is one more path component under the verse, and
`resolve_range` already splits on `/` generically.

| unit | `@corresp` | placed |
|---|---|---|
| `half-verse` | verse URN + `/a` or `/b` | mechanically, at the etnachta |
| `verse-part` | verse URN + `/<incipit>` | from `VERSE_PARTS`, by declared incipit |

`verse-part` follows the rule JLPTEI-3.md already gives for divisions of a poem. The two cut at
different points — a named part really does straddle the accentual boundary in Exodus 34:7 — so
they are separate unit-spaces and neither ends the other's scope, nor the verse's.

Issue #64's cases, resolved end to end against the reference database:

| URN | text |
|---|---|
| `nahum/2/2/b-2/3/a` | צַפֵּה־דֶרֶךְ … כִּגְאוֹן יִשְׂרָאֵל |
| `kings_1/9/4-/9/5/a` | וְאַתָּה אִם־תֵּלֵךְ … עַל־יִשְׂרָאֵל לְעֹלָם |
| `exodus/34/6/adonai_adonai-34/7/venakeh` | the Thirteen Attributes |
| `genesis/1/31/b` | וַיְהִי־עֶרֶב וַיְהִי־בֹקֶר |

## Absolute range ends

A relative range end replaces trailing components of the start and so always lands at the start's
own depth — it cannot say "from a half-verse to the end of a whole one". An end beginning with
`/` replaces the whole path below the work:

| range | means |
|---|---|
| `…:genesis/1/1-2/3` | Genesis 1:1 through 2:3 — relative, unchanged |
| `…:nahum/2/2/b-2/3/a` | 2:2b through 2:3a — relative, same depth |
| `…:nahum/2/2/b-/2/5` | 2:2b through the end of 2:5 — **absolute** |
| `…:nahum/2/2-2/3/a` | `ValueError`, naming `-/2/3/a` as the fix |

That last one is a pre-existing silent corruption: it built a URN with the scheme sliced off and
resolved to nothing.

## Coverage, stated plainly

JLPTEI-3.md carries the full table. Not covered: a break inside a word, a maqqef-joined unit, or
a `tei:choice`; a verse whose two cantillations divide it differently (Exodus 20:2 has its
etnachta in one place under ta'am elyon and another under ta'am tachton, so there is no one
division a URN could denote); a verse with no etnachta; and verses in Psalms, Proverbs and Job
where ole-we-yored governs, since there the etnachta is not the primary division and dividing
at it would misname the halves.

A project need not carry them at all — a translation has no accents. A reference to a division a
project lacks resolves to the division containing it, which is what happened before any of this;
what is new is that it is never silent. The compiler warns, and `validate_urn_references` reports
every such reference ahead of a build. The printed instruction stays too: in a volume set from a
project with no half-verses it is all a reader has.

## Parallel alignment

Alignment joined on exact URN equality, so an edition dividing the text more finely than the one
beside it put its subdivisions in rows facing empty cells. Rows are now formed at the divisions
both sides carry — decided *before* the split rather than merged after it, since every split
suspends and resumes the structure open across it and those carriers would otherwise fragment a
verse inside its own row.

## Verification

- Full suite: 1594 passed, 12 skipped.
- `validate_versification` OK (same 7 known-unresolved chapters); `validate_urn_references humash`
  clean.
- Emor's parshah and haftarah compile, Hebrew-only and Hebrew/JPS-parallel, identical to a
  pre-change baseline apart from the added milestones. The parallel build keeps the same 304 rows
  and 561 items.
- The humash regenerates byte-identically, as expected: every half-verse reference in the data
  still lies on a span `_without_anchor_verses` drops.

The submodule pointer is deliberately untouched — `RELEASE_PROCEDURE.md` moves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)