### PR TITLE
YAML-customizable formatting for the TeX/PDF exporter

### DIFF
--- a/doc/exporter-settings.example.yaml
+++ b/doc/exporter-settings.example.yaml
@@ -86,7 +86,7 @@ typography:
   # Declare your own and point a style at it by name.
   fonts:
     hebrew: ["Frank Ruehl CLM", "Ezra SIL", "SBL Hebrew", "FreeSerif"]
-    latin: "Linux Libertine O"
+    latin: ["Linux Libertine O", "TeX Gyre Pagella", "FreeSerif"]
 
   page:
     paper: letterpaper       # a4paper | letterpaper | legalpaper | a5paper

--- a/doc/exporter-settings.example.yaml
+++ b/doc/exporter-settings.example.yaml
@@ -72,11 +72,102 @@ declarations:
 
 # Output-format settings consumed by the TeX/PDF stage only.
 typography:
-  hebrew_font: "Frank Ruehl CLM"
-  latin_font: "Linux Libertine O"
-  layout: pairs
-  paper: letterpaper
-  fontsize: "11pt"
+  # Every key below is optional, and every default is what this exporter produced
+  # before any of it was configurable. doc/typography.md is the full reference:
+  # every key, its type, its allowed values, its default and what it affects.
+  #
+  # Every key is also checked. An unknown key, a value outside a closed list, a
+  # malformed length or a font chain with nothing installed is an error naming
+  # the path, raised before anything is rendered.
+
+  # Font families, each a chain tried in order — the first one installed wins,
+  # and none of them being installed is an error rather than a silent fallback.
+  # `latin` and `hebrew` always exist; declaring one replaces its default chain.
+  # Declare your own and point a style at it by name.
+  fonts:
+    hebrew: ["Frank Ruehl CLM", "Ezra SIL", "SBL Hebrew", "FreeSerif"]
+    latin: "Linux Libertine O"
+
+  page:
+    paper: letterpaper       # a4paper | letterpaper | legalpaper | a5paper
+                             # | b5paper | executivepaper | custom
+    orientation: portrait    # portrait | landscape
+    sides: two               # two: margins and running heads mirror between
+                             # recto and verso. one: printed on one side only.
+    chapter_start: recto     # recto: a book opens on a right-hand page
+    base_font_size: "11pt"   # 10pt | 11pt | 12pt — what named sizes scale from
+    # Margins are named for the binding, not the page edge, so they mean the same
+    # on a recto and a verso. Omitted margins keep the document class's own.
+    margins:
+      top: "1in"
+      bottom: "1in"
+      inner: "1.25in"        # at the binding edge
+      outer: "0.9in"         # at the fore edge
+      # binding_offset: "5mm"  # for the part of the page a binding swallows
+
+  paragraphs:
+    indent: "0pt"
+    spacing: "0.5em"
+    line_spacing: 1.0        # 0.5-3.0. Pointed Hebrew wants more than unpointed.
+    alignment: justify       # justify | left | right | center
+
+  # The appearance of each kind of text. Every role takes the same keys — font,
+  # size, weight, style, variant, align, space_before, space_after — and an
+  # omitted one leaves that aspect as the surrounding text has it. Sizes are the
+  # named ladder (xxx-small ... xxxx-large), which follows base_font_size, or an
+  # absolute length like 9pt, which does not.
+  styles:
+    heading1: {size: xx-large, weight: bold, align: center}
+    heading2: {size: x-large, weight: bold, align: center}
+    note: {size: "9pt"}
+    note_mark: {size: xx-small}
+    # ... and body, heading3, heading4, title_main, title_sub, title_alt,
+    # byline, edition, imprint, epigraph, imprimatur, title_page_block,
+    # citation, parsha, aliyah, verse_number, chapter_number, instruction,
+    # line_number, section_separator. See doc/typography.md.
+
+  line_numbers:
+    enabled: true
+    unit: page               # page | section — what numbering restarts at
+    increment: 5             # a number every nth line
+    first: 5                 # so they run 5, 10, 15 rather than 1, 5, 10
+    margin: outer            # inner | outer | left | right
+    separation: "1em"
+    numerals: arabic         # arabic | hebrew
+
+  notes:
+    placement: footnote      # footnote | endnote | none
+    anchor: interlinear      # interlinear: raised above the line and zero-width,
+                             # so the annotated text is not respaced — which is
+                             # what keeps two sides of a parallel text aligned.
+                             # superscript | inline are the alternatives.
+    mark: numeric            # numeric | alpha | roman | symbol
+
+  markers:
+    section_separator: "* * * *"   # between sections that carry no heading
+    verse_numbers: shown           # shown | hidden
+    chapter_numbers: shown
+    # Only conditions the compiler could not decide survive into the output, so a
+    # marker means "say this only if ...". A whole paragraph takes a rule rather
+    # than brackets: brackets several lines apart do not read as a pair.
+    conditional:
+      inline_open: "["
+      inline_close: "]"
+      block: rule                  # rule | brackets | none
+      rule_width: "25%"
+      rule_thickness: "0.4pt"
+
+  parallel:
+    layout: pairs            # pairs: two columns on a page. pages: facing pages,
+                             # which gives each text a full measure.
+    column_width: "43%"      # of the text block; the gap takes the remainder,
+                             # which is also what leaves room for line numbers
+    column_position: center  # left | center | right
+    # Which text goes on which side is `parallel.column_order` above, not here.
+
+  table_of_contents:
+    enabled: false
+    depth: 4                 # 1-4; independent of the PDF bookmark depth
 
   # Running heads and feet. Omit both sections to leave the book class's own
   # page style alone.

--- a/doc/humash-settings.example.yaml
+++ b/doc/humash-settings.example.yaml
@@ -89,7 +89,7 @@ declarations:
 typography:
   fonts:
     hebrew: ["Frank Ruehl CLM", "Ezra SIL", "SBL Hebrew", "FreeSerif"]
-    latin: "Linux Libertine O"
+    latin: ["Linux Libertine O", "TeX Gyre Pagella", "FreeSerif"]
   page:
     paper: letterpaper
     base_font_size: "11pt"

--- a/doc/humash-settings.example.yaml
+++ b/doc/humash-settings.example.yaml
@@ -87,11 +87,14 @@ declarations:
   # cycle year in the margin.
 
 typography:
-  hebrew_font: "Frank Ruehl CLM"
-  latin_font: "Linux Libertine O"
-  layout: pairs
-  paper: letterpaper
-  fontsize: "11pt"
+  fonts:
+    hebrew: ["Frank Ruehl CLM", "Ezra SIL", "SBL Hebrew", "FreeSerif"]
+    latin: "Linux Libertine O"
+  page:
+    paper: letterpaper
+    base_font_size: "11pt"
+  parallel:
+    layout: pairs
 
   # Running heads and feet. `all` puts the same content on every page; use `odd`
   # and `even` instead to differentiate them. `left`, `center` and `right` are

--- a/doc/typography.md
+++ b/doc/typography.md
@@ -74,6 +74,15 @@ typography:
     note-sans: ["DejaVu Sans"]                                           # your own
 ```
 
+**Only a chain you write is checked.** The two defaults are not: a document that asked for
+nothing must still export on a machine that does not have this project's house fonts, so the
+renderer falls back for them on its own. Writing a chain down — even one whose names happen to
+be the defaults — opts it into the check.
+
+That makes a one-name chain a deliberate assertion: name a single font and a machine without it
+fails the build rather than quietly substituting another. Give the chain a widely available last
+resort, as the default `hebrew` chain ends in `FreeSerif`, if you would rather it degrade.
+
 The check needs `fontconfig` (`fc-list`). On a machine without it the check is skipped and the
 chain is handed to the renderer to resolve at build time instead.
 

--- a/doc/typography.md
+++ b/doc/typography.md
@@ -1,0 +1,305 @@
+# Typography settings
+
+Everything about how an exported document looks. This is the `typography:` section of a
+settings file, read by the output stage only; the linear-XML compiler ignores it.
+
+**Every setting is optional and every default reproduces the output this exporter has always
+produced.** A settings file with no `typography:` section, or one that sets a single key, gets
+the same document it always got in every other respect.
+
+**Invalid settings fail before anything is rendered.** Unknown keys, values outside a closed
+list, malformed lengths and font chains with nothing installed are all errors naming the
+offending key and its path. Nothing is silently ignored and nothing silently falls back —
+a setting that was quietly dropped would leave a document missing what was asked for, with
+nothing to say why.
+
+Settings are renderer-agnostic: they describe the document, not the commands that typeset it.
+There is no TeX in a settings file, and there is no place to put any.
+
+```yaml
+typography:
+  page:
+    paper: a5paper
+    margins: {inner: 25mm, outer: 18mm}
+  paragraphs:
+    line_spacing: 1.3
+  styles:
+    heading1: {size: x-large, weight: bold, align: center}
+    note: {size: 9pt, weight: normal}
+  line_numbers:
+    enabled: false
+```
+
+## Value types
+
+| Type | Written as | Notes |
+| --- | --- | --- |
+| length | `12pt`, `1.5em`, `25mm`, `0.75in` | Units: `pt`, `bp`, `mm`, `cm`, `in`, `pc`, `em`, `ex`. `em` and `ex` are relative to the font in force where the length is used. |
+| absolute length | `12pt`, `25mm` | The same without `em`/`ex`. Required where the length is itself defining a font size. |
+| percentage | `43%` | Of the enclosing measure. |
+| size | `x-large` or `10pt` | See the ladder below. |
+
+### The size ladder
+
+A named size follows `page.base_font_size`, so raising the document from 11pt to 12pt scales
+every named size with it. An absolute length pins a role to an exact size regardless. Each
+step of the ladder is roughly 1.2 times the one below it.
+
+| Name | Relative size | | Name | Relative size |
+| --- | --- | --- | --- | --- |
+| `xxx-small` | smallest | | `large` | one step up |
+| `xx-small` | | | `x-large` | |
+| `x-small` | | | `xx-large` | |
+| `small` | one step down | | `xxx-large` | |
+| `normal` | the base size | | `xxxx-large` | largest |
+
+## `fonts`
+
+Named font families. Each is a **chain of names tried in order**; the first one installed on
+the machine building the document is used. If none of them is installed, that is an error —
+falling back to whatever the renderer would have picked produces a document that is quietly
+not the one that was asked for, and for Hebrew it is usually one with no vowels or
+cantillation. A bare string is shorthand for a one-name chain.
+
+Two families always exist, because the exporter refers to them by role rather than by name:
+`latin` for Latin-script text and `hebrew` for Hebrew-script text. Declaring one **replaces**
+its default chain rather than extending it. You may declare families of your own and point a
+style at them by name.
+
+```yaml
+typography:
+  fonts:
+    hebrew: ["Frank Ruehl CLM", "Ezra SIL", "SBL Hebrew", "FreeSerif"]   # the default chain
+    latin: "Linux Libertine O"                                           # the default
+    note-sans: ["DejaVu Sans"]                                           # your own
+```
+
+The check needs `fontconfig` (`fc-list`). On a machine without it the check is skipped and the
+chain is handed to the renderer to resolve at build time instead.
+
+## `page`
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `page.paper` | `a4paper` \| `letterpaper` \| `legalpaper` \| `a5paper` \| `b5paper` \| `executivepaper` \| `custom` | `letterpaper` | Sheet size. |
+| `page.width` | absolute length | — | Sheet width. Required with `paper: custom`, an error otherwise. |
+| `page.height` | absolute length | — | Sheet height. Same. |
+| `page.orientation` | `portrait` \| `landscape` | `portrait` | |
+| `page.sides` | `one` \| `two` | `two` | `two` mirrors margins and running heads between recto and verso. |
+| `page.chapter_start` | `recto` \| `any` | `recto` | `recto` opens each book on a right-hand page, inserting a blank if needed. |
+| `page.base_font_size` | `10pt` \| `11pt` \| `12pt` | `11pt` | The size named sizes are relative to. Only these three exist; anything else would silently become one of them. |
+
+### `page.margins`
+
+Every margin defaults to the document class's own, which is what the exporter produced before
+margins were configurable. Margins are named for the **binding**, not for the page edge, so
+`inner` and `outer` mean the same thing on a recto and a verso. On a one-sided document
+`inner` is the left margin and `outer` the right.
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `page.margins.top` | length | class default | Space above the text block. |
+| `page.margins.bottom` | length | class default | Space below the text block. |
+| `page.margins.inner` | length | class default | Margin at the binding edge. |
+| `page.margins.outer` | length | class default | Margin at the fore edge. |
+| `page.margins.binding_offset` | length | class default | Added at the binding edge and taken off the fore edge, for the part of the page a binding swallows. |
+
+## `paragraphs`
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `paragraphs.indent` | length | `0pt` | First-line indent. |
+| `paragraphs.spacing` | length | `0.5em` | Vertical space between paragraphs. |
+| `paragraphs.line_spacing` | number, 0.5–3.0 | `1.0` | Multiple of single spacing. Hebrew with vowels and cantillation needs more leading than unpointed text. |
+| `paragraphs.alignment` | `justify` \| `left` \| `right` \| `center` | `justify` | |
+
+## `styles`
+
+The appearance of each kind of text the exporter distinguishes. Setting one changes only that
+role; the rest keep their defaults.
+
+### Style attributes
+
+Every role takes the same eight keys. All are optional, and an omitted one leaves that aspect
+as the surrounding text has it.
+
+| Key | Type | Effect |
+| --- | --- | --- |
+| `font` | a family declared in `fonts` | Omit to let the text keep the font its script selects. |
+| `size` | size | See the ladder above. |
+| `weight` | `normal` \| `bold` | |
+| `style` | `normal` \| `italic` | |
+| `variant` | `normal` \| `small-caps` | |
+| `align` | `left` \| `right` \| `center` \| `justify` | Physical positions on the page, so they mean the same in a Hebrew and an English stream. Block-level roles only. |
+| `space_before` | length | Vertical space above. Block-level roles only. |
+| `space_after` | length | Vertical space below. Block-level roles only. |
+
+### Roles
+
+| Role | Default | What it sets |
+| --- | --- | --- |
+| `styles.body` | inherits | Ordinary running text. |
+| `styles.heading1` | `xx-large`, bold, centered | Top-level section heading. |
+| `styles.heading2` | `x-large`, bold, centered | Second-level heading. |
+| `styles.heading3` | `large`, bold, centered | Third-level heading. |
+| `styles.heading4` | `normal`, bold, centered | Fourth-level heading; the deepest there is. |
+| `styles.title_main` | `xxxx-large`, bold, centered, `1.5ex` after | The main title on the title page. |
+| `styles.title_sub` | `x-large`, centered, `1.5ex` before | The subtitle. |
+| `styles.title_alt` | `large`, centered, `1ex` after | An alternative title, usually the title in the other language. |
+| `styles.byline` | `large`, centered, `3ex` before | The author/editor line. |
+| `styles.edition` | centered, `2ex` before | The edition statement. |
+| `styles.imprint` | centered, `4ex` before | The publisher/place/date block at the foot of the title page. |
+| `styles.epigraph` | `small`, italic, centered, `2ex` before | An epigraph on the title page. |
+| `styles.imprimatur` | `small`, italic, centered, `2ex` before | An imprimatur or approbation. |
+| `styles.title_page_block` | centered | Any other paragraph on the title page. |
+| `styles.citation` | italic, centered | A scriptural citation on a line of its own, naming where a reading begins or resumes. |
+| `styles.parsha` | `large`, bold | A parsha name, run in at the head of the text it opens. |
+| `styles.aliyah` | bold | An aliyah or maftir marker, inline at the verse it begins on. |
+| `styles.verse_number` | inherits | The verse number at the start of each verse. |
+| `styles.chapter_number` | `large`, bold | The chapter number, inline at the start of a chapter. |
+| `styles.instruction` | bold | An instruction to the reader, in the note apparatus. |
+| `styles.note` | bold | The text of an editorial note. |
+| `styles.note_mark` | `xx-small` | The mark that anchors a note, in the text and where the note is printed. |
+| `styles.line_number` | inherits | Marginal line numbers. |
+| `styles.section_separator` | centered | The separator between unheaded sections. |
+
+## `line_numbers`
+
+Marginal line numbers, as a critical edition uses to cite a passage.
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `line_numbers.enabled` | boolean | `true` | When false no number is printed. The numbering machinery still runs, so cross-references and the apparatus are unaffected. |
+| `line_numbers.unit` | `page` \| `section` | `page` | What numbering restarts at. |
+| `line_numbers.increment` | integer ≥ 1 | `5` | Print a number every nth line. |
+| `line_numbers.first` | integer ≥ 1 | `5` | The first line number printed, so the numbers run 5, 10, 15 rather than 1, 5, 10. |
+| `line_numbers.margin` | `inner` \| `outer` \| `left` \| `right` | `outer` | `inner`/`outer` are relative to the binding; `left`/`right` are fixed. In a `pairs` parallel layout each column takes the nearer outer margin regardless, since the alternative is numbers in the gutter between the columns. |
+| `line_numbers.separation` | length | `1em` | Space between the number and the text block. |
+| `line_numbers.numerals` | `arabic` \| `hebrew` | `arabic` | |
+
+## `notes`
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `notes.placement` | `footnote` \| `endnote` \| `none` | `footnote` | Where the text of a note is printed. `none` drops notes entirely, anchor and all, and is an error if a note style is also set — the two cannot both hold and the one that silently wins deletes the notes. |
+| `notes.anchor` | `interlinear` \| `superscript` \| `inline` | `interlinear` | How the mark that points at a note is set. `interlinear` raises it above the line and gives it no width, so the text it annotates is not respaced — which is what keeps two sides of a parallel text aligned. |
+| `notes.mark` | `numeric` \| `alpha` \| `roman` \| `symbol` | `numeric` | The series marks are drawn from. The symbol series has six members and repeats the symbol past the sixth, as a printed apparatus does. |
+
+There is deliberately no setting for showing the *lemma* — the words a note is attached to,
+repeated where the note is printed. A note anchors at a point rather than over a range, so
+there are no such words: the apparatus entry's lemma is the mark itself, and printing it would
+give "∗ ] ∗ the note text".
+
+## `markers`
+
+The small marks that structure a text without being part of it.
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `markers.section_separator` | text | `* * * *` | Printed between sections that carry no heading. An empty string leaves nothing but the space. |
+| `markers.verse_numbers` | `shown` \| `hidden` | `shown` | |
+| `markers.chapter_numbers` | `shown` \| `hidden` | `shown` | |
+
+### `markers.conditional`
+
+Only conditions the compiler could not decide survive into the output, so a marker means "say
+this only if …", and the reader has to be able to see where the passage starts and stops.
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `markers.conditional.inline_open` | text | `[` | Opens a conditional run inside a paragraph. |
+| `markers.conditional.inline_close` | text | `]` | Closes it. |
+| `markers.conditional.block` | `rule` \| `brackets` \| `none` | `rule` | How a whole conditional paragraph is delimited. Brackets several lines apart do not read as a pair, hence the rule. |
+| `markers.conditional.rule_width` | percentage | `25%` | Width of the rule, as a percentage of the measure. |
+| `markers.conditional.rule_thickness` | length | `0.4pt` | |
+
+## `parallel`
+
+The geometry of a parallel-text layout.
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `parallel.layout` | `pairs` \| `pages` | `pairs` | `pairs` puts two columns on the same page; `pages` sets the texts on facing pages, which gives each a full measure and suits a long work. |
+| `parallel.column_width` | percentage | `43%` | Width of each column as a percentage of the text block, in `pairs` layout. The two columns and the gap share 100%, so well under 50% each — the remainder leaves the outer margins room for line numbers. |
+| `parallel.column_position` | `left` \| `center` \| `right` | `center` | Where the pair of columns sits in the text block, in `pairs` layout. |
+
+**Which text goes on which side is not set here.** It is `parallel.column_order` in the
+compiler section of the settings file — `primary_first` puts the primary stream on the left,
+`primary_last` swaps them — because the compiler is what decides the order the streams are
+emitted in.
+
+## `table_of_contents`
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `table_of_contents.enabled` | boolean | `false` | Print a table of contents. |
+| `table_of_contents.depth` | integer 1–4 | `4` | Heading levels shown. Independent of the PDF bookmark depth, which is always four levels deep. |
+
+## `page_header` and `page_footer`
+
+Running heads and feet. Empty by default, which leaves the document class's own page style
+alone. Each takes either `all` — the same content on every page — or `odd` and/or `even` to
+differentiate them; combining `all` with either is an error.
+
+```yaml
+typography:
+  page_header:
+    odd:
+      left: "{book-title}"                                    # bare string = just text
+      right: {text: "Page {page}", language: en}
+    even:
+      left: {text: "{page-hebrew}", language: he}
+      center: {text: "Chapter {chapter-number}", language: en, if: "{chapter-number}"}
+  page_footer:
+    all:
+      center: "{page}"
+```
+
+`left`, `center` and `right` are *physical* positions on the page, not logical ones: `left` is
+the left edge whichever way the text runs. Each is either a bare string or a mapping with:
+
+- `text` — the template.
+- `language` — the slot's base direction, which decides the order its runs are laid out in,
+  and the font for content that declares nothing else. Defaults to the document's own
+  `xml:lang`; only Hebrew (`he`, `he-*`) versus everything else is distinguished. Every run
+  carries its own direction inside that, so a mixed title like "רות RUTH" reads correctly in a
+  slot of either direction and digits are never reversed.
+- `if` — a second template. When it expands to nothing the whole position is dropped, literal
+  text included, so `"Chapter {chapter-number}"` leaves no orphaned "Chapter" on a page before
+  the first chapter.
+
+Anything outside braces is literal text; `{{` and `}}` are literal braces. The codes are a
+closed list, and an unrecognized one is a settings error:
+
+| Code | Expands to |
+| --- | --- |
+| `{page}` | the page number as the document numbers it (roman in front matter) |
+| `{page-hebrew}` | the page number in Hebrew numerals |
+| `{document-title}` | the title from the TEI header, fixed for the whole document |
+| `{book-title}` | the head of the enclosing `tei:div[@type='book']` |
+| `{chapter-number}` | the `n` of the last `tei:milestone[@unit='chapter']` |
+| `{chapter-number-hebrew}` | the same, in Hebrew numerals |
+| `{head1}` … `{head4}` | the last heading at that level |
+| `{section-title}` | the last heading at any level |
+| `{book-title-alt}`, `{head1-alt}` … `{head4-alt}`, `{section-title-alt}` | the same, from the *second* parallel column |
+
+Everything but `{page}`, `{page-hebrew}` and `{document-title}` names whatever was in force at
+the *end* of the page, so a heading starting partway down a page names that page. The `-alt`
+codes are what let a running head name the second language of a parallel volume; in a
+non-parallel document they expand to nothing.
+
+Title pages never carry a running head or foot, nor do the blank pages inserted to keep a
+title page on a recto.
+
+## How this reaches the renderer
+
+`opensiddur/exporter/typography.py` holds the models above and knows nothing about any
+renderer. `opensiddur/exporter/tex/typography_tex.py` turns a validated settings tree into a
+block of LuaLaTeX, which `tex/reledmac.xslt` emits after all of its own definitions — so the
+stylesheet keeps every default it ever had and the settings override them. A directive is
+emitted only for a setting the file actually wrote, which is what keeps an unconfigured
+document byte-for-byte what it was.
+
+Adding a setting means adding a field to the model, a case to the emitter, a row to this
+document, and a test. `opensiddur/tests/exporter/test_typography_doc.py` fails if the row is
+missing.

--- a/opensiddur/exporter/README.md
+++ b/opensiddur/exporter/README.md
@@ -87,92 +87,55 @@ left column for a `pairs` layout); `primary_last` swaps them.
 
 ### Typography (PDF/TeX stage only)
 
+The `typography` section says how the exported document should look: paper and margins, fonts,
+the size and weight of each kind of text, line spacing, line numbers, how notes are marked,
+running heads. It is read by the PDF/TeX stage only; the linear-XML compiler ignores it.
+
+**[`doc/typography.md`](../../doc/typography.md) is the full reference** — every key, its type,
+its allowed values, its default and what it affects.
+
 ```yaml
 typography:
-  hebrew_font: "Frank Ruehl CLM"     # any installed OpenType font with Hebrew coverage
-  latin_font: "Linux Libertine O"    # any installed OpenType font for the Latin stream
-  layout: pages                      # "pages" → facing pages; "pairs" → two columns/page
-  paper: a4paper                     # any \documentclass paper option
-  fontsize: 11pt                     # 10pt | 11pt | 12pt
+  fonts:
+    hebrew: ["Frank Ruehl CLM", "Ezra SIL", "SBL Hebrew", "FreeSerif"]  # tried in order
+    latin: "Linux Libertine O"
+  page:
+    paper: letterpaper          # a4paper | letterpaper | legalpaper | a5paper | b5paper
+                                # | executivepaper | custom
+    base_font_size: 11pt        # 10pt | 11pt | 12pt
+    sides: two                  # two | one
+    margins: {inner: 1in, outer: 0.75in}
+  paragraphs:
+    line_spacing: 1.0           # 0.5-3.0
+  styles:
+    heading1: {size: xx-large, weight: bold, align: center}
+    note: {size: 9pt}
+  line_numbers:
+    enabled: true
+    increment: 5
+  notes:
+    placement: footnote         # footnote | endnote | none
+    anchor: interlinear         # interlinear | superscript | inline
+  parallel:
+    layout: pairs               # pairs -> two columns/page; pages -> facing pages
   table_of_contents:
-    enabled: false                   # true → print a table of contents page
-    depth: 4                         # 1-4; heading levels shown in the printed TOC
+    enabled: false
+    depth: 4
+  page_header: {}               # running heads; see doc/typography.md
+  page_footer: {}
 ```
 
-The `typography` section is read by the PDF/TeX stage only; the linear-XML
-compiler ignores it. Every key is optional — when the section (or any single
-key) is omitted, the defaults shown above are used. Fonts that aren't found
-on the system fall back to a sensible default automatically (`Ezra SIL` →
-`SBL Hebrew` → `FreeSerif` for Hebrew).
+Every key is optional, and every default reproduces the output this exporter has always
+produced — a settings file need only say what it wants changed.
 
-`table_of_contents.depth` controls only the printed table of contents; it is
-independent of the PDF bookmark/outline depth, which is always 4 levels deep
-regardless of this setting.
+Every key is also *checked*. An unknown key, a value outside a closed list, a malformed length
+or a font chain with nothing installed is an error naming the offending path, raised before
+anything is rendered. Nothing is silently ignored: a setting that was quietly dropped would
+leave a document missing what was asked for with nothing to say why.
 
-### Running heads and feet
-
-`typography.page_header` and `typography.page_footer` put content in the left,
-center and right of each page. Omit them and the book class's own page style is
-left alone.
-
-```yaml
-typography:
-  page_header:
-    odd:
-      left: "{book-title}"                                    # bare string = just text
-      right: {text: "Page {page}", language: en}
-    even:
-      left: {text: "{page-hebrew}", language: he}
-      center: {text: "Chapter {chapter-number}", language: en, if: "{chapter-number}"}
-  page_footer:
-    all:                                                      # same on every page
-      center: "{page}"
-```
-
-Each of `page_header` and `page_footer` takes either `all` — the same content on
-every page — or `odd` and/or `even` to differentiate them. Combining `all` with
-`odd` or `even` is an error.
-
-`left`, `center` and `right` are *physical* positions on the page, not logical
-ones: `left` is the left edge whichever way the text runs.
-
-Each position is either a bare string or a mapping with:
-
-- `text` — the template (see the codes below).
-- `language` — the slot's base direction, which decides the order its runs are
-  laid out in, and the font for content that declares nothing else. Defaults to
-  the document's own `xml:lang`; only Hebrew (`he`, `he-*`) versus everything
-  else is distinguished. Every run — literal text, a heading recorded in a mark,
-  the page number — carries its own direction inside that, so a mixed title like
-  "רות RUTH" reads correctly in a slot of either direction, and digits are never
-  reversed.
-- `if` — a second template. When it expands to nothing, the whole position is
-  dropped, literal text included, so `"Chapter {chapter-number}"` leaves no
-  orphaned "Chapter" on a page before the first chapter.
-
-Anything outside braces is literal text; `{{` and `}}` are literal braces. The
-codes are a closed list, and an unrecognized one is a settings error:
-
-| Code | Expands to |
-| --- | --- |
-| `{page}` | the page number as the document numbers it (roman in front matter) |
-| `{page-hebrew}` | the page number in Hebrew numerals |
-| `{document-title}` | the title from the TEI header, fixed for the whole document |
-| `{book-title}` | the head of the enclosing `tei:div[@type='book']` |
-| `{chapter-number}` | the `n` of the last `tei:milestone[@unit='chapter']` |
-| `{chapter-number-hebrew}` | the same, in Hebrew numerals |
-| `{head1}` … `{head4}` | the last heading at that level |
-| `{section-title}` | the last heading at any level |
-| `{book-title-alt}`, `{head1-alt}` … `{head4-alt}`, `{section-title-alt}` | the same, from the *second* parallel column |
-
-Everything but `{page}`, `{page-hebrew}` and `{document-title}` names whatever
-was in force at the *end* of the page, so a heading starting partway down a page
-names that page. The `-alt` codes are what let a running head name the second
-language of a parallel volume; in a non-parallel document they expand to
-nothing.
-
-Title pages never carry a running head or foot, nor do the blank pages inserted
-to keep a title page on a recto.
+Note that which text goes on which side of a parallel layout is `parallel.column_order` in the
+compiler section above, not in `typography` — the compiler is what decides the order the
+streams are emitted in.
 
 ## Settings file versioning
 Note that this file is likely to change slightly in format as more output

--- a/opensiddur/exporter/settings.py
+++ b/opensiddur/exporter/settings.py
@@ -1,9 +1,8 @@
 """ Exporter settings management utilities. """
 
-from enum import StrEnum
 from pathlib import Path
 from typing import Optional
-from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 import yaml
 
 from opensiddur.exporter.linear import (
@@ -15,7 +14,7 @@ from opensiddur.exporter.linear import (
 from opensiddur.exporter.compiler import CompilerProcessor
 from opensiddur.exporter.conditional_settings import yaml_to_declaration_entries
 from opensiddur.exporter.derived_settings import SettingChangeTrigger, recalculate_derived_settings
-from opensiddur.exporter.tex.running_heads import RunningHeadConfig
+from opensiddur.exporter.typography import TypographyConfig
 from opensiddur.common.constants import PROJECT_DIRECTORY
 
 
@@ -45,6 +44,8 @@ def _apply_project_directory(
 
 
 class Prioritizations(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     transclusion: list[str] = Field(default_factory=list)
     instructions: list[str] = Field(default_factory=list)
 
@@ -59,6 +60,8 @@ class Prioritizations(BaseModel):
         return _validate_project_list(v, _project_directory_from_context(info))
 
 class ParallelConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     projects: list[str] = Field(default_factory=list)
     column_order: ParallelColumnOrder = ParallelColumnOrder.PRIMARY_FIRST
 
@@ -68,61 +71,16 @@ class ParallelConfig(BaseModel):
         return _validate_project_list(v, _project_directory_from_context(info))
 
 
-class ParallelLayout(StrEnum):
-    """ Parallel-text page layout for the TeX/PDF stage.
-
-    pages: facing pages (reledpar \\Pages) — best for full critical editions.
-    pairs: two columns on the same page (reledpar \\Columns) — best for short docs.
-    """
-    PAGES = "pages"
-    PAIRS = "pairs"
-
-
-class PaperType(StrEnum):
-    """LaTeX \\documentclass paper options.
-
-    Keep this intentionally small and conventional; add more as needed.
-    """
-
-    A4PAPER = "a4paper"
-    LETTERPAPER = "letterpaper"
-    LEGALPAPER = "legalpaper"
-    A5PAPER = "a5paper"
-    B5PAPER = "b5paper"
-    EXECUTIVEPAPER = "executivepaper"
-
-
-class TableOfContentsConfig(BaseModel):
-    """ Auto-generated table of contents (PDF/TeX stage only).
-
-    ``depth`` is independent of the PDF bookmark depth, which is always 4
-    levels deep regardless of this setting.
-    """
-    enabled: bool = False
-    depth: int = Field(default=4, ge=1, le=4)
-
-
-class TypographyConfig(BaseModel):
-    """ Output-format settings consumed by the TeX/PDF stage only.
-
-    These don't affect the linear-XML compiler; they're forwarded as XSLT
-    parameters to ``reledmac.xslt``. Defaults match what the in-house LuaLaTeX
-    setup expects on a typical Linux TeXLive install.
-    """
-    hebrew_font: str = "Frank Ruehl CLM"
-    latin_font: str = "Linux Libertine O"
-    layout: ParallelLayout = ParallelLayout.PAIRS
-    paper: PaperType = PaperType.LETTERPAPER
-    fontsize: str = "11pt"
-    table_of_contents: TableOfContentsConfig = Field(default_factory=TableOfContentsConfig)
-    # Running heads and feet. Empty by default, which leaves the book class's
-    # own page style alone. See opensiddur/exporter/tex/running_heads.py for
-    # the closed list of codes a slot may use.
-    page_header: RunningHeadConfig = Field(default_factory=RunningHeadConfig)
-    page_footer: RunningHeadConfig = Field(default_factory=RunningHeadConfig)
-
-
 class SettingsYaml(BaseModel):
+    """ A settings file, whole.
+
+    Unknown keys are refused at every level: a mistyped setting that is quietly
+    ignored produces a document that is missing what was asked for, with nothing
+    to say why.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
     priority: Prioritizations
     annotations: list[str] = Field(default_factory=list)
     parallel: Optional[ParallelConfig] = None

--- a/opensiddur/exporter/tex/escape.py
+++ b/opensiddur/exporter/tex/escape.py
@@ -1,0 +1,25 @@
+""" Escaping literal text for LaTeX.
+
+Shared by everything that puts user-supplied strings — running-head templates,
+section separators, conditional markers — into the emitted document.
+"""
+
+import re
+
+
+# Stands in for a literal backslash while the other specials are escaped, so
+# that the braces of its own replacement text are not escaped in turn. U+0000
+# cannot occur in a YAML scalar, so it can never collide with real input.
+_BACKSLASH_SENTINEL = "\x00"
+
+
+def escape_tex(s: str) -> str:
+    """Escape characters that have special meaning in LaTeX.
+
+    Covers the same characters as ``f:escape-tex`` in ``reledmac.xslt``.
+    """
+    t = s.replace("\\", _BACKSLASH_SENTINEL)
+    t = re.sub(r"([&%$#_{}])", r"\\\1", t)
+    t = t.replace("~", r"\textasciitilde{}")
+    t = t.replace("^", r"\textasciicircum{}")
+    return t.replace(_BACKSLASH_SENTINEL, r"\textbackslash{}")

--- a/opensiddur/exporter/tex/latex.py
+++ b/opensiddur/exporter/tex/latex.py
@@ -28,8 +28,12 @@ sys.path.insert(0, str(project_root))
 
 from opensiddur.common.xslt import xslt_transform_string  # noqa: E402
 from opensiddur.common.constants import PROJECT_DIRECTORY  # noqa: E402
-from opensiddur.exporter.settings import TypographyConfig  # noqa: E402
+from opensiddur.exporter.typography import TypographyConfig  # noqa: E402
 from opensiddur.exporter.tex.running_heads import build_page_style_tex  # noqa: E402
+from opensiddur.exporter.tex.typography_tex import (  # noqa: E402
+    build_typography_preamble,
+    documentclass_options,
+)
 
 XSLT_FILE = Path(__file__).parent / "reledmac.xslt"
 
@@ -358,7 +362,16 @@ def transform_xml_to_tex(
 
     Returns:
         The transformed LaTeX content as a string.
+
+    Raises:
+        pydantic.ValidationError: if the settings file's typography section is
+            invalid. Deliberately outside the catch-all below, whose one-line
+            report would throw away the part of the message that says which
+            setting is wrong and why.
     """
+    if typography is None:
+        typography = load_typography(settings_file)
+
     try:
         with open(input_file, "r", encoding="utf-8") as input_fd:
             input_xml = input_fd.read()
@@ -374,17 +387,21 @@ def transform_xml_to_tex(
         credits_tex = credits_to_tex(group_credits(credits))
         sources_preamble_tex, sources_postamble_tex = extract_sources(file_references)
 
-        if typography is None:
-            typography = load_typography(settings_file)
-
         # Running-head slots that declare no language of their own follow the
         # document's, so their direction is right without being restated.
-        root_language = etree.parse(input_file).getroot().get(
-            "{http://www.w3.org/XML/1998/namespace}lang"
-        )
+        parsed = etree.parse(input_file)
+        root = parsed.getroot()
+        root_language = root.get("{http://www.w3.org/XML/1998/namespace}lang")
         page_style_tex = build_page_style_tex(
             typography.page_header, typography.page_footer, root_language
         )
+        # Several reledpar declarations do not exist unless the package is
+        # loaded, and the stylesheet loads it only for a document with two
+        # aligned streams. The typography block has to know which this is.
+        has_parallel = (
+            root.find(".//{http://jewishliturgy.org/ns/processing}parallel") is not None
+        )
+        typography_tex = build_typography_preamble(typography, has_parallel)
 
         result = xslt_transform_string(
             Path(xslt_file),
@@ -401,11 +418,11 @@ def transform_xml_to_tex(
                     + "\n"
                     + sources_postamble_tex
                 ),
-                "hebrew-font": typography.hebrew_font,
-                "latin-font": typography.latin_font,
-                "layout": typography.layout.value,
-                "paper": typography.paper.value,
-                "fontsize": typography.fontsize,
+                "documentclass-options": documentclass_options(typography),
+                "typography-preamble": typography_tex,
+                "layout": typography.parallel.layout.value,
+                "notes-placement": typography.notes.placement.value,
+                "notes-mark": typography.notes.mark.value,
                 "table-of-contents": typography.table_of_contents.enabled,
                 "table-of-contents-depth": typography.table_of_contents.depth,
                 "page-style-preamble": page_style_tex,

--- a/opensiddur/exporter/tex/reledmac.xslt
+++ b/opensiddur/exporter/tex/reledmac.xslt
@@ -40,12 +40,32 @@
     <xsl:param name="additional-preamble" as="xs:string?"/>
     <xsl:param name="additional-postamble" as="xs:string?"/>
 
-    <!-- Typography (driven by settings.yaml `typography` section) -->
-    <xsl:param name="hebrew-font" as="xs:string">Frank Ruehl CLM</xsl:param>
-    <xsl:param name="latin-font" as="xs:string">Linux Libertine O</xsl:param>
+    <!-- Typography (driven by settings.yaml `typography` section).
+
+         Everything this stylesheet lays out is defined below as a macro or a
+         declaration with the defaults it has always had, so the output is
+         complete and correct with no typography settings at all. The settings
+         reach it two ways:
+
+           $documentclass-options   for the handful of things the class has to
+                                    be told when it is loaded (base font size,
+                                    paper, one- or two-sided);
+           $typography-preamble     a block of \renewcommand and \setlength,
+                                    emitted after every default below, built by
+                                    opensiddur/exporter/tex/typography_tex.py.
+
+         Only the settings that change the *structure* of the emitted document,
+         rather than its appearance, need a parameter of their own — those are
+         the three below the class options. -->
+    <xsl:param name="documentclass-options" as="xs:string">11pt,letterpaper</xsl:param>
+    <xsl:param name="typography-preamble" as="xs:string?"/>
     <xsl:param name="layout" as="xs:string">pages</xsl:param>
-    <xsl:param name="paper" as="xs:string">a4paper</xsl:param>
-    <xsl:param name="fontsize" as="xs:string">11pt</xsl:param>
+    <!-- footnote | endnote | none — where the text of an editorial note goes.
+         `none` drops notes entirely, anchor and all. -->
+    <xsl:param name="notes-placement" as="xs:string">footnote</xsl:param>
+    <!-- numeric | alpha | roman | symbol — the series note marks are drawn
+         from. The serial is known here, so the conversion is done here. -->
+    <xsl:param name="notes-mark" as="xs:string">numeric</xsl:param>
 
     <!-- Auto-generated table of contents (driven by settings.yaml
          `typography.table_of_contents`). Depth is independent of the PDF
@@ -78,9 +98,7 @@
         <xsl:variable name="has-parallel" select="exists(//p:parallel)"/>
 
         <xsl:text>\documentclass[</xsl:text>
-        <xsl:value-of select="$fontsize"/>
-        <xsl:text>,</xsl:text>
-        <xsl:value-of select="$paper"/>
+        <xsl:value-of select="$documentclass-options"/>
         <xsl:text>]{book}&#10;</xsl:text>
 
         <xsl:text>\usepackage{geometry}&#10;</xsl:text>
@@ -89,9 +107,13 @@
         <xsl:text>\setdefaultlanguage{english}&#10;</xsl:text>
         <xsl:text>\setotherlanguage{hebrew}&#10;</xsl:text>
 
-        <!-- Latin font: try the requested one, otherwise let LaTeX pick the default. -->
-        <xsl:text>\IfFontExistsTF{</xsl:text><xsl:value-of select="$latin-font"/><xsl:text>}{&#10;</xsl:text>
-        <xsl:text>  \setmainfont{</xsl:text><xsl:value-of select="$latin-font"/><xsl:text>}&#10;</xsl:text>
+        <!-- The default faces. A settings file that names its own fonts overrides
+             these from $typography-preamble below, where the chain has already
+             been checked against the installed fonts; these are the fallback for
+             a document that asks for nothing. -->
+        <!-- Latin font: try the default, otherwise let LaTeX pick its own. -->
+        <xsl:text>\IfFontExistsTF{Linux Libertine O}{&#10;</xsl:text>
+        <xsl:text>  \setmainfont{Linux Libertine O}&#10;</xsl:text>
         <xsl:text>}{}&#10;</xsl:text>
 
         <!-- Hebrew font: try the requested one, with fallbacks for systems that don't have it.
@@ -99,9 +121,8 @@
         <!-- The Hebrew faces we ship against (Frank Ruehl CLM, Ezra SIL, SBL Hebrew) have
              no bold companion, so \bfseries would silently do nothing and headings would
              be indistinguishable from body text. BoldFont={*},AutoFakeBold synthesizes one. -->
-        <xsl:text>\IfFontExistsTF{</xsl:text><xsl:value-of select="$hebrew-font"/><xsl:text>}{&#10;</xsl:text>
-        <xsl:text>  \newfontfamily\hebrewfont[Renderer=HarfBuzz,Script=Hebrew,BoldFont={*},AutoFakeBold=2]{</xsl:text>
-        <xsl:value-of select="$hebrew-font"/><xsl:text>}&#10;</xsl:text>
+        <xsl:text>\IfFontExistsTF{Frank Ruehl CLM}{&#10;</xsl:text>
+        <xsl:text>  \newfontfamily\hebrewfont[Renderer=HarfBuzz,Script=Hebrew,BoldFont={*},AutoFakeBold=2]{Frank Ruehl CLM}&#10;</xsl:text>
         <xsl:text>}{&#10;</xsl:text>
         <xsl:text>  \IfFontExistsTF{Ezra SIL}{&#10;</xsl:text>
         <xsl:text>    \newfontfamily\hebrewfont[Renderer=HarfBuzz,Script=Hebrew,BoldFont={*},AutoFakeBold=2]{Ezra SIL}&#10;</xsl:text>
@@ -330,10 +351,18 @@
         <xsl:text>\Xinplaceofnumber[B]{0pt}&#10;</xsl:text>
 
         <!-- Line numbers must always be LTR (otherwise RTL contexts can flip digits).
-             reledmac exposes \linenumberstyle; reledpar uses \linenumrepR and a
-             right-side flag.
+             reledpar uses \linenumrepR and a right-side flag, set below.
              Use \hbox to contain direction/language changes without leaking
-             \begingroup/\endgroup into reledmac's aux-file write machinery. -->
+             \begingroup/\endgroup into reledmac's aux-file write machinery.
+
+             NOTE: this line does nothing. \linenumberstyle is a *declaration*
+             whose only job is to define \linenumrep, and reledmac calls it once
+             as it loads, so redefining it afterwards never takes effect — the
+             left-side numbers are still reledmac's own \@arabic. Left as it is
+             rather than corrected here, because correcting it would change the
+             output of every existing document; typography settings that touch
+             line numbers write \linenumrep, which is the macro that is actually
+             consulted (see tex/typography_tex.py). -->
         <xsl:text>\renewcommand*{\linenumberstyle}[1]{\hbox{\textdir TLT\selectlanguage{english}#1}}&#10;</xsl:text>
         <!-- line numbering by page -->
         <xsl:text>\lineation{page}&#10;</xsl:text>
@@ -391,14 +420,50 @@
         <xsl:text>\setlength{\parindent}{0pt}&#10;</xsl:text>
         <xsl:text>\setlength{\parskip}{0.5em}&#10;</xsl:text>
 
+        <!-- Font switches applied to the whole body, from typography.styles.body.
+             Empty unless configured; emitted at the top of the document, where it
+             is in force for everything that follows. -->
+        <xsl:text>\newcommand{\OSBodyStyle}{}&#10;</xsl:text>
+
+        <!-- Separator between sections that carry no heading. Split in two so a
+             settings file can change the mark and its appearance independently. -->
+        <xsl:text>\newcommand{\OSSectionSeparatorStyle}[1]{\begin{center}#1\end{center}}&#10;</xsl:text>
+        <xsl:text>\newcommand{\OSSectionSeparator}{\OSSectionSeparatorStyle{* * * *}}&#10;</xsl:text>
+
+        <xsl:if test="$notes-placement = 'endnote'">
+            <!-- The endnote apparatus is configured separately from the footnote
+                 one above, and needs the same treatment: no line number, and no
+                 repetition of the lemma, which is the raised mark itself and
+                 would print the serial twice. The notes are printed at the end
+                 of the document (see the postamble). -->
+            <xsl:text>\Xendnonumber[B]&#10;</xsl:text>
+            <xsl:text>\Xendlemmaseparator[B]{}&#10;</xsl:text>
+            <xsl:text>\makeatletter&#10;</xsl:text>
+            <xsl:text>\Xendwraplemma[B]{\@gobble}&#10;</xsl:text>
+            <xsl:text>\makeatother&#10;</xsl:text>
+        </xsl:if>
+
+        <!-- Everything the settings file asked for, overriding the defaults above.
+             Empty when it asked for nothing. Last, so that it wins; but before
+             $additional-preamble, which carries the bibliography and is not
+             typography. -->
+        <xsl:value-of select="$typography-preamble"/>
+
         <xsl:value-of select="$additional-preamble"/>
         <xsl:text>&#10;</xsl:text>
 
         <xsl:text>\begin{document}&#10;</xsl:text>
+        <xsl:text>\OSBodyStyle&#10;</xsl:text>
 
         <xsl:apply-templates select="tei:TEI/tei:text"/>
 
         <xsl:text>&#10;</xsl:text>
+        <xsl:if test="$notes-placement = 'endnote'">
+            <!-- Endnotes are collected as the document is typeset and printed
+                 here, after the text and before the metadata appendix. -->
+            <xsl:text>\section*{Notes}&#10;</xsl:text>
+            <xsl:text>\doendnotes{B}&#10;</xsl:text>
+        </xsl:if>
         <!-- Metadata appendix (licenses, credits, sources). -->
         <xsl:value-of select="$additional-postamble"/>
         <xsl:text>&#10;</xsl:text>
@@ -887,7 +952,7 @@
                         <xsl:if test="$in-pstart">
                             <xsl:text>\pend&#10;</xsl:text>
                         </xsl:if>
-                        <xsl:text>\begin{center}* * * *\end{center}&#10;</xsl:text>
+                        <xsl:text>\OSSectionSeparator&#10;</xsl:text>
                         <xsl:next-iteration>
                             <xsl:with-param name="in-pstart" select="false()"/>
                         </xsl:next-iteration>
@@ -1535,7 +1600,46 @@
         </xsl:call-template>
     </xsl:template>
 
+    <!-- The mark that anchors a note, in the series $notes-mark asks for.
+         format-integer handles alpha and roman for any serial; the traditional
+         symbol series has only six members, so past the sixth the symbol is
+         repeated, which is how a printed apparatus has always done it. -->
+    <xsl:variable name="note-symbols" as="xs:string+"
+                  select="('\textasteriskcentered', '\textdagger', '\textdaggerdbl',
+                           '\textsection', '\textbardbl', '\textparagraph')"/>
+
+    <xsl:function name="f:note-mark" as="xs:string">
+        <xsl:param name="serial" as="xs:integer"/>
+        <xsl:choose>
+            <xsl:when test="$notes-mark = 'alpha'">
+                <xsl:sequence select="format-integer($serial, 'a')"/>
+            </xsl:when>
+            <xsl:when test="$notes-mark = 'roman'">
+                <xsl:sequence select="format-integer($serial, 'i')"/>
+            </xsl:when>
+            <xsl:when test="$notes-mark = 'symbol'">
+                <xsl:variable name="symbol"
+                              select="$note-symbols[($serial - 1) mod count($note-symbols) + 1]"/>
+                <xsl:sequence select="string-join(
+                    for $repeat in 1 to ($serial - 1) idiv count($note-symbols) + 1
+                    return $symbol, '')"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="string($serial)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
     <xsl:template name="os-b-footnote">
+        <xsl:param name="serial" as="xs:integer"/>
+        <xsl:if test="$notes-placement != 'none'">
+            <xsl:call-template name="os-b-footnote-emit">
+                <xsl:with-param name="serial" select="$serial"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="os-b-footnote-emit">
         <xsl:param name="serial" as="xs:integer"/>
         <!-- In bidi/RTL contexts, empty-lemma \edtext{} can be fragile with reledmac's
              aux-file writes. Use an explicit visible-but-zero-width lemma via
@@ -1546,9 +1650,11 @@
              corrupts the catcode-group that controls [ ] delimiters when the .1
              file is re-read on the next pass. -->
         <xsl:text>\leavevmode{\OSRTLfalse\edtext{\OSInterlinearNotemark{</xsl:text>
-        <xsl:value-of select="string($serial)"/>
-        <xsl:text>}}{\Bfootnote{\OSFootnotemark{</xsl:text>
-        <xsl:value-of select="string($serial)"/>
+        <xsl:value-of select="f:note-mark($serial)"/>
+        <xsl:text>}}{\</xsl:text>
+        <xsl:value-of select="if ($notes-placement = 'endnote') then 'Bendnote' else 'Bfootnote'"/>
+        <xsl:text>{\OSFootnotemark{</xsl:text>
+        <xsl:value-of select="f:note-mark($serial)"/>
         <xsl:text>}\notenote{</xsl:text>
         <xsl:call-template name="note-content"/>
         <xsl:text>}}}}</xsl:text>

--- a/opensiddur/exporter/tex/running_heads.py
+++ b/opensiddur/exporter/tex/running_heads.py
@@ -24,6 +24,8 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from opensiddur.exporter.tex.escape import escape_tex
+
 
 # ---------------------------------------------------------------------------
 # The closed code list
@@ -66,24 +68,6 @@ RUNNING_HEAD_CODES: dict[str, str] = {
 }
 
 
-# Stands in for a literal backslash while the other specials are escaped, so
-# that the braces of its own replacement text are not escaped in turn. U+0000
-# cannot occur in a YAML scalar, so it can never collide with real input.
-_BACKSLASH_SENTINEL = "\x00"
-
-
-def _escape_tex(s: str) -> str:
-    """Escape characters that have special meaning in LaTeX.
-
-    Covers the same characters as ``f:escape-tex`` in ``reledmac.xslt``.
-    """
-    t = s.replace("\\", _BACKSLASH_SENTINEL)
-    t = re.sub(r"([&%$#_{}])", r"\\\1", t)
-    t = t.replace("~", r"\textasciitilde{}")
-    t = t.replace("^", r"\textasciicircum{}")
-    return t.replace(_BACKSLASH_SENTINEL, r"\textbackslash{}")
-
-
 # Hebrew block plus the Hebrew presentation forms, matching the range
 # f:emit-bidi-mark uses in reledmac.xslt. Hebrew segments joined by whitespace
 # or connecting punctuation are one run: a paired parsha name is written with
@@ -110,7 +94,7 @@ def _emit_bidi_literal(s: str) -> str:
     position = 0
     for match in _HEBREW_RUN.finditer(s):
         _append_ltr(parts, s[position:match.start()])
-        parts.append(r"\texthebrew{" + _escape_tex(match.group()) + "}")
+        parts.append(r"\texthebrew{" + escape_tex(match.group()) + "}")
         position = match.end()
     _append_ltr(parts, s[position:])
     return "".join(parts)
@@ -124,7 +108,7 @@ def _append_ltr(parts: list[str], text: str) -> None:
         # it would only add empty groups.
         parts.append(text)
         return
-    parts.append(r"{\textdir TLT\selectlanguage{english}" + _escape_tex(text) + "}")
+    parts.append(r"{\textdir TLT\selectlanguage{english}" + escape_tex(text) + "}")
 
 
 @dataclass(frozen=True)
@@ -221,7 +205,7 @@ class RunningHeadPosition(BaseModel):
     case stays a one-liner in YAML.
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     text: str = ""
     # Direction and font are chosen from this. Defaults to the document's own
@@ -254,6 +238,8 @@ class RunningHeadPosition(BaseModel):
 class RunningHeadSide(BaseModel):
     """The three slots of a running head or foot on one class of page."""
 
+    model_config = ConfigDict(extra="forbid")
+
     left: RunningHeadPosition = Field(default_factory=RunningHeadPosition)
     center: RunningHeadPosition = Field(default_factory=RunningHeadPosition)
     right: RunningHeadPosition = Field(default_factory=RunningHeadPosition)
@@ -273,6 +259,8 @@ class RunningHeadConfig(BaseModel):
     Nothing declared means "leave the book-class defaults alone" — the presence
     of content is the switch, so there is no separate `enabled` flag.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     all: Optional[RunningHeadSide] = None
     odd: Optional[RunningHeadSide] = None

--- a/opensiddur/exporter/tex/typography_tex.py
+++ b/opensiddur/exporter/tex/typography_tex.py
@@ -1,0 +1,667 @@
+""" Translating typography settings into LuaLaTeX.
+
+``opensiddur/exporter/typography.py`` describes how a document should look in
+renderer-agnostic terms. This module turns that description into TeX for the
+reledmac pipeline. All the TeX is here; none of it is in the settings models,
+and none of it is in a settings file.
+
+Two products come out of a :class:`TypographyConfig`:
+
+``documentclass_options`` — the bracketed options on ``\\documentclass``, which
+have to be there and nowhere else.
+
+``build_typography_preamble`` — a block of ``\\renewcommand`` and ``\\setlength``
+that ``reledmac.xslt`` emits *after* all of its own definitions. The stylesheet
+keeps every default it ever had; this block overrides them. So a settings file
+that says nothing produces an empty block and, with it, exactly the document the
+exporter produced before any of this existed.
+
+**A directive is emitted only for a setting the user actually wrote.** Not for
+one that merely equals its default. Some of the stylesheet's behaviour is
+contextual — line numbers sit in the outer margin in a parallel document and
+wherever reledmac puts them otherwise — and no single default value can stand
+for that. Keying on what was written keeps the untouched cases untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from opensiddur.exporter.tex.escape import escape_tex
+from opensiddur.exporter.typography import (
+    Alignment,
+    ChapterStart,
+    ColumnPosition,
+    ConditionalBlock,
+    FontStyle,
+    FontVariant,
+    FontWeight,
+    HEBREW_FAMILY,
+    LATIN_FAMILY,
+    NamedSize,
+    NoteAnchor,
+    Numerals,
+    Orientation,
+    PaperType,
+    ParallelLayout,
+    Sides,
+    TextStyle,
+    TypographyConfig,
+    Visibility,
+    resolve_font,
+)
+
+
+# ---------------------------------------------------------------------------
+# Size and style tokens
+# ---------------------------------------------------------------------------
+
+# The named ladder, in the order it is documented. LaTeX's size commands are a
+# ten-step scale whose steps are roughly 1.2x, which is where the ladder's shape
+# comes from; each name is pinned to one step so that a document's sizes stay
+# proportional when its base size changes.
+_NAMED_SIZE_COMMANDS: dict[NamedSize, str] = {
+    NamedSize.XXX_SMALL: r"\tiny",
+    NamedSize.XX_SMALL: r"\scriptsize",
+    NamedSize.X_SMALL: r"\footnotesize",
+    NamedSize.SMALL: r"\small",
+    NamedSize.NORMAL: r"\normalsize",
+    NamedSize.LARGE: r"\large",
+    NamedSize.X_LARGE: r"\Large",
+    NamedSize.XX_LARGE: r"\LARGE",
+    NamedSize.XXX_LARGE: r"\huge",
+    NamedSize.XXXX_LARGE: r"\Huge",
+}
+
+_WEIGHT_COMMANDS = {FontWeight.NORMAL: r"\mdseries", FontWeight.BOLD: r"\bfseries"}
+_SHAPE_COMMANDS = {FontStyle.NORMAL: r"\upshape", FontStyle.ITALIC: r"\itshape"}
+_VARIANT_COMMANDS = {FontVariant.NORMAL: "", FontVariant.SMALL_CAPS: r"\scshape"}
+
+
+def _size_command(size: Optional[str], line_spacing: float) -> str:
+    """The TeX command that selects a size.
+
+    A named size is one of the ten scale commands. An absolute length needs an
+    explicit baseline too, since ``\\fontsize`` sets both; the conventional 1.2x
+    leading is scaled by the document's line spacing so that a role given an
+    exact size still respects ``paragraphs.line_spacing``.
+    """
+    if size is None:
+        return ""
+    if size in _NAMED_SIZE_COMMANDS:
+        return _NAMED_SIZE_COMMANDS[NamedSize(size)]
+    value, unit = _split_length(size)
+    baseline = value * 1.2 * line_spacing
+    return rf"\fontsize{{{_format_number(value)}{unit}}}{{{_format_number(baseline)}{unit}}}\selectfont"
+
+
+def _split_length(length: str) -> tuple[float, str]:
+    for position, character in enumerate(length):
+        if character.isalpha():
+            return float(length[:position]), length[position:]
+    raise ValueError(f"length without a unit: {length!r}")  # pragma: no cover
+
+
+def _format_number(value: float) -> str:
+    """Trim a float to something TeX reads cleanly: 12.0 -> 12, 14.4 -> 14.4."""
+    text = f"{value:.3f}".rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _font_command(family: Optional[str]) -> str:
+    """The command that selects a declared family.
+
+    ``latin`` is the document's main font, so selecting it is just returning to
+    the normal font; ``hebrew`` is polyglossia's, which the stylesheet declares.
+    Anything else is a family this module declared, named after its key.
+    """
+    if family is None:
+        return ""
+    if family == LATIN_FAMILY:
+        return r"\normalfont"
+    if family == HEBREW_FAMILY:
+        return r"\hebrewfont"
+    return "\\" + _family_macro_name(family)
+
+
+def _family_macro_name(family: str) -> str:
+    """A TeX control-sequence name for a user-declared family key.
+
+    Control sequences are letters only, so digits, hyphens and underscores in
+    the key are dropped and each word is capitalised: ``note-sans`` becomes
+    ``OSfontNoteSans``.
+    """
+    words = "".join(character if character.isalnum() else " " for character in family)
+    return "OSfont" + "".join(word.capitalize() for word in words.split())
+
+
+def style_tokens(style: TextStyle, line_spacing: float = 1.0) -> str:
+    """The font-switching commands for a style, in the order TeX wants them.
+
+    The font comes first because it may reset the shape and series, then the
+    size, then the attributes that survive a size change.
+    """
+    return "".join(
+        (
+            _font_command(style.font),
+            _size_command(style.size, line_spacing),
+            _WEIGHT_COMMANDS.get(style.weight, "") if style.weight else "",
+            _SHAPE_COMMANDS.get(style.style, "") if style.style else "",
+            _VARIANT_COMMANDS.get(style.variant, "") if style.variant else "",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Alignment
+# ---------------------------------------------------------------------------
+
+# Two ways to align, because two contexts.
+#
+# Anything that can appear inside a reledmac \pstart is aligned with balanced
+# \hfill inside the line. reledmac captures numbered text one \par-delimited
+# line at a time, so a \par inside a group escapes that capture and, under
+# reledpar's \Columns, lands outside its column; and a \parbox sizes itself from
+# \linewidth, which is wider than a reledpar column. Fill glue works against the
+# current measure, so it is correct in single-text and in either column.
+_INLINE_ALIGNMENT: dict[Alignment, tuple[str, str]] = {
+    Alignment.CENTER: (r"\mbox{}\hfill", r"\hfill\mbox{}"),
+    Alignment.LEFT: ("", r"\hfill\mbox{}"),
+    Alignment.RIGHT: (r"\mbox{}\hfill", ""),
+    Alignment.JUSTIFY: ("", ""),
+}
+
+# Title-page material is set outside all numbering, so it can use real
+# paragraph alignment and get proper line breaking.
+_BLOCK_ALIGNMENT: dict[Alignment, str] = {
+    Alignment.CENTER: r"\centering",
+    Alignment.LEFT: r"\raggedright",
+    Alignment.RIGHT: r"\raggedleft",
+    Alignment.JUSTIFY: "",
+}
+
+
+def _inline_aligned(style: TextStyle, content: str) -> str:
+    before, after = _INLINE_ALIGNMENT[style.align or Alignment.JUSTIFY]
+    return before + content + after
+
+
+def _vspace(length: Optional[str]) -> str:
+    return rf"\vspace{{{length}}}" if length else ""
+
+
+def _block_paragraph(style: TextStyle, body: str, line_spacing: float) -> str:
+    """A centred (or otherwise aligned) paragraph with space around it."""
+    alignment = _BLOCK_ALIGNMENT[style.align or Alignment.JUSTIFY]
+    tokens = style_tokens(style, line_spacing)
+    return (
+        _vspace(style.space_before)
+        + "{"
+        + alignment
+        + r"\normalfont"
+        + tokens
+        + " "
+        + body
+        + r"\par}"
+        + _vspace(style.space_after)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Document class options
+# ---------------------------------------------------------------------------
+
+
+def documentclass_options(config: TypographyConfig) -> str:
+    """The options for ``\\documentclass[...]{book}``.
+
+    Only what the class itself has to be told: everything else is a package
+    option or a declaration, and can be set later in the preamble where it is
+    easier to reason about. ``twoside`` and ``openright`` are the class's own
+    defaults and are left unsaid, so an unconfigured document keeps the exact
+    option list it always had.
+    """
+    page = config.page
+    options = [page.base_font_size.value]
+    if page.paper is not PaperType.CUSTOM:
+        options.append(page.paper.value)
+    if page.sides is Sides.ONE:
+        options.append("oneside")
+    if page.chapter_start is ChapterStart.ANY:
+        options.append("openany")
+    return ",".join(options)
+
+
+# ---------------------------------------------------------------------------
+# Preamble sections
+# ---------------------------------------------------------------------------
+
+
+def _font_declaration(command: str, options: str, names: list[str]) -> list[str]:
+    """Declare a font family, falling back through the chain if need be.
+
+    When fontconfig can tell us which of the names is installed, the declaration
+    names it outright. When it cannot — no fontconfig on this machine — the
+    chain is emitted as nested ``\\IfFontExistsTF`` so TeX makes the same choice
+    at compile time. The chain is known to contain an installed font either way:
+    settings validation refuses one that does not.
+    """
+    resolved = resolve_font(names)
+    if resolved is not None:
+        return [f"{command}{options}{{{resolved}}}"]
+
+    lines: list[str] = []
+    for depth, name in enumerate(names[:-1]):
+        lines.append("  " * depth + rf"\IfFontExistsTF{{{name}}}{{")
+        lines.append("  " * (depth + 1) + f"{command}{options}{{{name}}}")
+        lines.append("  " * depth + "}{")
+    lines.append("  " * (len(names) - 1) + f"{command}{options}{{{names[-1]}}}")
+    lines.extend("  " * depth + "}" for depth in reversed(range(len(names) - 1)))
+    return lines
+
+
+# Hebrew faces in common use have no bold companion, so \bfseries would silently
+# do nothing and a bold heading would be indistinguishable from body text.
+# BoldFont={*} with AutoFakeBold synthesizes one. HarfBuzz shaping is what gets
+# vowels and cantillation placed correctly.
+_HEBREW_FONT_OPTIONS = "[Renderer=HarfBuzz,Script=Hebrew,BoldFont={*},AutoFakeBold=2]"
+
+
+def _fonts_section(config: TypographyConfig) -> list[str]:
+    lines: list[str] = []
+    for family, spec in sorted(config.fonts.items()):
+        if family in (LATIN_FAMILY, HEBREW_FAMILY) and family not in config.declared_fonts:
+            # The stylesheet already declares these, with the same chain.
+            continue
+        if family == LATIN_FAMILY:
+            lines.extend(_font_declaration(r"\setmainfont", "", spec.names))
+        elif family == HEBREW_FAMILY:
+            # \hebrewfont already exists — the stylesheet declared it — so this
+            # has to renew rather than declare.
+            lines.extend(
+                _font_declaration(r"\renewfontfamily\hebrewfont", _HEBREW_FONT_OPTIONS, spec.names)
+            )
+            lines.append(r"\let\hebrewfontsf\hebrewfont")
+        else:
+            lines.extend(
+                _font_declaration(
+                    "\\newfontfamily\\" + _family_macro_name(family), "", spec.names
+                )
+            )
+    return lines
+
+
+def _geometry_section(config: TypographyConfig) -> list[str]:
+    """Page size and margins, as ``geometry`` options.
+
+    The stylesheet loads ``geometry`` with no options at all, so an unconfigured
+    document gets the document class's own margins. Only what was asked for is
+    said here.
+    """
+    page = config.page
+    options: list[str] = []
+    if page.paper is PaperType.CUSTOM:
+        options.append(f"paperwidth={page.width}")
+        options.append(f"paperheight={page.height}")
+    if page.orientation is Orientation.LANDSCAPE:
+        options.append("landscape")
+
+    margins = page.margins
+    # inner/outer are geometry's names for the binding and fore edges, and it
+    # only understands them on a two-sided document. On a one-sided one they are
+    # simply the left and right margins.
+    two_sided = page.sides is Sides.TWO
+    for name, option in (
+        ("top", "top"),
+        ("bottom", "bottom"),
+        ("inner", "inner" if two_sided else "left"),
+        ("outer", "outer" if two_sided else "right"),
+        ("binding_offset", "bindingoffset"),
+    ):
+        value = getattr(margins, name)
+        if name in margins.model_fields_set and value is not None:
+            options.append(f"{option}={value}")
+
+    return [rf"\geometry{{{','.join(options)}}}"] if options else []
+
+
+def _paragraph_section(config: TypographyConfig) -> list[str]:
+    paragraphs = config.paragraphs
+    written = paragraphs.model_fields_set
+    lines: list[str] = []
+    if "indent" in written:
+        lines.append(rf"\setlength{{\parindent}}{{{paragraphs.indent}}}")
+    if "spacing" in written:
+        lines.append(rf"\setlength{{\parskip}}{{{paragraphs.spacing}}}")
+    if "line_spacing" in written:
+        lines.append(rf"\linespread{{{_format_number(paragraphs.line_spacing)}}}\selectfont")
+    if "alignment" in written:
+        alignment = _BLOCK_ALIGNMENT[paragraphs.alignment]
+        # \AtBeginDocument because the raggedness has to survive the class's own
+        # \normalfont setup, and because \raggedright in a preamble is a no-op.
+        lines.append(rf"\AtBeginDocument{{{alignment}}}" if alignment else "")
+    return [line for line in lines if line]
+
+
+# Each role, the macro that renders it, and how that macro is built. The
+# stylesheet defines every one of these with the same shape, so overriding one
+# is a matter of substituting the style's tokens for the hardcoded ones.
+def _styles_section(config: TypographyConfig) -> list[str]:
+    styles = config.styles
+    spacing = config.paragraphs.line_spacing
+    written = styles.model_fields_set
+    lines: list[str] = []
+
+    def tokens(style: TextStyle) -> str:
+        return style_tokens(style, spacing)
+
+    def emit(role: str, definition_of) -> None:
+        if role in written:
+            lines.append(definition_of(getattr(styles, role)))
+
+    # Body text has no macro of its own; the stylesheet applies \OSBodyStyle at
+    # the start of the document, where it is in force for everything.
+    emit("body", lambda s: rf"\renewcommand{{\OSBodyStyle}}{{{tokens(s)}}}")
+
+    # Headings: plain paragraph content inside a \pstart, hence inline alignment.
+    for role, macro in (
+        ("heading1", r"\OSheadA"),
+        ("heading2", r"\OSheadB"),
+        ("heading3", r"\OSheadC"),
+        ("heading4", r"\OSheadD"),
+    ):
+        emit(
+            role,
+            lambda s, macro=macro: rf"\renewcommand{{{macro}}}[1]{{"
+            + _inline_aligned(s, r"{\normalfont" + tokens(s) + " #1}")
+            + "}",
+        )
+
+    # Title page: set outside all numbering, so real paragraphs are safe.
+    for role, macro in (
+        ("title_main", r"\OSTitleMain"),
+        ("title_sub", r"\OSTitleSub"),
+        ("title_alt", r"\OSTitleAlt"),
+        ("byline", r"\OSByline"),
+        ("edition", r"\OSDocEdition"),
+        ("imprint", r"\OSDocImprint"),
+        ("epigraph", r"\OSEpigraph"),
+        ("imprimatur", r"\OSImprimatur"),
+        ("title_page_block", r"\OSTitlePageBlock"),
+    ):
+        emit(
+            role,
+            lambda s, macro=macro: rf"\renewcommand{{{macro}}}[1]{{"
+            + _block_paragraph(s, "#1", spacing)
+            + "}",
+        )
+
+    # Verse and chapter numbers force LTR: digits laid out in an RTL context
+    # come out reversed, so 50 would read 05.
+    emit(
+        "verse_number",
+        lambda s: r"\renewcommand{\vno}[1]{\textsuperscript{{\textdir TLT"
+        r"\selectlanguage{english}" + tokens(s) + r"#1}}\,}",
+    )
+    emit(
+        "chapter_number",
+        lambda s: r"\renewcommand{\chno}[1]{{" + tokens(s)
+        + r"{\textdir TLT\selectlanguage{english}#1}}\,}",
+    )
+    emit(
+        "citation",
+        lambda s: r"\renewcommand{\OScitation}[1]{"
+        + _inline_aligned(s, r"{\normalfont" + tokens(s) + " #1}")
+        + "}",
+    )
+    emit(
+        "aliyah",
+        lambda s: r"\renewcommand{\OSaliyah}[1]{{" + tokens(s) + r"[#1]}\,}",
+    )
+    emit(
+        "parsha",
+        lambda s: r"\renewcommand{\OSParsha}[1]{{\normalfont" + tokens(s) + r" #1}\quad}",
+    )
+    emit(
+        "instruction",
+        lambda s: r"\renewcommand{\instructionnote}[1]{{" + tokens(s) + " #1}}",
+    )
+    emit("note", lambda s: r"\renewcommand{\notenote}[1]{{" + tokens(s) + " #1}}")
+    # styles.line_number is emitted by _line_numbers_section: the style and
+    # the numeral system write the same macro, so they have to be combined.
+    emit(
+        "section_separator",
+        lambda s: r"\renewcommand{\OSSectionSeparatorStyle}[1]{"
+        + _block_paragraph(s, "#1", spacing)
+        + "}",
+    )
+    return lines
+
+
+def _note_mark_tex(style: TextStyle, anchor: NoteAnchor, spacing: float) -> list[str]:
+    """The in-text anchor and the mark repeated where the note is printed.
+
+    ``\\OSInterlinearNotemark`` keeps its name whichever anchor is chosen: it is
+    what the stylesheet emits, and the setting decides only what it does.
+    """
+    # The stylesheet sets note marks in a sans face so they read as editorial
+    # apparatus rather than as part of the text. Keep that unless the settings
+    # name a font of their own — changing the anchor should not silently change
+    # the face too.
+    tokens = (r"\sffamily" if style.font is None else "") + style_tokens(style, spacing)
+    if anchor is NoteAnchor.INTERLINEAR:
+        # Raised, zero-width and centred on the anchor, so the mark sits in the
+        # interlinear band and the text it annotates is not respaced — which is
+        # what keeps two sides of a parallel text aligned.
+        body = (
+            r"\leavevmode\hbox to 0pt{\hss{\textdir TLT\raisebox{1.5ex}"
+            r"{{\selectlanguage{english}\kern0.05em\normalfont"
+            + tokens
+            + r" #1\kern0.05em}}}\hss}"
+        )
+    elif anchor is NoteAnchor.SUPERSCRIPT:
+        body = (
+            r"\textsuperscript{{\textdir TLT\selectlanguage{english}\normalfont"
+            + tokens
+            + " #1}}"
+        )
+    else:
+        body = r"{\textdir TLT\selectlanguage{english}\normalfont" + tokens + " #1}"
+    return [
+        r"\renewcommand{\OSInterlinearNotemark}[1]{%",
+        "  " + body + "%",
+        "}",
+        r"\renewcommand{\OSFootnotemark}[1]{%",
+        r"  {\textdir TLT\selectlanguage{english}\normalfont" + tokens + r" #1}\space",
+        "}",
+    ]
+
+
+def _notes_section(config: TypographyConfig) -> list[str]:
+    notes = config.notes
+    lines: list[str] = []
+    if "note_mark" in config.styles.model_fields_set or "anchor" in notes.model_fields_set:
+        lines.extend(
+            _note_mark_tex(
+                config.styles.note_mark, notes.anchor, config.paragraphs.line_spacing
+            )
+        )
+    return lines
+
+
+def _line_numbers_section(config: TypographyConfig, has_parallel: bool) -> list[str]:
+    line_numbers = config.line_numbers
+    written = line_numbers.model_fields_set
+    lines: list[str] = []
+    if not line_numbers.enabled:
+        # reledmac's own switch, the one \skipnumbering sets for a single
+        # paragraph. Setting it in the preamble applies it to all of them: the
+        # numbering machinery still runs, so cross-references and the apparatus
+        # are unaffected, but no number is printed. Nothing else in this section
+        # would have anything to configure.
+        return [r"\numberlinefalse"]
+    if "unit" in written:
+        lines.append(rf"\lineation{{{line_numbers.unit.value}}}")
+    if "increment" in written:
+        lines.append(rf"\linenumincrement{{{line_numbers.increment}}}")
+        if has_parallel:
+            lines.append(rf"\linenumincrementR{{{line_numbers.increment}}}")
+    if "first" in written:
+        lines.append(rf"\firstlinenum{{{line_numbers.first}}}")
+        if has_parallel:
+            lines.append(rf"\firstlinenumR{{{line_numbers.first}}}")
+    if "margin" in written:
+        margin = line_numbers.margin.value
+        lines.append(rf"\linenummargin{{{margin}}}")
+        if has_parallel:
+            lines.append(rf"\linenummarginR{{{margin}}}")
+    if "separation" in written:
+        lines.append(rf"\setlength{{\linenumsep}}{{{line_numbers.separation}}}")
+    if "numerals" in written or "line_number" in config.styles.model_fields_set:
+        lines.extend(_line_number_format_tex(config, has_parallel))
+    return lines
+
+
+def _line_number_format_tex(config: TypographyConfig, has_parallel: bool) -> list[str]:
+    """How a line number is set.
+
+    The macro is ``\\linenumrep``, not ``\\linenumberstyle``: the latter is a
+    declaration whose only job is to define the former, and reledmac calls it
+    once, as it loads. Redefining it afterwards has no effect at all.
+
+    Hebrew numerals are letters, so unlike digits they belong in the surrounding
+    direction and need no left-to-right wrapper. Digits do: laid out in an RTL
+    context they come out reversed, 50 reading as 05.
+    """
+    tokens = style_tokens(config.styles.line_number, config.paragraphs.line_spacing)
+    if config.line_numbers.numerals is Numerals.HEBREW:
+        body = tokens + r"\hebrewnumeral{#1}"
+    else:
+        body = r"\textdir TLT\selectlanguage{english}" + tokens + r"\@arabic{#1}"
+    # \@arabic is internal; the \hbox keeps the direction and language switches
+    # from leaking into reledmac's aux-file writes.
+    lines = [r"\makeatletter", r"\renewcommand*{\linenumrep}[1]{\hbox{" + body + "}}"]
+    if has_parallel:
+        lines.append(r"\renewcommand*{\linenumrepR}[1]{\hbox{" + body + "}}")
+    lines.append(r"\makeatother")
+    return lines
+
+
+def _markers_section(config: TypographyConfig) -> list[str]:
+    markers = config.markers
+    written = markers.model_fields_set
+    lines: list[str] = []
+    if "section_separator" in written:
+        separator = escape_tex(markers.section_separator)
+        lines.append(
+            r"\renewcommand{\OSSectionSeparator}{"
+            + (rf"\OSSectionSeparatorStyle{{{separator}}}" if separator else "")
+            + "}"
+        )
+    if "verse_numbers" in written and markers.verse_numbers is Visibility.HIDDEN:
+        lines.append(r"\renewcommand{\vno}[1]{}")
+    if "chapter_numbers" in written and markers.chapter_numbers is Visibility.HIDDEN:
+        lines.append(r"\renewcommand{\chno}[1]{}")
+
+    conditional = markers.conditional
+    conditional_written = conditional.model_fields_set
+    if "inline_open" in conditional_written:
+        lines.append(
+            r"\renewcommand{\OSCondStartInline}{{\bfseries"
+            + escape_tex(conditional.inline_open)
+            + "}}"
+        )
+    if "inline_close" in conditional_written:
+        lines.append(
+            r"\renewcommand{\OSCondEndInline}{{\bfseries"
+            + escape_tex(conditional.inline_close)
+            + "}}"
+        )
+    if conditional_written & {"block", "rule_width", "rule_thickness"}:
+        width = _percent_of(conditional.rule_width, r"\linewidth")
+        if conditional.block is ConditionalBlock.RULE:
+            # A full-width box rather than \par-separated material: these rules
+            # sit inside reledmac \pstart groups, where \par does not reliably
+            # break the line.
+            lines.append(
+                r"\renewcommand{\OSCondRule}{\leavevmode\hbox to \linewidth{\hss\rule{"
+                + width
+                + "}{"
+                + conditional.rule_thickness
+                + r"}\hss}}"
+            )
+            lines.append(r"\renewcommand{\OSCondStartBlock}{\OSCondRule}")
+            lines.append(r"\renewcommand{\OSCondEndBlock}{\OSCondRule}")
+        elif conditional.block is ConditionalBlock.BRACKETS:
+            lines.append(r"\renewcommand{\OSCondStartBlock}{\OSCondStartInline}")
+            lines.append(r"\renewcommand{\OSCondEndBlock}{\OSCondEndInline}")
+        else:
+            lines.append(r"\renewcommand{\OSCondStartBlock}{}")
+            lines.append(r"\renewcommand{\OSCondEndBlock}{}")
+    return lines
+
+
+def _percent_of(percent: str, dimension: str) -> str:
+    """``43%`` of ``\\textwidth`` is ``0.43\\textwidth``."""
+    return _format_number(float(percent.rstrip("%")) / 100) + dimension
+
+
+def _parallel_section(config: TypographyConfig, has_parallel: bool) -> list[str]:
+    parallel = config.parallel
+    written = parallel.model_fields_set
+    if not has_parallel or parallel.layout is not ParallelLayout.PAIRS:
+        # Column geometry exists only where there are two columns on one page.
+        return []
+    lines: list[str] = []
+    if "column_width" in written:
+        width = _percent_of(parallel.column_width, r"\textwidth")
+        lines.append(rf"\setlength{{\Lcolwidth}}{{{width}}}")
+        lines.append(rf"\setlength{{\Rcolwidth}}{{{width}}}")
+    if "column_position" in written:
+        lines.append(
+            rf"\columnsposition{{{_COLUMN_POSITIONS[parallel.column_position]}}}"
+        )
+    return lines
+
+
+_COLUMN_POSITIONS = {
+    ColumnPosition.LEFT: "L",
+    ColumnPosition.CENTER: "C",
+    ColumnPosition.RIGHT: "R",
+}
+
+
+# ---------------------------------------------------------------------------
+# The whole block
+# ---------------------------------------------------------------------------
+
+
+def build_typography_preamble(
+    config: TypographyConfig, has_parallel: bool = False
+) -> str:
+    """Everything the settings ask for, as TeX, in preamble order.
+
+    Returns the empty string when the settings ask for nothing, which leaves the
+    stylesheet's own defaults untouched.
+
+    ``has_parallel`` says whether the document has two aligned streams. Several
+    reledpar declarations do not exist unless the package is loaded, and the
+    package is loaded only for such a document, so emitting them unconditionally
+    would break every other one.
+    """
+    sections = [
+        ("Fonts", _fonts_section(config)),
+        ("Page geometry", _geometry_section(config)),
+        ("Paragraphs", _paragraph_section(config)),
+        ("Text styles", _styles_section(config)),
+        ("Notes", _notes_section(config)),
+        ("Line numbers", _line_numbers_section(config, has_parallel)),
+        ("Markers", _markers_section(config)),
+        ("Parallel columns", _parallel_section(config, has_parallel)),
+    ]
+    lines: list[str] = []
+    for title, section in sections:
+        if section:
+            lines.append(f"% --- {title} (typography settings) ---")
+            lines.extend(section)
+    return "\n".join(lines) + "\n" if lines else ""

--- a/opensiddur/exporter/typography.py
+++ b/opensiddur/exporter/typography.py
@@ -967,9 +967,15 @@ class TypographyConfig(ForbidExtra):
         self._declared_fonts = frozenset(self.fonts)
         for family, names in _DEFAULT_FONTS.items():
             self.fonts.setdefault(family, FontFamily(names=list(names)))
-        for family, spec in self.fonts.items():
+        # Only a chain the settings file named is checked. A default the user
+        # never asked for must not fail on a machine that happens not to have
+        # it: the renderer already falls back for those — for the PDF stage,
+        # the stylesheet's own \IfFontExistsTF chain — and refusing to build at
+        # all would mean nobody could export anything without first installing
+        # this project's house fonts.
+        for family in self._declared_fonts:
             try:
-                resolve_font(spec.names)
+                resolve_font(self.fonts[family].names)
             except ValueError as e:
                 raise ValueError(f"font `{family}`: {e}") from e
         return self

--- a/opensiddur/exporter/typography.py
+++ b/opensiddur/exporter/typography.py
@@ -1,0 +1,1005 @@
+""" Typography settings: the user-facing description of how a document should look.
+
+This module is deliberately renderer-agnostic. Nothing here knows about TeX —
+sizes are a named ladder or a length with a unit, not ``\\LARGE``; a page has
+``inner`` and ``outer`` margins, not ``\\geometry`` options. The translation into
+one renderer's commands lives beside that renderer; for the PDF stage that is
+``opensiddur/exporter/tex/typography_tex.py``.
+
+Two rules shape the models:
+
+*Every setting has a default, and the defaults reproduce the output the exporter
+produced before any of this was configurable.* A settings file that omits the
+``typography`` section, or any part of it, gets exactly what it got before.
+
+*Invalid settings fail at load time, not in the renderer.* Every model forbids
+unknown keys, every vocabulary is a closed enum, and lengths are pattern-checked,
+so a typo names itself and its YAML path instead of surfacing as a LaTeX error
+several minutes into a build — or, worse, as a silently wrong page.
+
+The one part of the settings tree that lives elsewhere is
+``page_header``/``page_footer``: their model and their TeX generator are a single
+piece of logic, and both are in ``tex/running_heads.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from enum import StrEnum
+from functools import lru_cache
+from typing import Annotated, Optional, Union
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    StringConstraints,
+    model_validator,
+)
+
+from opensiddur.exporter.tex.running_heads import RunningHeadConfig
+
+
+# ---------------------------------------------------------------------------
+# Value types
+# ---------------------------------------------------------------------------
+
+# Units a length may carry. `em`/`ex` are relative to the font in force where the
+# length is used, which is what makes a setting like `paragraphs.spacing: 0.5em`
+# survive a change of base font size. The rest are absolute.
+_LENGTH_PATTERN = r"^-?(?:\d+(?:\.\d+)?|\.\d+)(?:pt|bp|mm|cm|in|pc|em|ex)$"
+
+Length = Annotated[
+    str,
+    StringConstraints(pattern=_LENGTH_PATTERN),
+    Field(
+        description=(
+            "A length with a unit: pt, bp, mm, cm, in, pc, em or ex. "
+            "em and ex are relative to the font in force."
+        ),
+    ),
+]
+
+# A font size given as a length must be absolute: a size in `em` would be
+# relative to the size it is itself defining. Use a NamedSize for a size
+# relative to the base.
+_ABSOLUTE_LENGTH_PATTERN = r"^(?:\d+(?:\.\d+)?|\.\d+)(?:pt|bp|mm|cm|in|pc)$"
+
+AbsoluteLength = Annotated[
+    str,
+    StringConstraints(pattern=_ABSOLUTE_LENGTH_PATTERN),
+    Field(
+        description=(
+            "A positive length in an absolute unit: pt, bp, mm, cm, in or pc. "
+            "Relative units are not allowed where the length defines a font size."
+        ),
+    ),
+]
+
+_PERCENT_PATTERN = r"^(?:\d+(?:\.\d+)?|\.\d+)%$"
+
+Percent = Annotated[
+    str,
+    StringConstraints(pattern=_PERCENT_PATTERN),
+    Field(description="A percentage of the enclosing measure, e.g. `43%`."),
+]
+
+
+class NamedSize(StrEnum):
+    """ A font size relative to the document's base size.
+
+    A named size follows ``page.base_font_size``, so raising the document from
+    11pt to 12pt scales every heading with it. Use an absolute
+    :data:`Length` instead when a role needs an exact size regardless.
+
+    The ladder is symmetric around ``normal`` and each step is roughly 1.2x.
+    """
+
+    XXX_SMALL = "xxx-small"
+    XX_SMALL = "xx-small"
+    X_SMALL = "x-small"
+    SMALL = "small"
+    NORMAL = "normal"
+    LARGE = "large"
+    X_LARGE = "x-large"
+    XX_LARGE = "xx-large"
+    XXX_LARGE = "xxx-large"
+    XXXX_LARGE = "xxxx-large"
+
+
+FontSize = Union[NamedSize, AbsoluteLength]
+
+
+class FontWeight(StrEnum):
+    NORMAL = "normal"
+    BOLD = "bold"
+
+
+class FontStyle(StrEnum):
+    NORMAL = "normal"
+    ITALIC = "italic"
+
+
+class FontVariant(StrEnum):
+    NORMAL = "normal"
+    SMALL_CAPS = "small-caps"
+
+
+class Alignment(StrEnum):
+    """ Horizontal alignment.
+
+    ``left`` and ``right`` are physical positions on the page, so they mean the
+    same thing in a Hebrew and an English stream; ``start``/``end`` semantics are
+    deliberately not offered, because a bilingual document would need both at
+    once and could not say so.
+    """
+
+    LEFT = "left"
+    RIGHT = "right"
+    CENTER = "center"
+    JUSTIFY = "justify"
+
+
+class Sides(StrEnum):
+    """ Whether the document is printed on one or both sides of the leaf. """
+
+    ONE = "one"
+    TWO = "two"
+
+
+class ChapterStart(StrEnum):
+    """ Where a new book or chapter is allowed to begin. """
+
+    RECTO = "recto"  # always on a right-hand page, inserting a blank if needed
+    ANY = "any"
+
+
+class Orientation(StrEnum):
+    PORTRAIT = "portrait"
+    LANDSCAPE = "landscape"
+
+
+class Numerals(StrEnum):
+    ARABIC = "arabic"
+    HEBREW = "hebrew"
+
+
+class BaseFontSize(StrEnum):
+    """ The document's base font size.
+
+    Only these three are available: they are the sizes the underlying document
+    class ships font-size tables for, and asking for anything else silently gets
+    one of them. Set individual roles in ``styles`` for other sizes.
+    """
+
+    PT10 = "10pt"
+    PT11 = "11pt"
+    PT12 = "12pt"
+
+
+class PaperType(StrEnum):
+    """ Paper size.
+
+    ``custom`` requires ``page.width`` and ``page.height``; every other value
+    forbids them.
+    """
+
+    A4PAPER = "a4paper"
+    LETTERPAPER = "letterpaper"
+    LEGALPAPER = "legalpaper"
+    A5PAPER = "a5paper"
+    B5PAPER = "b5paper"
+    EXECUTIVEPAPER = "executivepaper"
+    CUSTOM = "custom"
+
+
+class ParallelLayout(StrEnum):
+    """ Parallel-text page layout.
+
+    pages: facing pages — best for full critical editions.
+    pairs: two columns on the same page — best for short documents.
+    """
+
+    PAGES = "pages"
+    PAIRS = "pairs"
+
+
+class LineationUnit(StrEnum):
+    """ What line numbering counts within before restarting. """
+
+    PAGE = "page"
+    SECTION = "section"
+
+
+class LineNumberMargin(StrEnum):
+    """ Which margin line numbers sit in.
+
+    ``inner``/``outer`` are relative to the binding and therefore swap between
+    recto and verso; ``left``/``right`` are fixed physical positions.
+    """
+
+    INNER = "inner"
+    OUTER = "outer"
+    LEFT = "left"
+    RIGHT = "right"
+
+
+class NotePlacement(StrEnum):
+    """ Where the text of a note is printed.
+
+    footnote: at the foot of the page the note is anchored on.
+    endnote:  collected at the end of the document.
+    none:     notes are dropped entirely, anchor and all.
+    """
+
+    FOOTNOTE = "footnote"
+    ENDNOTE = "endnote"
+    NONE = "none"
+
+
+class NoteAnchor(StrEnum):
+    """ How the mark that points at a note is set in the text.
+
+    interlinear: raised into the space above the line, taking no width, so the
+                 text it annotates is not respaced.
+    superscript: an ordinary superscript attached to the preceding word.
+    inline:      at full size on the baseline.
+    """
+
+    INTERLINEAR = "interlinear"
+    SUPERSCRIPT = "superscript"
+    INLINE = "inline"
+
+
+class NoteMark(StrEnum):
+    """ The series a note's mark is drawn from. """
+
+    NUMERIC = "numeric"
+    ALPHA = "alpha"
+    ROMAN = "roman"
+    SYMBOL = "symbol"
+
+
+class ConditionalBlock(StrEnum):
+    """ How a whole conditional paragraph is delimited.
+
+    Only conditions the compiler could not decide survive into the output, so a
+    marker means "say this only if ...", and a reader has to see where the
+    passage starts and stops.
+    """
+
+    RULE = "rule"
+    BRACKETS = "brackets"
+    NONE = "none"
+
+
+class Visibility(StrEnum):
+    SHOWN = "shown"
+    HIDDEN = "hidden"
+
+
+class ColumnPosition(StrEnum):
+    """ Where the pair of columns sits within the text block. """
+
+    LEFT = "left"
+    CENTER = "center"
+    RIGHT = "right"
+
+
+# ---------------------------------------------------------------------------
+# Fonts
+# ---------------------------------------------------------------------------
+
+
+class ForbidExtra(BaseModel):
+    """ Base for every settings model: an unknown key is an error.
+
+    Silently ignoring a key the user wrote means the setting they asked for is
+    simply absent from the output, with nothing to say why. Forbidding extras
+    turns every typo into a message that names the key and its path.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class FontFamily(ForbidExtra):
+    """ A font, given as a chain of names tried in order.
+
+    The chain exists because the faces this project sets Hebrew in are not
+    installed everywhere: naming several lets one settings file work on a
+    machine that has ``Frank Ruehl CLM`` and on one that only has ``FreeSerif``.
+    The first name that is installed wins. If *none* of them is, that is an
+    error — a fallback to whatever the renderer would have picked produces a
+    document that is quietly not the one that was asked for, and for Hebrew it
+    is usually one with no vowels or cantillation.
+
+    A bare string is accepted as shorthand for a one-element chain.
+    """
+
+    names: list[str] = Field(
+        min_length=1,
+        description="Font names, most preferred first. The first one installed is used.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def accept_bare_string_or_list(cls, value: object) -> object:
+        if isinstance(value, str):
+            return {"names": [value]}
+        if isinstance(value, list):
+            return {"names": value}
+        return value
+
+
+# Families that always exist, because the stylesheet refers to them by role
+# rather than by name: every Hebrew run is set in `hebrew` and everything else
+# in `latin`. Users may add more and point a style at them.
+LATIN_FAMILY = "latin"
+HEBREW_FAMILY = "hebrew"
+
+_DEFAULT_FONTS = {
+    LATIN_FAMILY: ["Linux Libertine O"],
+    # Frank Ruehl CLM is the house face; Ezra SIL and SBL Hebrew are the usual
+    # scholarly substitutes; FreeSerif is the last resort that is present on
+    # essentially every Linux TeX installation.
+    HEBREW_FAMILY: ["Frank Ruehl CLM", "Ezra SIL", "SBL Hebrew", "FreeSerif"],
+}
+
+
+@lru_cache(maxsize=1)
+def _installed_font_families() -> Optional[frozenset[str]]:
+    """ Every font family fontconfig knows about, or None if it cannot be asked.
+
+    Cached: a settings file declares a handful of chains and each would
+    otherwise re-run the same query. Returning None rather than an empty set
+    keeps "fontconfig said there are no fonts" distinguishable from "there is no
+    fontconfig", which is the difference between failing and deferring the check
+    to the renderer.
+    """
+    if shutil.which("fc-list") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["fc-list", "--format", "%{family}\n"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    families = set()
+    for line in result.stdout.splitlines():
+        # fc-list reports a family's aliases comma-separated on one line.
+        for name in line.split(","):
+            name = name.strip()
+            if name:
+                families.add(name.casefold())
+    return frozenset(families)
+
+
+def resolve_font(names: list[str]) -> Optional[str]:
+    """ The first installed name in a chain.
+
+    Returns None when fontconfig is unavailable, which means "undecidable here";
+    the caller leaves the choice to the renderer in that case. Raises when
+    fontconfig is available and none of the names is installed.
+    """
+    installed = _installed_font_families()
+    if installed is None:
+        return None
+    for name in names:
+        if name.casefold() in installed:
+            return name
+    raise ValueError(
+        "none of these fonts is installed: "
+        + ", ".join(repr(name) for name in names)
+        + ". Install one of them, or name a font that is present "
+        "(`fc-list : family` lists them)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Text styles
+# ---------------------------------------------------------------------------
+
+
+class TextStyle(ForbidExtra):
+    """ How one kind of text is set.
+
+    Every field is optional and ``None`` means "leave it as the surrounding text
+    has it", so a style says only what it changes. The defaults on the roles in
+    :class:`Styles` spell out the appearance the exporter has always produced.
+    """
+
+    font: Optional[str] = Field(
+        default=None,
+        description=(
+            "A family declared in `typography.fonts`. Omit to let the text keep "
+            "the font its script selects (`hebrew` for Hebrew, `latin` otherwise)."
+        ),
+    )
+    size: Optional[FontSize] = Field(
+        default=None,
+        description=(
+            "A named size (xxx-small ... xxxx-large), which follows "
+            "`page.base_font_size`, or an absolute length such as `9pt`."
+        ),
+    )
+    weight: Optional[FontWeight] = Field(default=None, description="normal | bold")
+    style: Optional[FontStyle] = Field(default=None, description="normal | italic")
+    variant: Optional[FontVariant] = Field(
+        default=None, description="normal | small-caps"
+    )
+    align: Optional[Alignment] = Field(
+        default=None,
+        description="left | right | center | justify. Only meaningful for block-level roles.",
+    )
+    space_before: Optional[Length] = Field(
+        default=None, description="Vertical space above. Block-level roles only."
+    )
+    space_after: Optional[Length] = Field(
+        default=None, description="Vertical space below. Block-level roles only."
+    )
+
+    def is_empty(self) -> bool:
+        return all(value is None for value in self.__dict__.values())
+
+
+class Styles(ForbidExtra):
+    """ The appearance of each kind of text the exporter distinguishes.
+
+    The defaults are the appearance the stylesheet has always produced. Changing
+    one changes only that role.
+    """
+
+    body: TextStyle = Field(
+        default_factory=TextStyle,
+        description="Ordinary running text.",
+    )
+    heading1: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.XX_LARGE, weight=FontWeight.BOLD, align=Alignment.CENTER
+        ),
+        description="Top-level section heading.",
+    )
+    heading2: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.X_LARGE, weight=FontWeight.BOLD, align=Alignment.CENTER
+        ),
+        description="Second-level section heading.",
+    )
+    heading3: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.LARGE, weight=FontWeight.BOLD, align=Alignment.CENTER
+        ),
+        description="Third-level section heading.",
+    )
+    heading4: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.NORMAL, weight=FontWeight.BOLD, align=Alignment.CENTER
+        ),
+        description="Fourth-level section heading; the deepest level there is.",
+    )
+    title_main: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.XXXX_LARGE,
+            weight=FontWeight.BOLD,
+            align=Alignment.CENTER,
+            space_after="1.5ex",
+        ),
+        description="The main title on the title page.",
+    )
+    title_sub: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.X_LARGE, align=Alignment.CENTER, space_before="1.5ex"
+        ),
+        description="The subtitle on the title page.",
+    )
+    title_alt: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.LARGE, align=Alignment.CENTER, space_after="1ex"
+        ),
+        description="An alternative title, usually the title in the other language.",
+    )
+    byline: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.LARGE, align=Alignment.CENTER, space_before="3ex"
+        ),
+        description="The author/editor line on the title page.",
+    )
+    edition: TextStyle = Field(
+        default_factory=lambda: TextStyle(align=Alignment.CENTER, space_before="2ex"),
+        description="The edition statement on the title page.",
+    )
+    imprint: TextStyle = Field(
+        default_factory=lambda: TextStyle(align=Alignment.CENTER, space_before="4ex"),
+        description="The publisher/place/date block at the foot of the title page.",
+    )
+    epigraph: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.SMALL,
+            style=FontStyle.ITALIC,
+            align=Alignment.CENTER,
+            space_before="2ex",
+        ),
+        description="An epigraph on the title page.",
+    )
+    imprimatur: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            size=NamedSize.SMALL,
+            style=FontStyle.ITALIC,
+            align=Alignment.CENTER,
+            space_before="2ex",
+        ),
+        description="An imprimatur or approbation on the title page.",
+    )
+    title_page_block: TextStyle = Field(
+        default_factory=lambda: TextStyle(align=Alignment.CENTER),
+        description="Any other paragraph on the title page.",
+    )
+    citation: TextStyle = Field(
+        default_factory=lambda: TextStyle(
+            style=FontStyle.ITALIC, align=Alignment.CENTER
+        ),
+        description=(
+            "A scriptural citation set on a line of its own, naming where a "
+            "reading begins or resumes."
+        ),
+    )
+    parsha: TextStyle = Field(
+        default_factory=lambda: TextStyle(size=NamedSize.LARGE, weight=FontWeight.BOLD),
+        description="A parsha name, run in at the head of the text it opens.",
+    )
+    aliyah: TextStyle = Field(
+        default_factory=lambda: TextStyle(weight=FontWeight.BOLD),
+        description="An aliyah or maftir marker, inline at the verse it begins on.",
+    )
+    verse_number: TextStyle = Field(
+        default_factory=TextStyle,
+        description="The verse number at the start of each verse.",
+    )
+    chapter_number: TextStyle = Field(
+        default_factory=lambda: TextStyle(size=NamedSize.LARGE, weight=FontWeight.BOLD),
+        description="The chapter number, inline at the start of a chapter.",
+    )
+    instruction: TextStyle = Field(
+        default_factory=lambda: TextStyle(weight=FontWeight.BOLD),
+        description="An instruction to the reader, in the note apparatus.",
+    )
+    note: TextStyle = Field(
+        default_factory=lambda: TextStyle(weight=FontWeight.BOLD),
+        description="The text of an editorial note.",
+    )
+    note_mark: TextStyle = Field(
+        default_factory=lambda: TextStyle(size=NamedSize.XX_SMALL),
+        description=(
+            "The mark that anchors a note, both in the text and where the note "
+            "is printed."
+        ),
+    )
+    line_number: TextStyle = Field(
+        default_factory=TextStyle,
+        description="Marginal line numbers.",
+    )
+    section_separator: TextStyle = Field(
+        default_factory=lambda: TextStyle(align=Alignment.CENTER),
+        description="The separator between unheaded sections.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Page, paragraphs, and the rest
+# ---------------------------------------------------------------------------
+
+
+class Margins(ForbidExtra):
+    """ The white space around the text block.
+
+    Every margin defaults to None, which leaves the renderer's own default in
+    place — for the PDF stage that is the document class's, which is what the
+    exporter produced before margins were configurable.
+
+    Margins are always named ``inner`` and ``outer`` rather than left and right.
+    On a two-sided document the inner margin is the one at the binding, so it
+    changes sides between recto and verso; on a one-sided document inner is left
+    and outer is right, and the renderer maps them.
+    """
+
+    top: Optional[Length] = Field(default=None, description="Space above the text block.")
+    bottom: Optional[Length] = Field(
+        default=None, description="Space below the text block."
+    )
+    inner: Optional[Length] = Field(
+        default=None,
+        description="Margin at the binding edge (the left margin when `sides: one`).",
+    )
+    outer: Optional[Length] = Field(
+        default=None,
+        description="Margin at the fore edge (the right margin when `sides: one`).",
+    )
+    binding_offset: Optional[Length] = Field(
+        default=None,
+        description=(
+            "Extra space added at the binding edge and taken off the fore edge, "
+            "for the part of the page a binding swallows."
+        ),
+    )
+
+    def is_empty(self) -> bool:
+        return all(value is None for value in self.__dict__.values())
+
+
+class PageConfig(ForbidExtra):
+    """ The sheet itself: its size, which way up it is, and how it is bound. """
+
+    paper: PaperType = Field(
+        default=PaperType.LETTERPAPER,
+        description=(
+            "a4paper | letterpaper | legalpaper | a5paper | b5paper | "
+            "executivepaper | custom. `custom` requires `width` and `height`."
+        ),
+    )
+    width: Optional[Length] = Field(
+        default=None, description="Sheet width. Only with `paper: custom`."
+    )
+    height: Optional[Length] = Field(
+        default=None, description="Sheet height. Only with `paper: custom`."
+    )
+    orientation: Orientation = Field(
+        default=Orientation.PORTRAIT, description="portrait | landscape"
+    )
+    sides: Sides = Field(
+        default=Sides.TWO,
+        description=(
+            "two: printed on both sides, with margins and running heads that "
+            "mirror between recto and verso. one: printed on one side only."
+        ),
+    )
+    chapter_start: ChapterStart = Field(
+        default=ChapterStart.RECTO,
+        description=(
+            "recto: a book always opens on a right-hand page, with a blank "
+            "inserted if needed. any: it opens on whichever page comes next."
+        ),
+    )
+    base_font_size: BaseFontSize = Field(
+        default=BaseFontSize.PT11,
+        description="10pt | 11pt | 12pt. Named sizes in `styles` are relative to this.",
+    )
+    margins: Margins = Field(
+        default_factory=Margins,
+        description="Margins around the text block. Omitted margins keep the renderer's default.",
+    )
+
+    @model_validator(mode="after")
+    def validate_custom_paper(self) -> "PageConfig":
+        if self.paper is PaperType.CUSTOM:
+            missing = [
+                name
+                for name in ("width", "height")
+                if getattr(self, name) is None
+            ]
+            if missing:
+                raise ValueError(
+                    "`paper: custom` requires " + " and ".join(missing)
+                )
+        elif self.width is not None or self.height is not None:
+            raise ValueError(
+                f"`width` and `height` may only be set with `paper: custom`, "
+                f"not `paper: {self.paper.value}`"
+            )
+        return self
+
+
+class ParagraphConfig(ForbidExtra):
+    """ How paragraphs of running text are set. """
+
+    indent: Length = Field(
+        default="0pt", description="First-line indent. `0pt` for unindented paragraphs."
+    )
+    spacing: Length = Field(
+        default="0.5em", description="Vertical space between paragraphs."
+    )
+    line_spacing: float = Field(
+        default=1.0,
+        ge=0.5,
+        le=3.0,
+        description=(
+            "Multiple of single spacing. 1.0 is set solid, 1.5 is one-and-a-half "
+            "spaced. Note that Hebrew with vowels and cantillation needs more "
+            "leading than unpointed text."
+        ),
+    )
+    alignment: Alignment = Field(
+        default=Alignment.JUSTIFY,
+        description="justify | left | right | center",
+    )
+
+
+class LineNumberConfig(ForbidExtra):
+    """ Marginal line numbers, as a critical edition uses to cite a passage. """
+
+    enabled: bool = Field(
+        default=True, description="Whether line numbers are printed at all."
+    )
+    unit: LineationUnit = Field(
+        default=LineationUnit.PAGE,
+        description="page | section — what numbering restarts at.",
+    )
+    increment: int = Field(
+        default=5, ge=1, description="Print a number every nth line."
+    )
+    first: int = Field(
+        default=5,
+        ge=1,
+        description=(
+            "The first line number to print. The default matches `increment`, so "
+            "the numbers run 5, 10, 15 rather than 1, 5, 10."
+        ),
+    )
+    margin: LineNumberMargin = Field(
+        default=LineNumberMargin.OUTER,
+        description=(
+            "inner | outer | left | right. In a two-column parallel layout each "
+            "column takes the nearer outer margin regardless of this setting, "
+            "since the alternative is numbers in the gutter between the columns."
+        ),
+    )
+    separation: Length = Field(
+        default="1em",
+        description="Space between the number and the text block.",
+    )
+    numerals: Numerals = Field(
+        default=Numerals.ARABIC, description="arabic | hebrew"
+    )
+
+
+class NoteConfig(ForbidExtra):
+    """ Editorial notes and instructions: where they go and how they are marked. """
+
+    placement: NotePlacement = Field(
+        default=NotePlacement.FOOTNOTE,
+        description="footnote | endnote | none",
+    )
+    anchor: NoteAnchor = Field(
+        default=NoteAnchor.INTERLINEAR,
+        description=(
+            "interlinear | superscript | inline. `interlinear` raises the mark "
+            "above the line and gives it no width, so the text it annotates is "
+            "not respaced — which matters when both sides of a parallel text "
+            "have to stay aligned."
+        ),
+    )
+    mark: NoteMark = Field(
+        default=NoteMark.NUMERIC,
+        description="numeric | alpha | roman | symbol — the series marks are drawn from.",
+    )
+    # There is deliberately no setting for showing the lemma — the words a note
+    # is attached to, repeated where the note is printed. A note in this schema
+    # anchors at a point rather than over a range, so there are no such words to
+    # repeat: the apparatus entry's lemma is the mark itself, and printing it
+    # would give "* ] * the note text".
+
+
+class ConditionalMarkerConfig(ForbidExtra):
+    """ How an undecided conditional passage is delimited.
+
+    A condition the compiler could decide is resolved away, so anything marked
+    here is a passage the reader has to choose to say or skip.
+    """
+
+    inline_open: str = Field(
+        default="[", description="Opens a conditional run inside a paragraph."
+    )
+    inline_close: str = Field(
+        default="]", description="Closes a conditional run inside a paragraph."
+    )
+    block: ConditionalBlock = Field(
+        default=ConditionalBlock.RULE,
+        description=(
+            "rule | brackets | none — how a whole conditional paragraph is "
+            "delimited. Brackets several lines apart do not read as a pair, "
+            "hence the rule."
+        ),
+    )
+    rule_width: Percent = Field(
+        default="25%", description="Width of the rule, as a percentage of the measure."
+    )
+    rule_thickness: Length = Field(default="0.4pt", description="Thickness of the rule.")
+
+
+class MarkerConfig(ForbidExtra):
+    """ The small marks that structure a text without being part of it. """
+
+    section_separator: str = Field(
+        default="* * * *",
+        description=(
+            "Printed between sections that have no heading. Set to an empty "
+            "string to leave nothing but the space."
+        ),
+    )
+    verse_numbers: Visibility = Field(
+        default=Visibility.SHOWN, description="shown | hidden"
+    )
+    chapter_numbers: Visibility = Field(
+        default=Visibility.SHOWN, description="shown | hidden"
+    )
+    conditional: ConditionalMarkerConfig = Field(
+        default_factory=ConditionalMarkerConfig,
+        description="Markers around passages whose condition could not be decided.",
+    )
+
+
+class ParallelTypographyConfig(ForbidExtra):
+    """ The geometry of a parallel-text layout.
+
+    Which text goes on which side is not set here: it is `parallel.column_order`
+    in the compiler section of the settings file, because the compiler is what
+    decides the order the streams are emitted in.
+    """
+
+    layout: ParallelLayout = Field(
+        default=ParallelLayout.PAIRS,
+        description=(
+            "pairs: two columns on the same page. pages: facing pages, which "
+            "gives each text a full measure and suits a long work."
+        ),
+    )
+    column_width: Percent = Field(
+        default="43%",
+        description=(
+            "Width of each column as a percentage of the text block, in `pairs` "
+            "layout. The two columns and the gap between them share 100%, so "
+            "well under 50% each — the remainder leaves the outer margins room "
+            "for line numbers."
+        ),
+    )
+    column_position: ColumnPosition = Field(
+        default=ColumnPosition.CENTER,
+        description=(
+            "left | center | right — where the pair of columns sits in the text "
+            "block, in `pairs` layout."
+        ),
+    )
+
+
+class TableOfContentsConfig(ForbidExtra):
+    """ An auto-generated table of contents.
+
+    ``depth`` is independent of the PDF bookmark depth, which is always four
+    levels deep regardless of this setting.
+    """
+
+    enabled: bool = Field(
+        default=False, description="Whether to print a table of contents."
+    )
+    depth: int = Field(
+        default=4, ge=1, le=4, description="Heading levels shown, 1-4."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The whole tree
+# ---------------------------------------------------------------------------
+
+
+class TypographyConfig(ForbidExtra):
+    """ Everything about how the exported document looks.
+
+    Read by the output stage only; the linear-XML compiler ignores it. Every
+    section is optional and every default reproduces the exporter's long-standing
+    output, so a settings file need only say what it wants changed.
+
+    See ``doc/typography.md`` for the full reference.
+    """
+
+    fonts: dict[str, FontFamily] = Field(
+        default_factory=dict,
+        description=(
+            "Named font families, each a chain of names tried in order. "
+            "`latin` and `hebrew` always exist and are used for Latin-script and "
+            "Hebrew-script text respectively; add your own and point a style at "
+            "them by name."
+        ),
+    )
+    page: PageConfig = Field(
+        default_factory=PageConfig, description="Paper size, sides, base font size, margins."
+    )
+    paragraphs: ParagraphConfig = Field(
+        default_factory=ParagraphConfig, description="Indent, spacing, leading, alignment."
+    )
+    styles: Styles = Field(
+        default_factory=Styles, description="The appearance of each kind of text."
+    )
+    line_numbers: LineNumberConfig = Field(
+        default_factory=LineNumberConfig, description="Marginal line numbers."
+    )
+    notes: NoteConfig = Field(
+        default_factory=NoteConfig, description="Placement and marking of notes."
+    )
+    markers: MarkerConfig = Field(
+        default_factory=MarkerConfig,
+        description="Section separators, verse and chapter numbers, conditional markers.",
+    )
+    parallel: ParallelTypographyConfig = Field(
+        default_factory=ParallelTypographyConfig,
+        description="Geometry of a parallel-text layout.",
+    )
+    table_of_contents: TableOfContentsConfig = Field(
+        default_factory=TableOfContentsConfig,
+        description="An auto-generated table of contents.",
+    )
+    page_header: RunningHeadConfig = Field(
+        default_factory=RunningHeadConfig,
+        description=(
+            "Running head. Empty by default, which leaves the renderer's own "
+            "page style alone. See doc/typography.md for the template codes."
+        ),
+    )
+    page_footer: RunningHeadConfig = Field(
+        default_factory=RunningHeadConfig, description="Running foot; same shape as `page_header`."
+    )
+
+    # Which families the settings file actually named, as opposed to the ones
+    # filled in below. The renderer emits a font declaration only for the
+    # former, so an unmentioned `hebrew` keeps whatever the renderer already
+    # does — which for the PDF stage is the same chain, chosen at TeX time.
+    _declared_fonts: frozenset[str] = PrivateAttr(default=frozenset())
+
+    @property
+    def declared_fonts(self) -> frozenset[str]:
+        """ The font families the settings file named itself. """
+        return self._declared_fonts
+
+    @model_validator(mode="after")
+    def apply_font_defaults(self) -> "TypographyConfig":
+        """ Fill in `latin` and `hebrew` and check every chain resolves.
+
+        A user-declared `latin` or `hebrew` replaces the default outright rather
+        than extending it: someone who names a Hebrew face and gets Frank Ruehl
+        anyway, because their name was misspelled and the old chain was still
+        underneath, has been told nothing.
+        """
+        self._declared_fonts = frozenset(self.fonts)
+        for family, names in _DEFAULT_FONTS.items():
+            self.fonts.setdefault(family, FontFamily(names=list(names)))
+        for family, spec in self.fonts.items():
+            try:
+                resolve_font(spec.names)
+            except ValueError as e:
+                raise ValueError(f"font `{family}`: {e}") from e
+        return self
+
+    @model_validator(mode="after")
+    def validate_style_font_references(self) -> "TypographyConfig":
+        for role, style in self.styles.__dict__.items():
+            if style.font is not None and style.font not in self.fonts:
+                known = ", ".join(sorted(self.fonts))
+                raise ValueError(
+                    f"styles.{role}.font names `{style.font}`, which is not "
+                    f"declared in typography.fonts (declared: {known})"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_notes_are_not_styled_away(self) -> "TypographyConfig":
+        """ Styling notes that are switched off is a contradiction, not a no-op.
+
+        Someone who sets a note style and `placement: none` in the same file has
+        two intentions that cannot both hold, and the one that silently wins
+        deletes their notes.
+        """
+        if self.notes.placement is NotePlacement.NONE:
+            # Only an explicitly written style is a contradiction; the defaults
+            # are always present and say nothing about what the user wants.
+            for role in ("note", "note_mark"):
+                if role in self.styles.model_fields_set:
+                    raise ValueError(
+                        f"styles.{role} is set but notes.placement is `none`, "
+                        "so no notes are printed. Remove one of the two."
+                    )
+        return self

--- a/opensiddur/tests/exporter/test_latex.py
+++ b/opensiddur/tests/exporter/test_latex.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 from pydantic import ValidationError
 
 import opensiddur.exporter.tex.latex as latex_module
+from opensiddur.exporter import typography as typography_module
 from opensiddur.exporter.typography import PaperType, ParallelLayout, TypographyConfig
 from opensiddur.exporter.tex.latex import (
     CreditRecord,
@@ -34,6 +35,19 @@ from opensiddur.exporter.tex.latex import (
     load_typography,
     transform_xml_to_tex,
 )
+
+
+def _no_fontconfig():
+    """Mock out the installed-font lookup.
+
+    The settings models check a font chain a settings file names against
+    fontconfig. Whether the machine running the tests has Ezra SIL is not what
+    any test here is about, and a test that turned on it would fail for reasons
+    that have nothing to do with the code.
+    """
+    return patch.object(
+        typography_module, "_installed_font_families", return_value=None
+    )
 
 
 class TestExtractLicenses(unittest.TestCase):
@@ -427,7 +441,8 @@ typography:
     depth: 2
 """
         )
-        cfg = load_typography(settings_path)
+        with _no_fontconfig():
+            cfg = load_typography(settings_path)
         self.assertEqual(cfg.fonts["hebrew"].names, ["Ezra SIL", "FreeSerif"])
         self.assertEqual(cfg.fonts["latin"].names, ["TeX Gyre Pagella"])
         self.assertEqual(cfg.parallel.layout, ParallelLayout.PAIRS)
@@ -568,16 +583,17 @@ class TestTransformXmlToTex(unittest.TestCase):
           <tei:text><tei:body><tei:p>x</tei:p></tei:body></tei:text>
         </tei:TEI>"""
         f = self._create("p", "input.xml", xml)
-        typography = TypographyConfig.model_validate(
-            {
-                "fonts": {"hebrew": ["Ezra SIL", "FreeSerif"], "latin": "FreeSerif"},
-                "parallel": {"layout": "pairs"},
-                "page": {"paper": "letterpaper", "base_font_size": "12pt"},
-            }
-        )
+        with _no_fontconfig():
+            typography = TypographyConfig.model_validate(
+                {
+                    "fonts": {"hebrew": ["Ezra SIL", "FreeSerif"], "latin": "FreeSerif"},
+                    "parallel": {"layout": "pairs"},
+                    "page": {"paper": "letterpaper", "base_font_size": "12pt"},
+                }
+            )
 
-        with patch.object(latex_module, "projects_source_root", self.test_dir):
-            out = transform_xml_to_tex(f, typography=typography)
+            with patch.object(latex_module, "projects_source_root", self.test_dir):
+                out = transform_xml_to_tex(f, typography=typography)
 
         self.assertIn(r"\documentclass[12pt,letterpaper]{book}", out)
         self.assertIn(r"\renewfontfamily\hebrewfont", out)

--- a/opensiddur/tests/exporter/test_latex.py
+++ b/opensiddur/tests/exporter/test_latex.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch
 from pydantic import ValidationError
 
 import opensiddur.exporter.tex.latex as latex_module
-from opensiddur.exporter.settings import PaperType, ParallelLayout, TypographyConfig
+from opensiddur.exporter.typography import PaperType, ParallelLayout, TypographyConfig
 from opensiddur.exporter.tex.latex import (
     CreditRecord,
     LicenseRecord,
@@ -414,22 +414,25 @@ priority:
   transclusion: [p]
   instructions: []
 typography:
-  hebrew_font: Ezra SIL
-  latin_font: TeX Gyre Pagella
-  layout: pairs
-  paper: letterpaper
-  fontsize: 12pt
+  fonts:
+    hebrew: [Ezra SIL, FreeSerif]
+    latin: TeX Gyre Pagella
+  parallel:
+    layout: pairs
+  page:
+    paper: letterpaper
+    base_font_size: 12pt
   table_of_contents:
     enabled: true
     depth: 2
 """
         )
         cfg = load_typography(settings_path)
-        self.assertEqual(cfg.hebrew_font, "Ezra SIL")
-        self.assertEqual(cfg.latin_font, "TeX Gyre Pagella")
-        self.assertEqual(cfg.layout, ParallelLayout.PAIRS)
-        self.assertEqual(cfg.paper, PaperType.LETTERPAPER)
-        self.assertEqual(cfg.fontsize, "12pt")
+        self.assertEqual(cfg.fonts["hebrew"].names, ["Ezra SIL", "FreeSerif"])
+        self.assertEqual(cfg.fonts["latin"].names, ["TeX Gyre Pagella"])
+        self.assertEqual(cfg.parallel.layout, ParallelLayout.PAIRS)
+        self.assertEqual(cfg.page.paper, PaperType.LETTERPAPER)
+        self.assertEqual(cfg.page.base_font_size, "12pt")
         self.assertTrue(cfg.table_of_contents.enabled)
         self.assertEqual(cfg.table_of_contents.depth, 2)
 
@@ -516,11 +519,12 @@ typography:
 priority:
   transclusion: [a-project-that-does-not-exist]
 typography:
-  hebrew_font: Some Font
+  page:
+    paper: a5paper
 """
         )
         cfg = load_typography(settings_path)
-        self.assertEqual(cfg.hebrew_font, "Some Font")
+        self.assertEqual(cfg.page.paper, PaperType.A5PAPER)
 
 
 class TestTransformXmlToTex(unittest.TestCase):
@@ -564,20 +568,77 @@ class TestTransformXmlToTex(unittest.TestCase):
           <tei:text><tei:body><tei:p>x</tei:p></tei:body></tei:text>
         </tei:TEI>"""
         f = self._create("p", "input.xml", xml)
-        typography = TypographyConfig(
-            hebrew_font="Ezra SIL",
-            latin_font="TeX Gyre Pagella",
-            layout=ParallelLayout.PAIRS,
-            paper="letterpaper",
-            fontsize="12pt",
+        typography = TypographyConfig.model_validate(
+            {
+                "fonts": {"hebrew": ["Ezra SIL", "FreeSerif"], "latin": "FreeSerif"},
+                "parallel": {"layout": "pairs"},
+                "page": {"paper": "letterpaper", "base_font_size": "12pt"},
+            }
         )
 
         with patch.object(latex_module, "projects_source_root", self.test_dir):
             out = transform_xml_to_tex(f, typography=typography)
 
         self.assertIn(r"\documentclass[12pt,letterpaper]{book}", out)
-        self.assertIn("Ezra SIL", out)
-        self.assertIn("TeX Gyre Pagella", out)
+        self.assertIn(r"\renewfontfamily\hebrewfont", out)
+        self.assertIn(r"\setmainfont{FreeSerif}", out)
+
+    def test_a_settings_file_reaches_the_emitted_tex(self):
+        """The whole path, YAML to TeX: a settings file that names paper,
+        margins, a heading size and line numbers has to show up in the
+        document, and nothing it did not name may."""
+        xml = b"""<?xml version="1.0"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body><tei:p>x</tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        f = self._create("p", "input.xml", xml)
+        settings_path = self.test_dir / "settings.yaml"
+        settings_path.write_text(
+            """
+typography:
+  page:
+    paper: a5paper
+    base_font_size: 10pt
+    sides: one
+    margins: {top: 2cm, inner: 25mm}
+  paragraphs:
+    line_spacing: 1.4
+  styles:
+    heading1: {size: small, weight: normal}
+  line_numbers:
+    enabled: false
+"""
+        )
+
+        with patch.object(latex_module, "projects_source_root", self.test_dir):
+            out = transform_xml_to_tex(f, settings_file=settings_path)
+
+        self.assertIn(r"\documentclass[10pt,a5paper,oneside]{book}", out)
+        self.assertIn("top=2cm", out)
+        self.assertIn("left=25mm", out)   # one-sided, so inner is the left margin
+        self.assertIn(r"\linespread{1.4}", out)
+        self.assertIn(r"\renewcommand{\OSheadA}", out)
+        self.assertIn(r"\numberlinefalse", out)
+        # Nothing the file did not ask for.
+        self.assertNotIn(r"\renewcommand{\OSheadB}", out)
+        self.assertNotIn("bottom=", out)
+
+    def test_an_invalid_settings_file_fails_before_anything_is_rendered(self):
+        """And says which setting is wrong. The blanket handler around the
+        transform would flatten the message to one line, so validation has to
+        happen outside it."""
+        xml = b"""<?xml version="1.0"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body><tei:p>x</tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        f = self._create("p", "input.xml", xml)
+        settings_path = self.test_dir / "settings.yaml"
+        settings_path.write_text("typography:\n  page:\n    paper: tabloid\n")
+
+        with patch.object(latex_module, "projects_source_root", self.test_dir):
+            with self.assertRaises(ValidationError) as caught:
+                transform_xml_to_tex(f, settings_file=settings_path)
+        self.assertIn("paper", str(caught.exception))
 
     def test_running_heads_are_built_into_the_page_style_preamble(self):
         xml = b"""<?xml version="1.0"?>
@@ -634,7 +695,7 @@ class TestTransformXmlToTex(unittest.TestCase):
           </tei:body></tei:text>
         </tei:TEI>""".encode("utf-8")
         f = self._create("p", "input.xml", xml)
-        typography = TypographyConfig(layout=ParallelLayout.PAIRS)
+        typography = TypographyConfig.model_validate({"parallel": {"layout": "pairs"}})
         with patch.object(latex_module, "projects_source_root", self.test_dir):
             out = transform_xml_to_tex(f, typography=typography)
         self.assertIn(r"\begin{pairs}", out)

--- a/opensiddur/tests/exporter/test_reledmac_xslt.py
+++ b/opensiddur/tests/exporter/test_reledmac_xslt.py
@@ -131,7 +131,18 @@ class TestPreamble(unittest.TestCase):
         out = _transform(xml)
         self.assertIn(r"\usepackage{reledpar}", out)
 
-    def test_preamble_honors_typography_parameters(self):
+    def test_documentclass_options_are_passed_through_verbatim(self):
+        """The class options are built in Python; the stylesheet only places them."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body><tei:p>Hi</tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml, **{"documentclass-options": "12pt,a5paper,oneside"})
+        self.assertIn(r"\documentclass[12pt,a5paper,oneside]{book}", out)
+
+    def test_typography_preamble_overrides_the_stylesheet_defaults(self):
+        """The block has to land after every default it is meant to override,
+        and before the bibliography, which is not typography."""
         xml = """<?xml version="1.0" encoding="UTF-8"?>
         <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
           <tei:text><tei:body><tei:p>Hi</tei:p></tei:body></tei:text>
@@ -139,15 +150,23 @@ class TestPreamble(unittest.TestCase):
         out = _transform(
             xml,
             **{
-                "hebrew-font": "Ezra SIL",
-                "latin-font": "TeX Gyre Pagella",
-                "paper": "letterpaper",
-                "fontsize": "12pt",
+                "typography-preamble": "\\OSTYPOGRAPHY\n",
+                "additional-preamble": "\\OSBIBLIOGRAPHY\n",
             },
         )
-        self.assertIn(r"\documentclass[12pt,letterpaper]{book}", out)
-        self.assertIn("Ezra SIL", out)
-        self.assertIn("TeX Gyre Pagella", out)
+        self.assertLess(out.index(r"\newcommand{\OSheadA}"), out.index(r"\OSTYPOGRAPHY"))
+        self.assertLess(out.index(r"\setlength{\parskip}"), out.index(r"\OSTYPOGRAPHY"))
+        self.assertLess(out.index(r"\OSTYPOGRAPHY"), out.index(r"\OSBIBLIOGRAPHY"))
+        self.assertLess(out.index(r"\OSTYPOGRAPHY"), out.index(r"\begin{document}"))
+
+    def test_empty_typography_preamble_leaves_the_defaults_alone(self):
+        """A document that configures nothing must be the document this
+        exporter has always produced."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body><tei:p>Hi</tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        self.assertEqual(_transform(xml), _transform(xml, **{"typography-preamble": ""}))
 
     def test_preamble_bookmarks_four_levels_deep(self):
         """The deeper heading levels (index > section > haftarah > rite) must reach the PDF
@@ -653,6 +672,76 @@ class TestNotesMapping(unittest.TestCase):
         self.assertIn("commentary", out)
         self.assertNotIn(r"\footnote{", out)
 
+    def test_notes_can_be_collected_as_endnotes(self):
+        """The apparatus series is the same; only where it is printed changes."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body><tei:p>
+            <tei:milestone unit="verse" n="1"/>Body<tei:note>commentary</tei:note>
+          </tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml, **{"notes-placement": "endnote"})
+        self.assertIn(r"\Bendnote{", out)
+        self.assertNotIn(r"\Bfootnote{", out)
+        # Collected as the document is typeset, so they have to be printed out.
+        self.assertIn(r"\doendnotes{B}", out)
+        self.assertLess(out.index(r"\doendnotes{B}"), out.index(r"\end{document}"))
+
+    def test_notes_can_be_dropped_entirely(self):
+        """Anchor and all: a mark pointing at a note that is not printed would
+        be worse than no note."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body><tei:p>
+            <tei:milestone unit="verse" n="1"/>Body<tei:note>commentary</tei:note>
+          </tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml, **{"notes-placement": "none"})
+        self.assertNotIn("commentary", out)
+        self.assertNotIn(r"\Bfootnote", out)
+        # The macro is still defined in the preamble, which costs nothing; what
+        # must be gone is every call to it.
+        body = out[out.index(r"\begin{document}"):]
+        self.assertNotIn(r"\OSInterlinearNotemark", body)
+
+    def test_note_marks_can_be_drawn_from_another_series(self):
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body><tei:p>
+            <tei:milestone unit="verse" n="1"/>A<tei:note>one</tei:note>
+            B<tei:note>two</tei:note>
+          </tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        alpha = _transform(xml, **{"notes-mark": "alpha"})
+        self.assertIn(r"\OSInterlinearNotemark{a}", alpha)
+        self.assertIn(r"\OSInterlinearNotemark{b}", alpha)
+
+        roman = _transform(xml, **{"notes-mark": "roman"})
+        self.assertIn(r"\OSInterlinearNotemark{i}", roman)
+        self.assertIn(r"\OSInterlinearNotemark{ii}", roman)
+
+        symbol = _transform(xml, **{"notes-mark": "symbol"})
+        self.assertIn(r"\OSInterlinearNotemark{\textasteriskcentered}", symbol)
+        self.assertIn(r"\OSInterlinearNotemark{\textdagger}", symbol)
+
+    def test_the_symbol_series_repeats_once_it_runs_out(self):
+        """Six symbols, then the same symbols doubled — how a printed apparatus
+        has always done it."""
+        notes = "".join(
+            f'<tei:note>n{i}</tei:note>' for i in range(1, 9)
+        )
+        xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body><tei:p>
+            <tei:milestone unit="verse" n="1"/>Body{notes}
+          </tei:p></tei:body></tei:text>
+        </tei:TEI>"""
+        out = _transform(xml, **{"notes-mark": "symbol"})
+        self.assertIn(r"\OSInterlinearNotemark{\textparagraph}", out)
+        self.assertIn(
+            r"\OSInterlinearNotemark{\textasteriskcentered\textasteriskcentered}", out
+        )
+
     def test_instruction_note_is_inline(self):
         xml = """<?xml version="1.0" encoding="UTF-8"?>
         <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
@@ -828,6 +917,35 @@ class TestNotesMapping(unittest.TestCase):
         out = _transform(xml)
         self.assertNotIn(r"\textdir TLT\selectlanguage{english}EVR-II-B-8", out)
         self.assertIn("EVR-II-B-8", out)
+
+
+class TestSectionSeparator(unittest.TestCase):
+    """A milestone[@rend='****'] separates sections that carry no heading."""
+
+    XML = """<?xml version="1.0" encoding="UTF-8"?>
+        <tei:TEI xmlns:tei="http://www.tei-c.org/ns/1.0">
+          <tei:text><tei:body>
+            <tei:p>Before</tei:p>
+            <tei:milestone unit="section" rend="****"/>
+            <tei:p>After</tei:p>
+          </tei:body></tei:text>
+        </tei:TEI>"""
+
+    def test_the_separator_goes_through_a_macro(self):
+        """Through a macro, so a settings file can change the mark and its
+        appearance without the stylesheet knowing what either is."""
+        out = _transform(self.XML)
+        body = out[out.index(r"\begin{document}"):]
+        self.assertIn(r"\OSSectionSeparator", body)
+
+    def test_the_default_macro_prints_what_it_always_printed(self):
+        out = _transform(self.XML)
+        self.assertIn(
+            r"\newcommand{\OSSectionSeparator}{\OSSectionSeparatorStyle{* * * *}}", out
+        )
+        self.assertIn(
+            r"\newcommand{\OSSectionSeparatorStyle}[1]{\begin{center}#1\end{center}}", out
+        )
 
 
 class TestInlineFormatting(unittest.TestCase):

--- a/opensiddur/tests/exporter/test_typography.py
+++ b/opensiddur/tests/exporter/test_typography.py
@@ -1,0 +1,359 @@
+"""Tests for the typography settings models (opensiddur/exporter/typography.py).
+
+Two things are being checked throughout: that every default reproduces the
+output this exporter produced before any of it was configurable, and that
+anything invalid is refused at load time rather than passed to the renderer.
+
+Font resolution shells out to fontconfig, so it is mocked here — a test that
+depended on which fonts this machine has installed would pass or fail for
+reasons that have nothing to do with the code.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from pydantic import ValidationError
+
+from opensiddur.exporter import typography as typography_module
+from opensiddur.exporter.typography import (
+    Alignment,
+    BaseFontSize,
+    ConditionalBlock,
+    FontFamily,
+    FontWeight,
+    LineationUnit,
+    NamedSize,
+    NoteAnchor,
+    NoteMark,
+    NotePlacement,
+    PaperType,
+    ParallelLayout,
+    Sides,
+    TextStyle,
+    TypographyConfig,
+    Visibility,
+    resolve_font,
+)
+
+
+def _validate(data: dict) -> TypographyConfig:
+    """Validate a settings fragment with fontconfig reporting nothing installed.
+
+    ``None`` from the query means "cannot be asked", which is how a machine
+    without fontconfig behaves, so no font chain is rejected and the tests stay
+    about the setting under test.
+    """
+    with patch.object(typography_module, "_installed_font_families", return_value=None):
+        return TypographyConfig.model_validate(data)
+
+
+class TestDefaults(unittest.TestCase):
+    """An empty settings section has to mean "what it has always looked like"."""
+
+    def setUp(self):
+        self.config = _validate({})
+
+    def test_page_defaults(self):
+        self.assertEqual(self.config.page.paper, PaperType.LETTERPAPER)
+        self.assertEqual(self.config.page.base_font_size, BaseFontSize.PT11)
+        self.assertEqual(self.config.page.sides, Sides.TWO)
+        self.assertTrue(self.config.page.margins.is_empty())
+
+    def test_paragraph_defaults_match_the_stylesheet(self):
+        self.assertEqual(self.config.paragraphs.indent, "0pt")
+        self.assertEqual(self.config.paragraphs.spacing, "0.5em")
+        self.assertEqual(self.config.paragraphs.line_spacing, 1.0)
+
+    def test_heading_defaults_step_down_by_one_rung_each(self):
+        sizes = [
+            self.config.styles.heading1.size,
+            self.config.styles.heading2.size,
+            self.config.styles.heading3.size,
+            self.config.styles.heading4.size,
+        ]
+        self.assertEqual(
+            sizes,
+            [
+                NamedSize.XX_LARGE,
+                NamedSize.X_LARGE,
+                NamedSize.LARGE,
+                NamedSize.NORMAL,
+            ],
+        )
+        for style in (
+            self.config.styles.heading1,
+            self.config.styles.heading4,
+        ):
+            self.assertEqual(style.weight, FontWeight.BOLD)
+            self.assertEqual(style.align, Alignment.CENTER)
+
+    def test_line_number_defaults_match_reledmac(self):
+        self.assertTrue(self.config.line_numbers.enabled)
+        self.assertEqual(self.config.line_numbers.unit, LineationUnit.PAGE)
+        # 5 and 5, so the numbers run 5, 10, 15 as they always have.
+        self.assertEqual(self.config.line_numbers.increment, 5)
+        self.assertEqual(self.config.line_numbers.first, 5)
+        self.assertEqual(self.config.line_numbers.separation, "1em")
+
+    def test_note_defaults(self):
+        self.assertEqual(self.config.notes.placement, NotePlacement.FOOTNOTE)
+        self.assertEqual(self.config.notes.anchor, NoteAnchor.INTERLINEAR)
+        self.assertEqual(self.config.notes.mark, NoteMark.NUMERIC)
+
+    def test_marker_defaults(self):
+        self.assertEqual(self.config.markers.section_separator, "* * * *")
+        self.assertEqual(self.config.markers.verse_numbers, Visibility.SHOWN)
+        self.assertEqual(self.config.markers.conditional.inline_open, "[")
+        self.assertEqual(self.config.markers.conditional.block, ConditionalBlock.RULE)
+        self.assertEqual(self.config.markers.conditional.rule_width, "25%")
+
+    def test_parallel_defaults(self):
+        self.assertEqual(self.config.parallel.layout, ParallelLayout.PAIRS)
+        self.assertEqual(self.config.parallel.column_width, "43%")
+
+    def test_table_of_contents_defaults_to_disabled(self):
+        self.assertFalse(self.config.table_of_contents.enabled)
+        self.assertEqual(self.config.table_of_contents.depth, 4)
+
+    def test_running_heads_default_to_nothing(self):
+        self.assertTrue(self.config.page_header.is_empty())
+        self.assertTrue(self.config.page_footer.is_empty())
+
+
+class TestUnknownKeysAreRefused(unittest.TestCase):
+    """A key nobody reads is a setting that silently did not happen."""
+
+    def test_unknown_key_at_the_top_level(self):
+        with self.assertRaises(ValidationError) as caught:
+            _validate({"pgae": {}})
+        self.assertIn("pgae", str(caught.exception))
+
+    def test_unknown_key_in_a_section(self):
+        with self.assertRaises(ValidationError) as caught:
+            _validate({"page": {"papper": "a4paper"}})
+        self.assertIn("papper", str(caught.exception))
+
+    def test_unknown_role_in_styles(self):
+        with self.assertRaises(ValidationError) as caught:
+            _validate({"styles": {"heading5": {"size": "large"}}})
+        self.assertIn("heading5", str(caught.exception))
+
+    def test_unknown_attribute_in_a_style(self):
+        with self.assertRaises(ValidationError) as caught:
+            _validate({"styles": {"body": {"colour": "red"}}})
+        self.assertIn("colour", str(caught.exception))
+
+    def test_unknown_key_in_a_nested_section(self):
+        with self.assertRaises(ValidationError) as caught:
+            _validate({"markers": {"conditional": {"inline_middle": "-"}}})
+        self.assertIn("inline_middle", str(caught.exception))
+
+
+class TestClosedVocabularies(unittest.TestCase):
+    def test_paper_must_be_a_known_size(self):
+        with self.assertRaises(ValidationError):
+            _validate({"page": {"paper": "tabloid"}})
+
+    def test_base_font_size_is_restricted_to_the_three_that_exist(self):
+        """Anything else silently becomes one of these, so asking is an error."""
+        for size in ("10pt", "11pt", "12pt"):
+            _validate({"page": {"base_font_size": size}})
+        for size in ("13pt", "11", "large"):
+            with self.assertRaises(ValidationError, msg=size):
+                _validate({"page": {"base_font_size": size}})
+
+    def test_note_placement_alignment_and_layout_are_closed(self):
+        for section, key, bad in (
+            ("notes", "placement", "margin"),
+            ("notes", "anchor", "raised"),
+            ("notes", "mark", "dingbat"),
+            ("paragraphs", "alignment", "middle"),
+            ("parallel", "layout", "columns"),
+            ("line_numbers", "unit", "paragraph"),
+            ("line_numbers", "numerals", "greek"),
+            ("markers", "verse_numbers", "maybe"),
+        ):
+            with self.assertRaises(ValidationError, msg=f"{section}.{key}"):
+                _validate({section: {key: bad}})
+
+    def test_style_attributes_are_closed(self):
+        for key, bad in (
+            ("weight", "semibold"),
+            ("style", "oblique"),
+            ("variant", "all-caps"),
+            ("align", "start"),
+        ):
+            with self.assertRaises(ValidationError, msg=key):
+                _validate({"styles": {"body": {key: bad}}})
+
+
+class TestLengths(unittest.TestCase):
+    def test_accepted_lengths(self):
+        for length in ("0pt", "12pt", "1.5em", "25mm", ".5in", "-3pt", "2ex", "1pc"):
+            _validate({"paragraphs": {"indent": length}})
+
+    def test_rejected_lengths(self):
+        for length in ("12", "12 pt", "large", "12px", "", "pt"):
+            with self.assertRaises(ValidationError, msg=repr(length)):
+                _validate({"paragraphs": {"indent": length}})
+
+    def test_a_size_may_be_a_named_rung_or_an_absolute_length(self):
+        config = _validate({"styles": {"note": {"size": "9pt"}, "body": {"size": "small"}}})
+        self.assertEqual(config.styles.note.size, "9pt")
+        self.assertEqual(config.styles.body.size, NamedSize.SMALL)
+
+    def test_a_size_may_not_be_relative_to_the_size_it_defines(self):
+        for size in ("1.2em", "2ex"):
+            with self.assertRaises(ValidationError, msg=size):
+                _validate({"styles": {"note": {"size": size}}})
+
+    def test_percentages(self):
+        _validate({"parallel": {"column_width": "40%"}})
+        for bad in ("40", "40 %", "%40"):
+            with self.assertRaises(ValidationError, msg=bad):
+                _validate({"parallel": {"column_width": bad}})
+
+    def test_bounded_numbers(self):
+        _validate({"paragraphs": {"line_spacing": 1.5}})
+        for bad in (0.1, 4.0):
+            with self.assertRaises(ValidationError, msg=str(bad)):
+                _validate({"paragraphs": {"line_spacing": bad}})
+        with self.assertRaises(ValidationError):
+            _validate({"line_numbers": {"increment": 0}})
+        with self.assertRaises(ValidationError):
+            _validate({"table_of_contents": {"depth": 5}})
+
+
+class TestCustomPaper(unittest.TestCase):
+    def test_custom_paper_needs_both_dimensions(self):
+        _validate({"page": {"paper": "custom", "width": "6in", "height": "9in"}})
+        with self.assertRaises(ValidationError) as caught:
+            _validate({"page": {"paper": "custom", "width": "6in"}})
+        self.assertIn("height", str(caught.exception))
+
+    def test_dimensions_without_custom_paper_are_an_error(self):
+        """Silently ignoring them would print a document at the wrong size."""
+        with self.assertRaises(ValidationError) as caught:
+            _validate({"page": {"paper": "a4paper", "width": "6in", "height": "9in"}})
+        self.assertIn("custom", str(caught.exception))
+
+
+class TestFontFamilies(unittest.TestCase):
+    def test_latin_and_hebrew_always_exist(self):
+        config = _validate({})
+        self.assertEqual(config.fonts["latin"].names, ["Linux Libertine O"])
+        self.assertIn("FreeSerif", config.fonts["hebrew"].names)
+
+    def test_a_bare_string_is_a_one_name_chain(self):
+        config = _validate({"fonts": {"latin": "TeX Gyre Pagella"}})
+        self.assertEqual(config.fonts["latin"].names, ["TeX Gyre Pagella"])
+
+    def test_declaring_a_family_replaces_its_default_chain(self):
+        """Leaving the old chain underneath would answer a misspelled font name
+        with the house font and no complaint."""
+        config = _validate({"fonts": {"hebrew": ["Ezra SIL"]}})
+        self.assertEqual(config.fonts["hebrew"].names, ["Ezra SIL"])
+
+    def test_declared_families_are_distinguished_from_filled_in_ones(self):
+        config = _validate({"fonts": {"hebrew": "Ezra SIL"}})
+        self.assertEqual(config.declared_fonts, frozenset({"hebrew"}))
+
+    def test_an_empty_chain_is_refused(self):
+        with self.assertRaises(ValidationError):
+            _validate({"fonts": {"latin": []}})
+
+    def test_a_style_may_only_name_a_declared_family(self):
+        _validate({"fonts": {"sans": "DejaVu Sans"}, "styles": {"note": {"font": "sans"}}})
+        with self.assertRaises(ValidationError) as caught:
+            _validate({"styles": {"note": {"font": "sans"}}})
+        self.assertIn("sans", str(caught.exception))
+
+
+class TestFontResolution(unittest.TestCase):
+    """The first installed name in a chain wins; none installed is an error."""
+
+    def setUp(self):
+        typography_module._installed_font_families.cache_clear()
+        self.addCleanup(typography_module._installed_font_families.cache_clear)
+
+    def _installed(self, *families):
+        return patch.object(
+            typography_module,
+            "_installed_font_families",
+            return_value=frozenset(name.casefold() for name in families),
+        )
+
+    def test_first_installed_name_wins(self):
+        with self._installed("Ezra SIL", "FreeSerif"):
+            self.assertEqual(
+                resolve_font(["Frank Ruehl CLM", "Ezra SIL", "FreeSerif"]), "Ezra SIL"
+            )
+
+    def test_matching_ignores_case(self):
+        with self._installed("freeserif"):
+            self.assertEqual(resolve_font(["FreeSerif"]), "FreeSerif")
+
+    def test_nothing_installed_is_an_error_naming_what_was_tried(self):
+        with self._installed("DejaVu Sans"):
+            with self.assertRaises(ValueError) as caught:
+                resolve_font(["Frank Ruehl CLM", "Ezra SIL"])
+        message = str(caught.exception)
+        self.assertIn("Frank Ruehl CLM", message)
+        self.assertIn("Ezra SIL", message)
+
+    def test_no_fontconfig_defers_the_choice_to_the_renderer(self):
+        with patch.object(typography_module.shutil, "which", return_value=None):
+            self.assertIsNone(resolve_font(["A Font That Does Not Exist"]))
+
+    def test_an_unresolvable_chain_fails_validation_naming_the_family(self):
+        with self._installed("DejaVu Sans"):
+            with self.assertRaises(ValidationError) as caught:
+                TypographyConfig.model_validate({"fonts": {"hebrew": ["No Such Face"]}})
+        message = str(caught.exception)
+        self.assertIn("hebrew", message)
+        self.assertIn("No Such Face", message)
+
+
+class TestContradictorySettings(unittest.TestCase):
+    def test_styling_notes_that_are_switched_off_is_an_error(self):
+        """Both intentions cannot hold, and the one that silently wins deletes
+        the notes."""
+        with self.assertRaises(ValidationError) as caught:
+            _validate({"notes": {"placement": "none"}, "styles": {"note": {"size": "9pt"}}})
+        self.assertIn("placement", str(caught.exception))
+
+    def test_switching_notes_off_alone_is_fine(self):
+        config = _validate({"notes": {"placement": "none"}})
+        self.assertEqual(config.notes.placement, NotePlacement.NONE)
+
+    def test_running_head_all_cannot_be_combined_with_odd_or_even(self):
+        with self.assertRaises(ValidationError):
+            _validate({"page_header": {"all": {"left": "x"}, "odd": {"left": "y"}}})
+
+
+class TestWhatTheUserWrote(unittest.TestCase):
+    """The renderer emits a directive only for a setting that was written, so
+    "written" has to stay distinguishable from "left at its default"."""
+
+    def test_an_unwritten_field_is_not_in_fields_set(self):
+        config = _validate({"line_numbers": {"increment": 10}})
+        self.assertIn("increment", config.line_numbers.model_fields_set)
+        self.assertNotIn("margin", config.line_numbers.model_fields_set)
+
+    def test_a_field_written_at_its_default_value_still_counts_as_written(self):
+        config = _validate({"line_numbers": {"increment": 5}})
+        self.assertIn("increment", config.line_numbers.model_fields_set)
+
+
+class TestTextStyle(unittest.TestCase):
+    def test_an_empty_style_says_nothing(self):
+        self.assertTrue(TextStyle().is_empty())
+        self.assertFalse(TextStyle(weight=FontWeight.BOLD).is_empty())
+
+    def test_a_font_family_accepts_a_list_or_a_string(self):
+        self.assertEqual(FontFamily.model_validate("One").names, ["One"])
+        self.assertEqual(FontFamily.model_validate(["One", "Two"]).names, ["One", "Two"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/exporter/test_typography.py
+++ b/opensiddur/tests/exporter/test_typography.py
@@ -269,6 +269,44 @@ class TestFontFamilies(unittest.TestCase):
         self.assertIn("sans", str(caught.exception))
 
 
+class TestDefaultFontsOnAMachineWithoutThem(unittest.TestCase):
+    """The default chains must never be the reason a build fails.
+
+    The house fonts are not installed everywhere — they are not on CI — and a
+    document that asked for nothing must still export. The renderer falls back
+    for the defaults; only a chain the settings file named is an error.
+    """
+
+    def _installed(self, *families):
+        return patch.object(
+            typography_module,
+            "_installed_font_families",
+            return_value=frozenset(name.casefold() for name in families),
+        )
+
+    def test_defaults_validate_where_none_of_them_is_installed(self):
+        with self._installed("DejaVu Sans"):
+            config = TypographyConfig()
+        self.assertEqual(config.fonts["latin"].names, ["Linux Libertine O"])
+
+    def test_a_settings_file_that_names_no_fonts_validates_too(self):
+        with self._installed("DejaVu Sans"):
+            TypographyConfig.model_validate({"page": {"paper": "a4paper"}})
+
+    def test_but_a_named_font_that_is_missing_still_fails(self):
+        with self._installed("DejaVu Sans"):
+            with self.assertRaises(ValidationError):
+                TypographyConfig.model_validate({"fonts": {"latin": "No Such Face"}})
+
+    def test_naming_a_default_chain_explicitly_opts_into_the_check(self):
+        """Writing it down is asking for it, whatever its value happens to be."""
+        with self._installed("DejaVu Sans"):
+            with self.assertRaises(ValidationError):
+                TypographyConfig.model_validate(
+                    {"fonts": {"latin": ["Linux Libertine O"]}}
+                )
+
+
 class TestFontResolution(unittest.TestCase):
     """The first installed name in a chain wins; none installed is an error."""
 

--- a/opensiddur/tests/exporter/test_typography_doc.py
+++ b/opensiddur/tests/exporter/test_typography_doc.py
@@ -1,0 +1,109 @@
+"""Every typography setting must be documented.
+
+A setting nobody can find is a setting nobody can use, and the reference in
+``doc/typography.md`` is only true for as long as somebody remembers to update
+it. This walks the model tree instead, so adding a field without a row in the
+table fails here rather than going unnoticed.
+"""
+
+import typing
+import unittest
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from opensiddur.exporter.typography import Styles, TextStyle, TypographyConfig
+
+
+DOC = Path(__file__).resolve().parents[3] / "doc" / "typography.md"
+
+# `page_header` and `page_footer` are running heads, documented as a section of
+# their own with their template codes rather than as a field tree; `fonts` is an
+# open mapping of user-chosen names, so it has no fixed paths to enumerate.
+_DOCUMENTED_AS_PROSE = {"page_header", "page_footer", "fonts"}
+
+
+def _model_of(annotation: object) -> type[BaseModel] | None:
+    """The model a field holds, looking through Optional and unions."""
+    candidates = (annotation,) + tuple(typing.get_args(annotation) or ())
+    for candidate in candidates:
+        if isinstance(candidate, type) and issubclass(candidate, BaseModel):
+            return candidate
+    return None
+
+
+def _setting_paths(model: type[BaseModel], prefix: str = "") -> list[str]:
+    """Every dotted key path a settings file may write.
+
+    ``TextStyle`` is not descended into: its eight attributes are the same for
+    every role and are documented once, in their own table, rather than
+    repeated two hundred times.
+    """
+    paths: list[str] = []
+    for name, field in model.model_fields.items():
+        path = f"{prefix}{name}"
+        if path in _DOCUMENTED_AS_PROSE:
+            continue
+        paths.append(path)
+        nested = _model_of(field.annotation)
+        if nested is not None and nested is not TextStyle:
+            paths.extend(_setting_paths(nested, path + "."))
+    return paths
+
+
+class TestEverySettingIsDocumented(unittest.TestCase):
+    def setUp(self):
+        self.doc = DOC.read_text(encoding="utf-8")
+
+    def test_every_setting_path_appears_in_the_reference(self):
+        """Written in full, so that searching the document for the key you have
+        in your settings file finds it."""
+        missing = [
+            path for path in _setting_paths(TypographyConfig) if f"`{path}`" not in self.doc
+        ]
+        self.assertEqual(
+            missing,
+            [],
+            "settings missing from doc/typography.md: " + ", ".join(missing),
+        )
+
+    def test_every_style_role_has_a_row_of_its_own(self):
+        """A role's default is not derivable from the attribute table, so each
+        one has to be named."""
+        missing = [
+            f"styles.{role}"
+            for role in Styles.model_fields
+            if f"styles.{role}" not in self.doc
+        ]
+        self.assertEqual(missing, [], "roles missing from doc/typography.md: " + ", ".join(missing))
+
+    def test_every_style_attribute_is_documented(self):
+        for attribute in TextStyle.model_fields:
+            self.assertIn(f"`{attribute}`", self.doc, f"style attribute {attribute}")
+
+    def test_the_prose_sections_are_actually_there(self):
+        """The paths skipped above are skipped because they are documented
+        another way, not because they are undocumented."""
+        headings = [line for line in self.doc.splitlines() if line.startswith("## ")]
+        for section in sorted(_DOCUMENTED_AS_PROSE):
+            self.assertTrue(
+                any(f"`{section}`" in heading for heading in headings),
+                f"no section heading for {section}",
+            )
+
+
+class TestExampleSettingsAreValid(unittest.TestCase):
+    """The example files are the first thing anyone copies from."""
+
+    def test_examples_validate_against_the_models(self):
+        import yaml
+
+        doc_dir = DOC.parent
+        for example in sorted(doc_dir.glob("*settings.example.yaml")):
+            with self.subTest(example=example.name):
+                data = yaml.safe_load(example.read_text(encoding="utf-8"))
+                TypographyConfig.model_validate(data.get("typography") or {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opensiddur/tests/exporter/test_typography_doc.py
+++ b/opensiddur/tests/exporter/test_typography_doc.py
@@ -9,9 +9,11 @@ table fails here rather than going unnoticed.
 import typing
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from pydantic import BaseModel
 
+from opensiddur.exporter import typography as typography_module
 from opensiddur.exporter.typography import Styles, TextStyle, TypographyConfig
 
 
@@ -96,13 +98,19 @@ class TestExampleSettingsAreValid(unittest.TestCase):
     """The example files are the first thing anyone copies from."""
 
     def test_examples_validate_against_the_models(self):
+        """Structure only: fontconfig is mocked out as unavailable, so this asks
+        whether the example is well formed, not whether the machine running the
+        tests happens to have the fonts it names."""
         import yaml
 
         doc_dir = DOC.parent
         for example in sorted(doc_dir.glob("*settings.example.yaml")):
             with self.subTest(example=example.name):
                 data = yaml.safe_load(example.read_text(encoding="utf-8"))
-                TypographyConfig.model_validate(data.get("typography") or {})
+                with patch.object(
+                    typography_module, "_installed_font_families", return_value=None
+                ):
+                    TypographyConfig.model_validate(data.get("typography") or {})
 
 
 if __name__ == "__main__":

--- a/opensiddur/tests/exporter/test_typography_tex.py
+++ b/opensiddur/tests/exporter/test_typography_tex.py
@@ -1,0 +1,422 @@
+"""Tests for the TeX side of typography settings.
+
+``opensiddur/exporter/tex/typography_tex.py`` is a pure function of the settings,
+so it is tested directly rather than through the XSLT.
+
+The property most of these tests are protecting: **a directive is emitted only
+for a setting the file actually wrote.** The stylesheet keeps every default it
+ever had and this block overrides them, so anything emitted for an unwritten
+setting is a change to a document that asked for none.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from opensiddur.exporter import typography as typography_module
+from opensiddur.exporter.typography import NamedSize, TextStyle, TypographyConfig
+from opensiddur.exporter.tex.typography_tex import (
+    build_typography_preamble,
+    documentclass_options,
+    style_tokens,
+)
+
+
+def _no_fontconfig():
+    """A machine that cannot be asked which fonts are installed.
+
+    Font resolution then defers to the renderer, which is the branch that emits
+    a fallback chain — the one worth testing, since it does not depend on which
+    fonts this machine happens to have. Both validation and emission consult
+    fontconfig, so both have to run inside this.
+    """
+    return patch.object(typography_module, "_installed_font_families", return_value=None)
+
+
+def _config(data: dict) -> TypographyConfig:
+    with _no_fontconfig():
+        return TypographyConfig.model_validate(data)
+
+
+def _tex(data: dict, has_parallel: bool = False) -> str:
+    with _no_fontconfig():
+        return build_typography_preamble(
+            TypographyConfig.model_validate(data), has_parallel
+        )
+
+
+class TestNothingConfigured(unittest.TestCase):
+    def test_an_empty_settings_section_emits_nothing_at_all(self):
+        """The whole point: an unconfigured document is the document this
+        exporter has always produced."""
+        self.assertEqual(_tex({}), "")
+
+    def test_default_class_options_are_what_they_have_always_been(self):
+        self.assertEqual(documentclass_options(_config({})), "11pt,letterpaper")
+
+
+class TestDocumentClassOptions(unittest.TestCase):
+    def test_paper_and_base_size(self):
+        options = documentclass_options(_config({"page": {"paper": "a5paper", "base_font_size": "12pt"}}))
+        self.assertEqual(options, "12pt,a5paper")
+
+    def test_one_sided_and_open_anywhere(self):
+        options = documentclass_options(
+            _config({"page": {"sides": "one", "chapter_start": "any"}})
+        )
+        self.assertEqual(options, "11pt,letterpaper,oneside,openany")
+
+    def test_the_class_defaults_are_left_unsaid(self):
+        """twoside and openright are the class's own, so saying them would
+        change the option list of a document that configured nothing."""
+        options = documentclass_options(
+            _config({"page": {"sides": "two", "chapter_start": "recto"}})
+        )
+        self.assertEqual(options, "11pt,letterpaper")
+
+    def test_custom_paper_is_left_out_of_the_class_options(self):
+        """There is no class option for it; geometry sets the dimensions."""
+        config = _config({"page": {"paper": "custom", "width": "6in", "height": "9in"}})
+        self.assertEqual(documentclass_options(config), "11pt")
+        tex = build_typography_preamble(config)
+        self.assertIn(r"\geometry{paperwidth=6in,paperheight=9in}", tex)
+
+
+class TestGeometry(unittest.TestCase):
+    def test_margins_are_emitted_only_when_written(self):
+        tex = _tex({"page": {"margins": {"top": "2cm", "inner": "25mm"}}})
+        self.assertIn("top=2cm", tex)
+        self.assertIn("inner=25mm", tex)
+        self.assertNotIn("bottom=", tex)
+        self.assertNotIn("outer=", tex)
+
+    def test_inner_and_outer_become_left_and_right_on_a_one_sided_document(self):
+        """geometry only understands inner/outer for a two-sided document; on a
+        one-sided one they are simply the left and right margins."""
+        tex = _tex({"page": {"sides": "one", "margins": {"inner": "1in", "outer": "2in"}}})
+        self.assertIn("left=1in", tex)
+        self.assertIn("right=2in", tex)
+        self.assertNotIn("inner=", tex)
+
+    def test_binding_offset(self):
+        self.assertIn("bindingoffset=5mm", _tex({"page": {"margins": {"binding_offset": "5mm"}}}))
+
+    def test_landscape(self):
+        self.assertIn(r"\geometry{landscape}", _tex({"page": {"orientation": "landscape"}}))
+
+    def test_no_geometry_call_when_the_page_is_not_configured(self):
+        self.assertNotIn(r"\geometry", _tex({"page": {"base_font_size": "12pt"}}))
+
+
+class TestFonts(unittest.TestCase):
+    def test_an_undeclared_family_is_left_to_the_stylesheet(self):
+        """The stylesheet already declares latin and hebrew with the same chain,
+        so re-emitting it would be noise at best."""
+        self.assertNotIn(r"\setmainfont", _tex({}))
+
+    def test_a_declared_latin_family_sets_the_main_font(self):
+        """One name is not a chain: it is named outright, with no test around
+        it, so a font that is not there fails the build rather than quietly
+        becoming something else."""
+        tex = _tex({"fonts": {"latin": "TeX Gyre Pagella"}})
+        self.assertIn(r"\setmainfont{TeX Gyre Pagella}", tex)
+        self.assertNotIn(r"\IfFontExistsTF", tex)
+
+    def test_a_declared_hebrew_family_renews_rather_than_declares(self):
+        """\\hebrewfont already exists — the stylesheet declared it — so a
+        \\newfontfamily here would be a "command already defined" error."""
+        tex = _tex({"fonts": {"hebrew": ["Ezra SIL"]}})
+        self.assertIn(r"\renewfontfamily\hebrewfont", tex)
+        self.assertNotIn(r"\newfontfamily\hebrewfont", tex)
+        self.assertIn("Renderer=HarfBuzz", tex)
+        self.assertIn(r"\let\hebrewfontsf\hebrewfont", tex)
+
+    def test_a_chain_becomes_nested_tests_when_fontconfig_cannot_choose(self):
+        tex = _tex({"fonts": {"latin": ["First", "Second", "Third"]}})
+        self.assertIn(r"\IfFontExistsTF{First}", tex)
+        self.assertIn(r"\IfFontExistsTF{Second}", tex)
+        # The last name is the fallback, not another test.
+        self.assertNotIn(r"\IfFontExistsTF{Third}", tex)
+        self.assertIn(r"\setmainfont{Third}", tex)
+
+    def test_a_resolved_chain_names_one_font_outright(self):
+        with patch.object(
+            typography_module,
+            "_installed_font_families",
+            return_value=frozenset({"second", "freeserif"}),
+        ):
+            config = TypographyConfig.model_validate({"fonts": {"latin": ["First", "Second"]}})
+            tex = build_typography_preamble(config)
+        self.assertIn(r"\setmainfont{Second}", tex)
+        self.assertNotIn(r"\IfFontExistsTF", tex)
+
+    def test_a_user_family_gets_a_command_named_after_its_key(self):
+        tex = _tex({"fonts": {"note-sans": "DejaVu Sans"}})
+        self.assertIn(r"\newfontfamily\OSfontNoteSans{DejaVu Sans}", tex)
+
+    def test_a_style_selects_a_user_family_by_that_command(self):
+        tex = _tex(
+            {"fonts": {"note-sans": "DejaVu Sans"}, "styles": {"note": {"font": "note-sans"}}}
+        )
+        self.assertIn(r"\renewcommand{\notenote}[1]{{\OSfontNoteSans #1}}", tex)
+
+
+class TestStyleTokens(unittest.TestCase):
+    def test_the_named_ladder_maps_onto_the_size_commands(self):
+        for name, command in (
+            (NamedSize.XXX_SMALL, r"\tiny"),
+            (NamedSize.SMALL, r"\small"),
+            (NamedSize.NORMAL, r"\normalsize"),
+            (NamedSize.XX_LARGE, r"\LARGE"),
+            (NamedSize.XXXX_LARGE, r"\Huge"),
+        ):
+            self.assertEqual(style_tokens(TextStyle(size=name)), command)
+
+    def test_an_absolute_size_carries_a_baseline_too(self):
+        """\\fontsize sets both, so a size given alone would leave the leading
+        of whatever font was in force."""
+        self.assertEqual(
+            style_tokens(TextStyle(size="10pt")), r"\fontsize{10pt}{12pt}\selectfont"
+        )
+
+    def test_line_spacing_scales_the_baseline_of_an_absolute_size(self):
+        self.assertEqual(
+            style_tokens(TextStyle(size="10pt"), line_spacing=1.5),
+            r"\fontsize{10pt}{18pt}\selectfont",
+        )
+
+    def test_weight_style_and_variant(self):
+        self.assertEqual(
+            style_tokens(TextStyle(weight="bold", style="italic", variant="small-caps")),
+            r"\bfseries\itshape\scshape",
+        )
+
+    def test_normal_is_stated_rather_than_implied(self):
+        """A role whose default is bold needs a way to say "not bold"."""
+        self.assertEqual(style_tokens(TextStyle(weight="normal")), r"\mdseries")
+
+
+class TestStyles(unittest.TestCase):
+    def test_only_the_written_roles_are_emitted(self):
+        tex = _tex({"styles": {"heading1": {"size": "large"}}})
+        self.assertIn(r"\renewcommand{\OSheadA}", tex)
+        self.assertNotIn(r"\OSheadB", tex)
+
+    def test_headings_are_aligned_with_fill_glue_not_a_paragraph(self):
+        """reledmac captures numbered text one \\par-delimited line at a time, so
+        a \\par here would escape that capture and, under reledpar, land outside
+        its column."""
+        tex = _tex({"styles": {"heading1": {"size": "large", "align": "center"}}})
+        self.assertIn(r"\mbox{}\hfill{\normalfont\large #1}\hfill\mbox{}", tex)
+        self.assertNotIn(r"\centering", tex)
+
+    def test_left_and_right_alignment_use_one_sided_fill(self):
+        self.assertIn(
+            r"\renewcommand{\OSheadA}[1]{{\normalfont\large #1}\hfill\mbox{}}",
+            _tex({"styles": {"heading1": {"size": "large", "align": "left"}}}),
+        )
+        self.assertIn(
+            r"\renewcommand{\OSheadA}[1]{\mbox{}\hfill{\normalfont\large #1}}",
+            _tex({"styles": {"heading1": {"size": "large", "align": "right"}}}),
+        )
+
+    def test_title_page_roles_are_real_paragraphs(self):
+        """A title page is set outside all numbering, so it can have proper
+        centred paragraphs with line breaking."""
+        tex = _tex({"styles": {"title_main": {"size": "xxxx-large", "align": "center"}}})
+        self.assertIn(r"{\centering\normalfont\Huge #1\par}", tex)
+
+    def test_space_before_and_after_sit_outside_the_group(self):
+        tex = _tex({"styles": {"byline": {"space_before": "3ex", "space_after": "1ex"}}})
+        self.assertIn(r"\renewcommand{\OSByline}[1]{\vspace{3ex}{", tex)
+        self.assertTrue(tex.rstrip().endswith(r"\par}\vspace{1ex}}"))
+
+    def test_verse_and_chapter_numbers_stay_left_to_right(self):
+        """Digits laid out in an RTL context come out reversed: 50 reads 05."""
+        for role, macro in (("verse_number", r"\vno"), ("chapter_number", r"\chno")):
+            tex = _tex({"styles": {role: {"size": "small"}}})
+            self.assertIn(rf"\renewcommand{{{macro}}}[1]{{", tex)
+            self.assertIn(r"\textdir TLT\selectlanguage{english}", tex)
+
+    def test_body_style_goes_through_the_document_wide_hook(self):
+        self.assertIn(
+            r"\renewcommand{\OSBodyStyle}{\small}", _tex({"styles": {"body": {"size": "small"}}})
+        )
+
+    def test_notes_and_instructions(self):
+        self.assertIn(
+            r"\renewcommand{\notenote}[1]{{\mdseries #1}}",
+            _tex({"styles": {"note": {"weight": "normal"}}}),
+        )
+        self.assertIn(
+            r"\renewcommand{\instructionnote}[1]{{\itshape #1}}",
+            _tex({"styles": {"instruction": {"style": "italic"}}}),
+        )
+
+
+class TestParagraphs(unittest.TestCase):
+    def test_indent_spacing_and_leading(self):
+        tex = _tex({"paragraphs": {"indent": "1em", "spacing": "1ex", "line_spacing": 1.5}})
+        self.assertIn(r"\setlength{\parindent}{1em}", tex)
+        self.assertIn(r"\setlength{\parskip}{1ex}", tex)
+        self.assertIn(r"\linespread{1.5}\selectfont", tex)
+
+    def test_alignment_is_applied_where_it_takes_effect(self):
+        """\\raggedright in a preamble is a no-op; it has to be applied once the
+        document has started."""
+        self.assertIn(r"\AtBeginDocument{\raggedright}", _tex({"paragraphs": {"alignment": "left"}}))
+
+    def test_justified_is_the_absence_of_raggedness(self):
+        self.assertEqual(_tex({"paragraphs": {"alignment": "justify"}}), "")
+
+
+class TestLineNumbers(unittest.TestCase):
+    def test_switching_them_off_uses_reledmacs_own_switch(self):
+        """The numbering machinery still runs, so cross-references and the
+        apparatus are unaffected; only the printing stops."""
+        self.assertIn(r"\numberlinefalse", _tex({"line_numbers": {"enabled": False}}))
+
+    def test_switching_them_off_makes_the_rest_of_the_section_moot(self):
+        tex = _tex({"line_numbers": {"enabled": False, "increment": 2}})
+        self.assertNotIn(r"\linenumincrement", tex)
+
+    def test_increment_first_and_separation(self):
+        tex = _tex({"line_numbers": {"increment": 2, "first": 1, "separation": "2em"}})
+        self.assertIn(r"\linenumincrement{2}", tex)
+        self.assertIn(r"\firstlinenum{1}", tex)
+        self.assertIn(r"\setlength{\linenumsep}{2em}", tex)
+
+    def test_the_right_hand_stream_is_configured_only_in_a_parallel_document(self):
+        """\\linenumincrementR does not exist unless reledpar is loaded, and it is
+        loaded only for a document with two aligned streams."""
+        self.assertNotIn(r"\linenumincrementR", _tex({"line_numbers": {"increment": 2}}))
+        self.assertIn(
+            r"\linenumincrementR{2}", _tex({"line_numbers": {"increment": 2}}, has_parallel=True)
+        )
+
+    def test_lineation_unit_and_margin(self):
+        tex = _tex({"line_numbers": {"unit": "section", "margin": "inner"}})
+        self.assertIn(r"\lineation{section}", tex)
+        self.assertIn(r"\linenummargin{inner}", tex)
+
+    def test_hebrew_numerals_need_no_left_to_right_wrapper(self):
+        """Their output is Hebrew letters, which belong in the surrounding
+        direction; only digits have to be forced."""
+        tex = _tex({"line_numbers": {"numerals": "hebrew"}})
+        self.assertIn(r"\hebrewnumeral{#1}", tex)
+        self.assertNotIn(r"\textdir TLT", tex)
+
+    def test_the_number_is_formatted_through_linenumrep(self):
+        """\\linenumberstyle is a declaration whose only job is to define
+        \\linenumrep, and reledmac calls it once as it loads — so redefining it
+        afterwards silently does nothing."""
+        tex = _tex({"line_numbers": {"numerals": "hebrew"}})
+        self.assertIn(r"\renewcommand*{\linenumrep}", tex)
+        self.assertNotIn(r"\linenumberstyle", tex)
+
+    def test_a_line_number_style_and_the_numeral_system_share_one_macro(self):
+        """Emitting them separately would let the second silently discard the
+        first."""
+        tex = _tex(
+            {
+                "styles": {"line_number": {"size": "small"}},
+                "line_numbers": {"numerals": "hebrew"},
+            }
+        )
+        self.assertEqual(tex.count(r"\renewcommand*{\linenumrep}"), 1)
+        self.assertIn(r"\small\hebrewnumeral{#1}", tex)
+
+    def test_the_right_hand_stream_is_formatted_only_in_a_parallel_document(self):
+        settings = {"styles": {"line_number": {"size": "small"}}}
+        self.assertNotIn(r"\linenumrepR", _tex(settings))
+        self.assertIn(r"\linenumrepR", _tex(settings, has_parallel=True))
+
+
+class TestNotes(unittest.TestCase):
+    def test_the_default_anchor_is_raised_and_zero_width(self):
+        """Zero width is what keeps the annotated text from being respaced, and
+        with it the two sides of a parallel text aligned."""
+        tex = _tex({"notes": {"anchor": "interlinear"}})
+        self.assertIn(r"\hbox to 0pt", tex)
+        self.assertIn(r"\raisebox{1.5ex}", tex)
+
+    def test_a_superscript_anchor(self):
+        tex = _tex({"notes": {"anchor": "superscript"}})
+        self.assertIn(r"\renewcommand{\OSInterlinearNotemark}[1]{", tex)
+        self.assertIn(r"\textsuperscript", tex)
+        self.assertNotIn(r"\hbox to 0pt", tex)
+
+    def test_an_inline_anchor(self):
+        tex = _tex({"notes": {"anchor": "inline"}})
+        self.assertNotIn(r"\textsuperscript", tex)
+        self.assertNotIn(r"\raisebox", tex)
+
+    def test_the_mark_keeps_its_sans_face_unless_a_font_is_asked_for(self):
+        """Changing the anchor should not silently change the face too."""
+        self.assertIn(r"\sffamily", _tex({"notes": {"anchor": "inline"}}))
+        tex = _tex(
+            {"fonts": {"serif": "FreeSerif"}, "styles": {"note_mark": {"font": "serif"}}}
+        )
+        self.assertNotIn(r"\sffamily", tex)
+        self.assertIn(r"\OSfontSerif", tex)
+
+    def test_the_lemma_is_not_a_setting(self):
+        """A note anchors at a point, so there are no annotated words to repeat;
+        the apparatus lemma is the mark itself."""
+        with self.assertRaises(Exception):
+            _tex({"notes": {"show_lemma": True}})
+
+
+class TestMarkers(unittest.TestCase):
+    def test_the_section_separator_is_escaped(self):
+        tex = _tex({"markers": {"section_separator": "~ & ~"}})
+        self.assertIn(r"\textasciitilde{}", tex)
+        self.assertIn(r"\&", tex)
+
+    def test_an_empty_separator_leaves_nothing_but_the_space(self):
+        self.assertIn(r"\renewcommand{\OSSectionSeparator}{}", _tex({"markers": {"section_separator": ""}}))
+
+    def test_hiding_verse_and_chapter_numbers(self):
+        tex = _tex({"markers": {"verse_numbers": "hidden", "chapter_numbers": "hidden"}})
+        self.assertIn(r"\renewcommand{\vno}[1]{}", tex)
+        self.assertIn(r"\renewcommand{\chno}[1]{}", tex)
+
+    def test_showing_them_is_the_stylesheet_default_and_emits_nothing(self):
+        self.assertEqual(_tex({"markers": {"verse_numbers": "shown"}}), "")
+
+    def test_conditional_inline_markers(self):
+        tex = _tex({"markers": {"conditional": {"inline_open": "(", "inline_close": ")"}}})
+        self.assertIn(r"\renewcommand{\OSCondStartInline}{{\bfseries(}}", tex)
+        self.assertIn(r"\renewcommand{\OSCondEndInline}{{\bfseries)}}", tex)
+
+    def test_the_conditional_block_rule(self):
+        tex = _tex({"markers": {"conditional": {"rule_width": "50%", "rule_thickness": "1pt"}}})
+        self.assertIn(r"\rule{0.5\linewidth}{1pt}", tex)
+
+    def test_a_bracketed_conditional_block_reuses_the_inline_markers(self):
+        tex = _tex({"markers": {"conditional": {"block": "brackets"}}})
+        self.assertIn(r"\renewcommand{\OSCondStartBlock}{\OSCondStartInline}", tex)
+
+    def test_conditional_blocks_can_be_left_unmarked(self):
+        tex = _tex({"markers": {"conditional": {"block": "none"}}})
+        self.assertIn(r"\renewcommand{\OSCondStartBlock}{}", tex)
+        self.assertIn(r"\renewcommand{\OSCondEndBlock}{}", tex)
+
+
+class TestParallelColumns(unittest.TestCase):
+    def test_column_geometry_needs_two_columns_on_one_page(self):
+        settings = {"parallel": {"column_width": "40%", "column_position": "left"}}
+        self.assertEqual(_tex(settings), "")
+        tex = _tex(settings, has_parallel=True)
+        self.assertIn(r"\setlength{\Lcolwidth}{0.4\textwidth}", tex)
+        self.assertIn(r"\setlength{\Rcolwidth}{0.4\textwidth}", tex)
+        self.assertIn(r"\columnsposition{L}", tex)
+
+    def test_facing_pages_have_no_columns_to_size(self):
+        tex = _tex(
+            {"parallel": {"layout": "pages", "column_width": "40%"}}, has_parallel=True
+        )
+        self.assertNotIn(r"\Lcolwidth", tex)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tei-to-pdf.sh
+++ b/scripts/tei-to-pdf.sh
@@ -9,8 +9,9 @@
 #
 # The optional ``-s <settings-file>`` flag is forwarded to *both* stages:
 #   - the compiler reads ``priority``, ``parallel``, ``annotations``;
-#   - the PDF stage reads ``typography`` (fonts, layout, paper, fontsize,
-#     running heads and feet).
+#   - the PDF stage reads ``typography`` (paper and margins, fonts, the size and
+#     weight of each kind of text, line spacing, line numbers, note marking,
+#     running heads and feet). See doc/typography.md for the full reference.
 #
 # Usage:
 #   ./tei-to-pdf.sh [-s <settings-file>] [--keep-tex | --tex-output <path>] <project> <file_name> <output-file>


### PR DESCRIPTION
Closes #36.

Fonts, sizes, spacing and every other formatting decision were either hardcoded in `reledmac.xslt` or exposed as one of five flat keys under `typography`. This expands that section into a documented, validated settings tree.

## What is configurable now

`fonts`, `page` (paper including `custom`, orientation, sides, chapter start, base font size, margins), `paragraphs` (indent, spacing, leading, alignment), `styles` (23 roles × 8 attributes), `line_numbers`, `notes`, `markers` (section separator, verse/chapter number visibility, conditional markers), `parallel` (layout, column width and position), plus the existing `table_of_contents` and running heads.

`doc/typography.md` is the full reference.

## Three properties shape it

**Renderer-agnostic.** `opensiddur/exporter/typography.py` holds the models and knows nothing about TeX — sizes are a named ladder (`xxx-small` … `xxxx-large`) or an absolute length, not `\LARGE`; a page has `inner` and `outer` margins, not `geometry` options. `tex/typography_tex.py` does the translation. There is no TeX in a settings file and no place to put any.

**Fail fast.** Every model forbids unknown keys, so a mistyped setting names itself and its path instead of being silently dropped. Every vocabulary is a closed enum, lengths are pattern-checked, `base_font_size` is restricted to the three sizes that actually exist, and cross-field checks catch contradictions (`paper: custom` without dimensions, a style naming an undeclared font family). Font chains are resolved against `fc-list` and a chain with nothing installed is an error naming the family and every name tried. Validation runs outside `transform_xml_to_tex`'s catch-all, which was flattening pydantic's message to one line.

**Sensible defaults, all documented.** The stylesheet keeps every default it ever had; the settings block is emitted after them and overrides them. A directive is emitted **only for a setting the file actually wrote**, not for one that merely equals its default — some of the stylesheet's behaviour is contextual and no single default value can stand for it. So an unconfigured document is unchanged: verified against `main`, the default `.tex` differs by three inert hook macros (`\OSBodyStyle`, `\OSSectionSeparator`, `\OSSectionSeparatorStyle`) and nothing else.

## Breaking change

The `typography` section is restructured with no back-compat aliases. Only `doc/exporter-settings.example.yaml` and `doc/humash-settings.example.yaml` used the old flat keys; both are ported. No project ships a settings file, and `exporter/README.md` already warned the format would change.

## Testing

1711 tests pass. New: `test_typography.py` (models and validation), `test_typography_tex.py` (TeX generation), `test_typography_doc.py` — which walks the model tree and fails if a field has no row in `doc/typography.md`, so the reference cannot drift.

Verified end-to-end by building real PDFs: A5/10pt with margins, 1.4 leading and line numbers off; custom 6×9in paper with Hebrew line numerals and hidden verse numbers; endnotes with symbol marks; and the haggadah in both `pairs` and `pages` parallel layouts.

## Three things worth a reviewer's attention

1. **`notes.show_lemma` was cut.** It cannot mean anything here — a `tei:note` anchors at a point, so the `\edtext` lemma *is* the mark, and enabling it printed `∗ ] ∗ the note text`. Found by rendering, not by reading.

2. **`\linenumberstyle` in `reledmac.xslt` has always been a no-op.** It is a declaration whose only job is to define `\linenumrep`, and reledmac calls it once as it loads — so the stylesheet's redefinition never takes effect and left-side line numbers have never been LTR-wrapped, despite the comment saying so. I annotated it and pointed the new settings at `\linenumrep`, but did **not** correct it: doing so changes the output of every existing document, which is a separate decision.

3. **`line_numbers.margin` is ignored in `pairs` layout.** The stylesheet forces each column to its nearer outer margin, since the alternative is numbers in the gutter between the columns. Documented as such rather than silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)