### PR TITLE
Download the pages the Birnbaum scan pages transclude their text from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   what changed — for the 815-page Birnbaum siddur that is ~17 requests and no file writes, against
   ~1,630 requests before. Downloads all 815 pages into `sourcetexts/sources/birnbaum_siddur/`
   as `text/NNN.txt` and `credits/NNN.txt`, matching the `jps1917` layout.
+- The Birnbaum importer now also downloads the pages the scans transclude their text from. Those
+  815 scan pages hold almost no text — median size 109 bytes — because 405 of them are mostly
+  `{{#קטע:PAGE|SECTION}}` calls, the Hebrew localisation of `{{#lst:}}` (labeled section
+  transclusion), with the text living in mainspace pages. The client gained generic support for
+  that mechanism (`find_transclusions`, `find_sections`, `is_redirect`, `download_closure`),
+  matching the localised parser-function and tag aliases rather than only the English spellings,
+  which is what hid this to begin with. 324 subtree pages land under `source/`, transitively
+  referenced pages outside it under `external/`, both mirroring the wiki's title hierarchy as
+  directories; a new `structure.json` records which named sections each page defines and which it
+  transcludes, including for the scan pages, since that is what ties printed pagination to
+  liturgical text. Redirects are kept — 151 of the subtree pages are redirects carrying
+  alternative names for a service.
+
+### Fixed
+- Batched Action API queries are sent as POST. Fifty Hebrew subpage titles percent-encode past the
+  URL length limit and the server answered `414 URI Too Long`, so batching was silently capped by
+  URL length on any wiki whose titles are not short and Latin.
 
 ### Changed
 - `RELEASE_PROCEDURE.md` now says to re-lock and push `uv.lock` after a release. The release script

--- a/opensiddur/importer/birnbaum_siddur/wikisource.py
+++ b/opensiddur/importer/birnbaum_siddur/wikisource.py
@@ -23,22 +23,34 @@ import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from opensiddur.importer.util.pages import (
     birnbaum_siddur_credits_directory,
     birnbaum_siddur_data_directory,
+    birnbaum_siddur_external_credits_directory,
+    birnbaum_siddur_external_text_directory,
+    birnbaum_siddur_source_credits_directory,
+    birnbaum_siddur_source_text_directory,
     birnbaum_siddur_text_directory,
     default_sourcetexts_root,
+    relative_path_to_title,
+    title_to_relative_path,
 )
 from opensiddur.importer.util.wikisource import (
     CONTACT_EMAIL_ENV_VAR,
     Wiki,
     WikisourceError,
     connect,
+    download_closure,
     fetch_contributors,
     fetch_revisions,
+    find_sections,
+    find_transclusions,
+    is_redirect,
     list_book_pages,
+    list_pages_with_prefix,
+    normalize_title,
     resolve_contact_email,
 )
 
@@ -49,7 +61,17 @@ SERVER = "he.wikisource.org"
 WIKI_NAMESPACE = "עמוד"  # ProofreadPage namespace 104, as named on he.wikisource
 BOOK_NAME = "Philip Birnbaum - ha-Siddur ha-Shalem (The Daily Prayer Book,1949).pdf"
 
+# The scan pages are nearly empty: they lay out the printed page and pull the actual
+# text in from this mainspace subtree with {{#קטע:…}} (labeled section transclusion).
+SOURCE_ROOT = "הסידור השלם (בירנבוים)"
+
+# Stop runaway traversal if the wiki ever grows a link out into unrelated content.
+# The real graph settles in two hops; anything deeper deserves a look before it is
+# silently downloaded.
+MAX_SOURCE_DEPTH = 5
+
 MANIFEST_NAME = "manifest.json"
+STRUCTURE_NAME = "structure.json"
 
 
 def _sha256(text: str) -> str:
@@ -111,6 +133,207 @@ def _needs_download(
     )
 
 
+def is_scan_page(title: str) -> bool:
+    """Whether a title names one of the scan pages we download page-by-page."""
+    return normalize_title(title).startswith(f"{WIKI_NAMESPACE}:")
+
+
+def classify_source_title(title: str) -> tuple[str, str]:
+    """Split a title into which tree it belongs in and its path within that tree.
+
+    Subtree pages drop the shared root prefix, so the on-disk layout mirrors the
+    siddur's own organization rather than repeating its name in every path. Anything
+    else keeps its full title, and the two trees stay separate so a path is never
+    ambiguous about whether a prefix was stripped.
+    """
+    title = normalize_title(title)
+    if title == SOURCE_ROOT:
+        return "source", "index"
+    if title.startswith(f"{SOURCE_ROOT}/"):
+        return "source", title[len(SOURCE_ROOT) + 1 :]
+    return "external", title
+
+
+def source_page_paths(
+    title: str, sourcetexts_root: Path | None = None
+) -> tuple[Path, Path]:
+    """Where the wikitext and credits for a source page belong."""
+    area, relative = classify_source_title(title)
+    if area == "source":
+        text_dir = birnbaum_siddur_source_text_directory(sourcetexts_root)
+        credits_dir = birnbaum_siddur_source_credits_directory(sourcetexts_root)
+    else:
+        text_dir = birnbaum_siddur_external_text_directory(sourcetexts_root)
+        credits_dir = birnbaum_siddur_external_credits_directory(sourcetexts_root)
+    relative_path = title_to_relative_path(relative)
+    return text_dir / relative_path, credits_dir / relative_path
+
+
+def download_source_pages(
+    wiki: Wiki,
+    sourcetexts_root: Path | None = None,
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+    manifest_pages: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], int]:
+    """Download the mainspace pages the scan pages transclude their text from.
+
+    Returns manifest entries keyed by wiki title, and how many pages were written.
+    Scan pages are deliberately not followed: they are downloaded separately, and the
+    two layers reference each other, so following them here would fetch the whole
+    book twice.
+    """
+    recorded: dict[str, Any] = {} if force else dict(manifest_pages or {})
+
+    logger.info("Enumerating the %s subtree ...", SOURCE_ROOT)
+    roots = list_pages_with_prefix(wiki, f"{SOURCE_ROOT}/")
+    # The prefix search cannot match the root page itself, whose title has no slash.
+    roots.append(SOURCE_ROOT)
+    logger.info("Found %d pages in the subtree", len(roots))
+
+    logger.info("Following transclusions ...")
+    revisions = download_closure(
+        wiki,
+        roots,
+        include=lambda title: not is_scan_page(title),
+        max_depth=MAX_SOURCE_DEPTH,
+    )
+
+    outside = sorted(t for t in revisions if classify_source_title(t)[0] == "external")
+    if outside:
+        logger.info("Pulled in %d page(s) from outside the subtree: %s", len(outside), outside)
+
+    titles = sorted(revisions)
+    stale = [
+        title
+        for title in titles
+        if force
+        or recorded.get(title, {}).get("revid") != revisions[title].revid
+        or not all(p.is_file() for p in source_page_paths(title, sourcetexts_root))
+    ]
+    logger.info("%d of %d source pages need writing", len(stale), len(titles))
+
+    if dry_run or not stale:
+        if not stale:
+            logger.info("Source pages are already up to date.")
+        return recorded, 0
+
+    logger.info("Fetching contributors for source pages ...")
+    contributors = fetch_contributors(wiki, stale)
+
+    written = 0
+    for title in stale:
+        revision = revisions[title]
+        if revision.content is None:
+            logger.warning("No wikitext returned for %s; leaving it for the next run", title)
+            continue
+        text_path, credits_path = source_page_paths(title, sourcetexts_root)
+        credits_text = "\n".join(contributors.get(title, []))
+
+        text_path.parent.mkdir(parents=True, exist_ok=True)
+        credits_path.parent.mkdir(parents=True, exist_ok=True)
+        text_path.write_text(revision.content, encoding="utf-8")
+        credits_path.write_text(credits_text, encoding="utf-8")
+
+        redirect, target = is_redirect(revision.content)
+        recorded[title] = {
+            "revid": revision.revid,
+            "timestamp": revision.timestamp,
+            "text_sha256": _sha256(revision.content),
+            "credits_sha256": _sha256(credits_text),
+            "redirect_target": target if redirect else None,
+        }
+        written += 1
+        if written % 50 == 0:
+            logger.info("Wrote %d/%d source pages", written, len(stale))
+
+    logger.info("Wrote %d source pages", written)
+    return recorded, written
+
+
+def _iter_stored_pages(
+    sourcetexts_root: Path | None = None,
+) -> Iterator[tuple[str, Path]]:
+    """Every downloaded page as ``(wiki title, path to its wikitext)``."""
+    scan_dir = birnbaum_siddur_text_directory(sourcetexts_root)
+    if scan_dir.is_dir():
+        for path in sorted(scan_dir.glob("*.txt")):
+            yield f"{WIKI_NAMESPACE}:{BOOK_NAME}/{int(path.stem)}", path
+
+    for area, directory in (
+        ("source", birnbaum_siddur_source_text_directory(sourcetexts_root)),
+        ("external", birnbaum_siddur_external_text_directory(sourcetexts_root)),
+    ):
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*.txt")):
+            relative = relative_path_to_title(path.relative_to(directory))
+            if area == "source":
+                title = SOURCE_ROOT if relative == "index" else f"{SOURCE_ROOT}/{relative}"
+            else:
+                title = relative
+            yield title, path
+
+
+def build_structure(sourcetexts_root: Path | None = None) -> dict[str, Any]:
+    """Describe how the downloaded pages fit together.
+
+    Derived entirely from the wikitext on disk, so it can be regenerated at any time
+    and is never a second source of truth. What it records is the thing Wikisource
+    contributes beyond the raw text: which named sections each page defines, and
+    which sections every other page pulls in. The scan pages are included precisely
+    because their transclusions are what tie the printed pagination to the liturgical
+    text.
+    """
+    pages: dict[str, Any] = {}
+    defined: dict[str, set[str]] = {}
+    data_dir = birnbaum_siddur_data_directory(sourcetexts_root)
+
+    for title, path in _iter_stored_pages(sourcetexts_root):
+        content = path.read_text(encoding="utf-8")
+        redirect, target = is_redirect(content)
+        sections = find_sections(content)
+        defined[normalize_title(title)] = set(sections)
+        pages[title] = {
+            "path": str(path.relative_to(data_dir)),
+            "redirect_target": target if redirect else None,
+            "defines": sections,
+            "transcludes": [
+                {"title": ref_title, "section": section}
+                for ref_title, section in find_transclusions(content)
+            ],
+        }
+
+    dangling = sorted(
+        {
+            (reference["title"], reference["section"])
+            for page in pages.values()
+            for reference in page["transcludes"]
+            if reference["section"] not in defined.get(normalize_title(reference["title"]), ())
+        }
+    )
+
+    return {
+        "generated_from": (
+            "the wikitext in text/, source/text/ and external/text/; regenerate rather "
+            "than edit by hand"
+        ),
+        "pages": pages,
+        "dangling": [{"title": t, "section": s} for t, s in dangling],
+    }
+
+
+def save_structure(structure: dict[str, Any], sourcetexts_root: Path | None = None) -> Path:
+    path = birnbaum_siddur_data_directory(sourcetexts_root) / STRUCTURE_NAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(structure, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
 def download_book(
     contact_email: str,
     sourcetexts_root: Path | None = None,
@@ -118,6 +341,7 @@ def download_book(
     dry_run: bool = False,
     force: bool = False,
     wiki: Wiki | None = None,
+    include_source: bool = True,
 ) -> dict[str, Any]:
     """Download every transcribed page of the book, skipping unchanged ones.
 
@@ -169,67 +393,94 @@ def download_book(
         ):
             stale.append(number)
 
-    logger.info("%d of %d pages need downloading", len(stale), len(page_numbers))
+    logger.info("%d of %d scan pages need downloading", len(stale), len(page_numbers))
 
+    written = 0
     if not stale:
-        logger.info("Everything is already up to date.")
-        return manifest
+        logger.info("Scan pages are already up to date.")
+    elif not dry_run:
+        stale_titles = [titles_by_number[n] for n in stale]
+        logger.info("Fetching wikitext ...")
+        contents = fetch_revisions(wiki, stale_titles, include_content=True)
+        logger.info("Fetching contributors ...")
+        contributors = fetch_contributors(wiki, stale_titles)
+
+        text_dir.mkdir(parents=True, exist_ok=True)
+        credits_dir.mkdir(parents=True, exist_ok=True)
+
+        for number in stale:
+            title = titles_by_number[number]
+            revision = contents.get(title)
+            if revision is None or revision.content is None:
+                logger.warning("No wikitext returned for %s; leaving it for the next run", title)
+                continue
+
+            key = page_key(number, digits)
+            credits_text = "\n".join(contributors.get(title, []))
+
+            (text_dir / f"{key}.txt").write_text(revision.content, encoding="utf-8")
+            (credits_dir / f"{key}.txt").write_text(credits_text, encoding="utf-8")
+
+            manifest_pages[key] = {
+                "revid": revision.revid,
+                "timestamp": revision.timestamp,
+                "text_sha256": _sha256(revision.content),
+                "credits_sha256": _sha256(credits_text),
+            }
+            written += 1
+            if written % 50 == 0:
+                logger.info("Wrote %d/%d scan pages", written, len(stale))
+
+    # The scan pages carry almost no text of their own; this is where it lives.
+    source_pages: dict[str, Any] = {} if force else dict(manifest.get("source_pages") or {})
+    source_written = 0
+    if include_source:
+        source_pages, source_written = download_source_pages(
+            wiki,
+            sourcetexts_root,
+            dry_run=dry_run,
+            force=force,
+            manifest_pages=source_pages,
+        )
 
     if dry_run:
         logger.info(
-            "Dry run: would download %d pages into %s and update %s",
+            "Dry run: would write %d scan page(s) and refresh source pages under %s",
             len(stale),
             data_dir,
-            manifest_path(sourcetexts_root),
         )
         return manifest
 
-    stale_titles = [titles_by_number[n] for n in stale]
-    logger.info("Fetching wikitext ...")
-    contents = fetch_revisions(wiki, stale_titles, include_content=True)
-    logger.info("Fetching contributors ...")
-    contributors = fetch_contributors(wiki, stale_titles)
-
-    text_dir.mkdir(parents=True, exist_ok=True)
-    credits_dir.mkdir(parents=True, exist_ok=True)
-
-    written = 0
-    for number in stale:
-        title = titles_by_number[number]
-        revision = contents.get(title)
-        if revision is None or revision.content is None:
-            logger.warning("No wikitext returned for %s; leaving it for the next run", title)
-            continue
-
-        key = page_key(number, digits)
-        credits_text = "\n".join(contributors.get(title, []))
-
-        (text_dir / f"{key}.txt").write_text(revision.content, encoding="utf-8")
-        (credits_dir / f"{key}.txt").write_text(credits_text, encoding="utf-8")
-
-        manifest_pages[key] = {
-            "revid": revision.revid,
-            "timestamp": revision.timestamp,
-            "text_sha256": _sha256(revision.content),
-            "credits_sha256": _sha256(credits_text),
-        }
-        written += 1
-        if written % 50 == 0:
-            logger.info("Wrote %d/%d pages", written, len(stale))
+    structure_file = data_dir / STRUCTURE_NAME
+    if not (written or source_written or not structure_file.is_file()):
+        # Nothing changed. Leaving the manifest alone keeps a no-op re-run genuinely
+        # no-op, so an unchanged run never shows up as a diff.
+        logger.info("Everything is already up to date.")
+        return manifest
 
     manifest = {
         "source": wiki.server,
         "book_name": BOOK_NAME,
         "namespace": WIKI_NAMESPACE,
+        "source_root": SOURCE_ROOT,
         "downloaded_at": datetime.now(timezone.utc).isoformat(),
         "pages": manifest_pages,
+        "source_pages": source_pages,
     }
     # Written once, at the end. A crash mid-run then leaves the previous manifest
     # intact and the interrupted pages simply look stale next time, which is safer
     # than a per-page write that could claim a page is current when its file was
     # only half written.
     save_manifest(manifest, sourcetexts_root)
-    logger.info("Wrote %d pages; manifest updated at %s", written, manifest_path(sourcetexts_root))
+    structure = build_structure(sourcetexts_root)
+    save_structure(structure, sourcetexts_root)
+    logger.info(
+        "Wrote %d scan page(s) and %d source page(s); %d pages indexed, %d dangling reference(s)",
+        written,
+        source_written,
+        len(structure["pages"]),
+        len(structure["dangling"]),
+    )
     return manifest
 
 
@@ -270,6 +521,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Refetch every page, ignoring the manifest.",
     )
+    parser.add_argument(
+        "--skip-source",
+        action="store_true",
+        help=(
+            "Download only the page-by-page scans, not the mainspace pages they "
+            "transclude their text from. Rarely what you want: the scan pages on "
+            "their own contain almost no text."
+        ),
+    )
     return parser
 
 
@@ -282,6 +542,7 @@ def main(argv: list[str] | None = None) -> int:
             args.sourcetexts_root,
             dry_run=args.dry_run,
             force=args.force,
+            include_source=not args.skip_source,
         )
     except WikisourceError as exc:
         logger.error("%s", exc)

--- a/opensiddur/importer/util/pages.py
+++ b/opensiddur/importer/util/pages.py
@@ -50,6 +50,54 @@ def birnbaum_siddur_credits_directory(sourcetexts_root: Path | None = None) -> P
     return birnbaum_siddur_data_directory(sourcetexts_root) / "credits"
 
 
+def birnbaum_siddur_source_text_directory(sourcetexts_root: Path | None = None) -> Path:
+    """Mainspace pages holding the text the scan pages transclude."""
+    return birnbaum_siddur_data_directory(sourcetexts_root) / "source" / "text"
+
+
+def birnbaum_siddur_source_credits_directory(sourcetexts_root: Path | None = None) -> Path:
+    """Contributor credits for the mainspace source pages."""
+    return birnbaum_siddur_data_directory(sourcetexts_root) / "source" / "credits"
+
+
+def birnbaum_siddur_external_text_directory(sourcetexts_root: Path | None = None) -> Path:
+    """Pages referenced from outside the siddur's own subtree."""
+    return birnbaum_siddur_data_directory(sourcetexts_root) / "external" / "text"
+
+
+def birnbaum_siddur_external_credits_directory(sourcetexts_root: Path | None = None) -> Path:
+    """Contributor credits for externally referenced pages."""
+    return birnbaum_siddur_data_directory(sourcetexts_root) / "external" / "credits"
+
+
+def title_to_relative_path(title: str, suffix: str = ".txt") -> Path:
+    """Map a wiki title to a relative path, turning subpage slashes into directories.
+
+    Mirroring the title hierarchy keeps the wiki's own organization visible on disk
+    and in diffs, which is most of the value of these pages.
+
+    Only ``%`` is escaped, so that the mapping round-trips: everything else a wiki
+    title may contain — Hebrew, spaces, parentheses, the gershayim quote in
+    ``צה"ל`` — is legal in a POSIX path segment and stays readable. Note the quote
+    would be a problem on Windows; these files are only ever read back through
+    :func:`relative_path_to_title`, so it is a portability caveat, not a bug.
+    """
+    segments = [segment.replace("%", "%25") for segment in title.split("/")]
+    if not segments or not all(segments):
+        raise ValueError(f"Title does not map to a path: {title!r}")
+    return Path(*segments[:-1], segments[-1] + suffix)
+
+
+def relative_path_to_title(path: Path | str, suffix: str = ".txt") -> str:
+    """Inverse of :func:`title_to_relative_path`."""
+    parts = list(Path(path).parts)
+    if not parts:
+        raise ValueError("Empty path does not map to a title")
+    if parts[-1].endswith(suffix):
+        parts[-1] = parts[-1][: -len(suffix)]
+    return "/".join(part.replace("%25", "%") for part in parts)
+
+
 def hebcal_leyning_data_directory(sourcetexts_root: Path | None = None) -> Path:
     """hebcal leyning raw data: <sourcetexts-root>/hebcal_leyning."""
     root = (

--- a/opensiddur/importer/util/wikisource.py
+++ b/opensiddur/importer/util/wikisource.py
@@ -194,6 +194,21 @@ def page_title(namespace: str, book_name: str, page_num: int | str) -> str:
     return f"{namespace}:{book_name}/{page_num}"
 
 
+def normalize_title(title: str) -> str:
+    """Canonical form of a wiki title, for comparing and deduplicating.
+
+    MediaWiki treats underscores and spaces as the same character in titles, so the
+    same page can be written either way — the Birnbaum siddur is linked both as
+    ``Philip Birnbaum - …`` and ``Philip_Birnbaum_-_…``. Without folding the two,
+    a link graph double-counts pages and a download set fetches them twice.
+
+    Deliberately does not touch capitalisation: whether the first letter is
+    case-insensitive is a per-wiki setting, and guessing wrong would merge two
+    genuinely distinct titles, which is worse than missing a duplicate.
+    """
+    return re.sub(r"\s+", " ", title.replace("_", " ")).strip()
+
+
 def batched(items: Sequence[Any], size: int = DEFAULT_BATCH_SIZE) -> Iterator[list[Any]]:
     """Split ``items`` into lists of at most ``size``."""
     if size < 1:
@@ -225,6 +240,12 @@ def api_get(
 
     The single place in this module that touches the network, so it owns the whole
     etiquette contract: identification, pacing, ``maxlag``, and backoff.
+
+    Sent as POST despite being a read. A batch of 50 long titles does not fit in a
+    URL — fifty Hebrew subpage titles percent-encode to well over 8KB and the server
+    answers 414 — and the Action API accepts POST for read queries precisely so that
+    batching is not limited by URL length. Nothing else changes: `maxlag`,
+    `Retry-After` and the error envelope behave identically either way.
     """
     query = dict(params)
     query.update(format="json", formatversion=2, maxlag=maxlag)
@@ -233,7 +254,7 @@ def api_get(
         if wiki.limiter is not None:
             wiki.limiter.wait()
 
-        response = wiki.session.get(wiki.api_url, params=query, timeout=timeout)
+        response = wiki.session.post(wiki.api_url, data=query, timeout=timeout)
 
         # Rate limiting and server-side faults are worth retrying; other 4xx are our
         # own fault and will fail identically no matter how long we wait.
@@ -324,6 +345,34 @@ def query_pages(
         query.update(continuation)
 
 
+def list_pages_with_prefix(
+    wiki: Wiki,
+    prefix: str,
+    *,
+    namespace_id: int = 0,
+    **kwargs: Any,
+) -> list[str]:
+    """Every page title in ``namespace_id`` starting with ``prefix``.
+
+    Titles come back in *lexicographic* order (``/1``, ``/10``, ``/100``), so reading
+    a single continuation batch numerically will appear full of holes that are not
+    there. Sort numerically yourself if that is what you need.
+    """
+    return sorted(
+        query_pages(
+            wiki,
+            {
+                "action": "query",
+                "generator": "allpages",
+                "gapnamespace": namespace_id,
+                "gapprefix": prefix,
+                "gaplimit": "max",
+            },
+            **kwargs,
+        )
+    )
+
+
 def list_book_pages(
     wiki: Wiki,
     book_name: str,
@@ -335,21 +384,9 @@ def list_book_pages(
 
     Enumerating beats assuming a range: it needs no hardcoded last page and it
     reports gaps honestly, for books that are only partly transcribed.
-
-    Note the titles come back in *lexicographic* order (``/1``, ``/10``, ``/100``),
-    so a numeric reading of any single continuation batch will appear full of holes
-    that are not there. Callers should sort the returned keys.
     """
-    pages = query_pages(
-        wiki,
-        {
-            "action": "query",
-            "generator": "allpages",
-            "gapnamespace": namespace_id,
-            "gapprefix": f"{book_name}/",
-            "gaplimit": "max",
-        },
-        **kwargs,
+    pages = list_pages_with_prefix(
+        wiki, f"{book_name}/", namespace_id=namespace_id, **kwargs
     )
 
     # gapprefix also matches deeper subpages; keep only direct numbered children.
@@ -452,3 +489,139 @@ def fetch_contributors(
 def is_bot_name(name: str) -> bool:
     """Whether a username looks like a bot, and so should not be credited."""
     return name.casefold().endswith("bot")
+
+
+# ---------------------------------------------------------------------------
+# Labeled Section Transclusion
+#
+# Wikisource projects routinely keep the real text on a few mainspace pages, cut
+# into named sections, and let other pages pull those sections in. The scan-backed
+# page view then holds almost no text of its own — the Birnbaum siddur's scan pages
+# have a median size of 109 bytes.
+#
+# Both the parser function and the tags are localised, so a wiki in Hebrew writes
+# `{{#קטע:PAGE|LABEL}}` and `<קטע התחלה=LABEL/>` where an English one writes
+# `{{#lst:PAGE|LABEL}}` and `<section begin=LABEL/>`. Matching only the English
+# spellings silently finds nothing rather than failing loudly, which is how this
+# was missed on the first pass.
+#
+# https://www.mediawiki.org/wiki/Extension:Labeled_Section_Transclusion
+# ---------------------------------------------------------------------------
+
+LST_PARSER_FUNCTIONS = ("lst", "section", "קטע")
+LST_SECTION_TAGS = ("section", "קטע")
+LST_BEGIN_ATTRIBUTES = ("begin", "התחלה")
+LST_END_ATTRIBUTES = ("end", "סוף")
+
+REDIRECT_PREFIXES = ("#redirect", "#הפניה")
+
+_NOWIKI_RE = re.compile(r"<nowiki>.*?</nowiki>|<!--.*?-->", re.DOTALL | re.IGNORECASE)
+
+_TRANSCLUSION_RE = re.compile(
+    r"\{\{\s*#(?:" + "|".join(LST_PARSER_FUNCTIONS) + r")\s*:\s*([^|}]+)\|([^}]*)\}\}",
+    re.IGNORECASE,
+)
+
+_SECTION_BEGIN_RE = re.compile(
+    r"<\s*(?:" + "|".join(LST_SECTION_TAGS) + r")\s+"
+    r"(?:" + "|".join(LST_BEGIN_ATTRIBUTES) + r")\s*=\s*"
+    r'(?:"([^"]*)"|\'([^\']*)\'|([^/>]+?))\s*/?\s*>',
+    re.IGNORECASE,
+)
+
+_REDIRECT_RE = re.compile(
+    r"^\s*(?:" + "|".join(re.escape(p) for p in REDIRECT_PREFIXES) + r")\s*:?\s*"
+    r"\[\[([^\]|]+)",
+    re.IGNORECASE,
+)
+
+
+def _strip_uninterpreted(wikitext: str) -> str:
+    """Blank out spans the parser would not act on, so we do not read markup in them."""
+    return _NOWIKI_RE.sub("", wikitext)
+
+
+def find_transclusions(wikitext: str) -> list[tuple[str, str]]:
+    """Every ``(target title, section label)`` this wikitext pulls in, in order.
+
+    Titles are normalised; labels are returned verbatim, since a label is an opaque
+    key chosen by an editor rather than a title.
+    """
+    return [
+        (normalize_title(target), label.strip())
+        for target, label in _TRANSCLUSION_RE.findall(_strip_uninterpreted(wikitext))
+    ]
+
+
+def find_sections(wikitext: str) -> list[str]:
+    """Every section label this wikitext defines, in order, deduplicated."""
+    labels: list[str] = []
+    for quoted, single, bare in _SECTION_BEGIN_RE.findall(_strip_uninterpreted(wikitext)):
+        label = (quoted or single or bare).strip()
+        if label and label not in labels:
+            labels.append(label)
+    return labels
+
+
+def is_redirect(wikitext: str) -> tuple[bool, str | None]:
+    """Whether this page is a redirect, and to where.
+
+    Roughly half the Birnbaum siddur's mainspace subpages are redirects carrying
+    alternative names for a service, so this is common enough to be worth reporting
+    rather than treating as an oddity.
+    """
+    match = _REDIRECT_RE.match(_strip_uninterpreted(wikitext))
+    if match is None:
+        return False, None
+    return True, normalize_title(match.group(1))
+
+
+def download_closure(
+    wiki: Wiki,
+    roots: Sequence[str],
+    *,
+    include: Callable[[str], bool],
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    max_depth: int | None = None,
+    **kwargs: Any,
+) -> dict[str, RevisionInfo]:
+    """Fetch ``roots`` and everything they transclude, breadth-first.
+
+    ``include`` decides whether a referenced title is followed, letting callers stop
+    at a namespace boundary or outside a subtree. Titles are tracked in normalised
+    form, so a reference cycle terminates — which matters, because these graphs are
+    genuinely cyclic: assemblies transclude scan pages that transclude assemblies.
+    """
+    collected: dict[str, RevisionInfo] = {}
+    seen: set[str] = set()
+    frontier: list[str] = []
+    for title in roots:
+        normalized = normalize_title(title)
+        if normalized not in seen:
+            seen.add(normalized)
+            frontier.append(normalized)
+    depth = 0
+
+    while frontier:
+        revisions = fetch_revisions(
+            wiki, frontier, include_content=True, batch_size=batch_size, **kwargs
+        )
+        collected.update(revisions)
+
+        if max_depth is not None and depth >= max_depth:
+            break
+
+        next_frontier: list[str] = []
+        for revision in revisions.values():
+            if not revision.content:
+                continue
+            for target, _label in find_transclusions(revision.content):
+                if target in seen or not include(target):
+                    continue
+                seen.add(target)
+                next_frontier.append(target)
+
+        frontier = next_frontier
+        depth += 1
+
+    return collected

--- a/opensiddur/tests/importer/birnbaum_siddur/test_wikisource.py
+++ b/opensiddur/tests/importer/birnbaum_siddur/test_wikisource.py
@@ -20,6 +20,22 @@ TITLES = {
     LAST: f"{wikisource.WIKI_NAMESPACE}:{wikisource.BOOK_NAME}/{LAST}",
 }
 
+ROOT = wikisource.SOURCE_ROOT
+FOUNDATION = f"{ROOT}/אשכנז/דפי יסוד/קדיש"
+REDIRECT_PAGE = f"{ROOT}/אשכנז/הלל"
+EXTERNAL = "עשרת הדברות/ניקוד"
+
+# The scan page names a section that the foundation page defines, which is the
+# relationship structure.json exists to record.
+SECTION = "כותרת חצי קדיש"
+SCAN_WIKITEXT = f"{{{{#קטע:{FOUNDATION}|{SECTION}}}}}"
+SOURCE_WIKITEXT = {
+    ROOT: "index page",
+    FOUNDATION: f"<קטע התחלה={SECTION}/>text<קטע סוף={SECTION}/>",
+    REDIRECT_PAGE: f"#הפניה [[{FOUNDATION}]]",
+    EXTERNAL: "<קטע התחלה=דברות/>text<קטע סוף=דברות/>",
+}
+
 
 class BirnbaumDownloadTestCase(unittest.TestCase):
     """Fixture wiring the downloader to a temporary sourcetexts tree and a fake wiki."""
@@ -39,12 +55,20 @@ class BirnbaumDownloadTestCase(unittest.TestCase):
 
         self.content_requests = []
         self.contributor_requests = []
+        self.closure_calls = []
+
+        # The source layer: revision ids keyed by title, same shape as the scan layer.
+        self.source_revids = {t: 500 for t in SOURCE_WIKITEXT}
 
         patcher = patch.multiple(
             wikisource,
             list_book_pages=MagicMock(return_value=dict(TITLES)),
             fetch_revisions=MagicMock(side_effect=self.fake_fetch_revisions),
             fetch_contributors=MagicMock(side_effect=self.fake_fetch_contributors),
+            list_pages_with_prefix=MagicMock(
+                return_value=[FOUNDATION, REDIRECT_PAGE]
+            ),
+            download_closure=MagicMock(side_effect=self.fake_download_closure),
         )
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -57,7 +81,7 @@ class BirnbaumDownloadTestCase(unittest.TestCase):
             title: RevisionInfo(
                 revid=self.revids[title],
                 timestamp="2022-02-07T05:35:00Z",
-                content=f"wikitext for {title}" if include_content else None,
+                content=SCAN_WIKITEXT if include_content else None,
             )
             for title in titles
         }
@@ -65,7 +89,23 @@ class BirnbaumDownloadTestCase(unittest.TestCase):
     def fake_fetch_contributors(self, wiki, titles, **kwargs):
         titles = list(titles)
         self.contributor_requests.append(titles)
-        return {title: self.contributors[title] for title in titles}
+        return {title: self.contributors.get(title, ["Dovi"]) for title in titles}
+
+    def fake_download_closure(self, wiki, roots, *, include, **kwargs):
+        """Stand in for the real walker, returning a fixed small source tree.
+
+        Records `include` so tests can assert what the real walker would follow
+        without re-implementing traversal here.
+        """
+        self.closure_calls.append((list(roots), include))
+        return {
+            title: RevisionInfo(
+                revid=self.source_revids[title],
+                timestamp="2022-02-07T05:35:00Z",
+                content=text,
+            )
+            for title, text in SOURCE_WIKITEXT.items()
+        }
 
     def run_download(self, **kwargs):
         return download_book(
@@ -94,6 +134,31 @@ class BirnbaumDownloadTestCase(unittest.TestCase):
     def read_manifest(self):
         return json.loads(self.manifest_file.read_text(encoding="utf-8"))
 
+    def read_structure(self):
+        path = wikisource.birnbaum_siddur_data_directory(self.root) / "structure.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def seed_everything_current(self):
+        """Put both layers on disk and in the manifest, exactly as a finished run would."""
+        self.seed_page(FIRST, "001", revid=self.revids[TITLES[FIRST]])
+        (self.text_dir / "815.txt").write_text(SCAN_WIKITEXT, encoding="utf-8")
+        (self.credits_dir / "815.txt").write_text("Dovi", encoding="utf-8")
+
+        source_pages = {}
+        for title, text in SOURCE_WIKITEXT.items():
+            text_path, credits_path = wikisource.source_page_paths(title, self.root)
+            text_path.parent.mkdir(parents=True, exist_ok=True)
+            credits_path.parent.mkdir(parents=True, exist_ok=True)
+            text_path.write_text(text, encoding="utf-8")
+            credits_path.write_text("Dovi", encoding="utf-8")
+            source_pages[title] = {"revid": self.source_revids[title]}
+
+        manifest = self.read_manifest()
+        manifest["pages"]["815"] = {"revid": self.revids[TITLES[LAST]]}
+        manifest["source_pages"] = source_pages
+        self.manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+        wikisource.save_structure(wikisource.build_structure(self.root), self.root)
+
 
 class TestFirstRun(BirnbaumDownloadTestCase):
     def test_downloads_every_page_when_there_is_no_manifest(self):
@@ -108,8 +173,7 @@ class TestFirstRun(BirnbaumDownloadTestCase):
             sorted(p.name for p in self.text_dir.iterdir()), ["001.txt", "815.txt"]
         )
         self.assertEqual(
-            (self.text_dir / "815.txt").read_text(encoding="utf-8"),
-            f"wikitext for {TITLES[LAST]}",
+            (self.text_dir / "815.txt").read_text(encoding="utf-8"), SCAN_WIKITEXT
         )
 
     def test_writes_contributors_one_per_line(self):
@@ -141,8 +205,9 @@ class TestIncrementalUpdate(BirnbaumDownloadTestCase):
 
         self.run_download()
 
+        # The source phase makes its own requests; assert on the scan phase's.
         self.assertEqual(self.content_requests, [[TITLES[LAST]]])
-        self.assertEqual(self.contributor_requests, [[TITLES[LAST]]])
+        self.assertEqual(self.contributor_requests[0], [TITLES[LAST]])
 
     def test_leaves_an_unchanged_page_untouched_on_disk(self):
         self.seed_page(FIRST, "001", revid=111, text="existing", credits="Dovi")
@@ -163,18 +228,31 @@ class TestIncrementalUpdate(BirnbaumDownloadTestCase):
         self.assertEqual(pages["815"]["revid"], 999)
 
     def test_downloads_nothing_when_the_whole_book_is_current(self):
-        self.seed_page(FIRST, "001", revid=111)
-        # Make page 815 current too.
-        (self.text_dir / "815.txt").write_text("existing", encoding="utf-8")
-        (self.credits_dir / "815.txt").write_text("Dovi", encoding="utf-8")
-        manifest = self.read_manifest()
-        manifest["pages"]["815"] = {"revid": 222, "timestamp": "2022-02-07T05:35:00Z"}
-        self.manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+        self.seed_everything_current()
 
         self.run_download()
 
         self.assertEqual(self.content_requests, [])
         self.assertEqual(self.contributor_requests, [])
+
+    def test_a_no_op_rerun_leaves_every_file_untouched(self):
+        # The property that makes re-running cheap enough to do routinely: an
+        # unchanged run must not even rewrite the manifest, or it shows up as a diff.
+        self.seed_everything_current()
+        before = {
+            p: p.stat().st_mtime_ns
+            for p in wikisource.birnbaum_siddur_data_directory(self.root).rglob("*")
+            if p.is_file()
+        }
+
+        self.run_download()
+
+        after = {
+            p: p.stat().st_mtime_ns
+            for p in wikisource.birnbaum_siddur_data_directory(self.root).rglob("*")
+            if p.is_file()
+        }
+        self.assertEqual(before, after)
 
     def test_refetches_when_a_file_has_gone_missing(self):
         # A manifest entry is not proof the files survived.
@@ -215,6 +293,120 @@ class TestDryRun(BirnbaumDownloadTestCase):
         self.run_download(dry_run=True)
 
         self.assertEqual(self.content_requests, [])
+
+
+class TestSourceLayout(BirnbaumDownloadTestCase):
+    def test_subtree_pages_mirror_the_title_hierarchy(self):
+        self.run_download()
+
+        expected = (
+            wikisource.birnbaum_siddur_source_text_directory(self.root)
+            / "אשכנז"
+            / "דפי יסוד"
+            / "קדיש.txt"
+        )
+        self.assertTrue(expected.is_file())
+        self.assertEqual(expected.read_text(encoding="utf-8"), SOURCE_WIKITEXT[FOUNDATION])
+
+    def test_credits_mirror_the_text_tree(self):
+        self.run_download()
+
+        self.assertTrue(
+            (
+                wikisource.birnbaum_siddur_source_credits_directory(self.root)
+                / "אשכנז" / "דפי יסוד" / "קדיש.txt"
+            ).is_file()
+        )
+
+    def test_the_root_page_becomes_index(self):
+        self.run_download()
+
+        self.assertTrue(
+            (wikisource.birnbaum_siddur_source_text_directory(self.root) / "index.txt").is_file()
+        )
+
+    def test_pages_outside_the_subtree_go_in_the_external_tree(self):
+        self.run_download()
+
+        expected = (
+            wikisource.birnbaum_siddur_external_text_directory(self.root)
+            / "עשרת הדברות" / "ניקוד.txt"
+        )
+        self.assertTrue(expected.is_file())
+
+    def test_redirects_are_kept_and_recorded(self):
+        # Roughly half the real subtree is redirects carrying alternate service
+        # names, so they are organization rather than noise.
+        self.run_download()
+
+        entry = self.read_manifest()["source_pages"][REDIRECT_PAGE]
+        self.assertEqual(entry["redirect_target"], FOUNDATION)
+        self.assertIsNone(self.read_manifest()["source_pages"][FOUNDATION]["redirect_target"])
+
+
+class TestClosureBoundary(BirnbaumDownloadTestCase):
+    def test_the_walker_is_told_not_to_follow_scan_pages(self):
+        # They are downloaded by the other phase; following them here would fetch
+        # the whole book a second time, since the two layers reference each other.
+        self.run_download()
+
+        _roots, include = self.closure_calls[0]
+        self.assertFalse(include(TITLES[FIRST]))
+        self.assertTrue(include(FOUNDATION))
+
+    def test_the_root_page_is_added_to_the_enumerated_roots(self):
+        # A prefix search on "ROOT/" cannot match ROOT itself.
+        self.run_download()
+
+        roots, _include = self.closure_calls[0]
+        self.assertIn(ROOT, roots)
+
+
+class TestStructure(BirnbaumDownloadTestCase):
+    def test_records_the_sections_a_page_defines(self):
+        self.run_download()
+
+        self.assertEqual(self.read_structure()["pages"][FOUNDATION]["defines"], [SECTION])
+
+    def test_records_what_the_scan_pages_transclude(self):
+        # This is the link between printed pagination and liturgical text, and the
+        # main reason structure.json exists.
+        self.run_download()
+
+        scan = self.read_structure()["pages"][TITLES[FIRST]]
+        self.assertEqual(scan["transcludes"], [{"title": FOUNDATION, "section": SECTION}])
+
+    def test_reports_references_that_resolve_to_nothing(self):
+        self.assertEqual(self.run_download() and self.read_structure()["dangling"], [])
+
+    def test_flags_a_dangling_reference(self):
+        SOURCE_WIKITEXT[FOUNDATION] = "<קטע התחלה=something else/>x"
+        self.addCleanup(
+            SOURCE_WIKITEXT.__setitem__,
+            FOUNDATION,
+            f"<קטע התחלה={SECTION}/>text<קטע סוף={SECTION}/>",
+        )
+
+        self.run_download()
+
+        self.assertIn(
+            {"title": FOUNDATION, "section": SECTION}, self.read_structure()["dangling"]
+        )
+
+    def test_says_it_is_derived(self):
+        self.run_download()
+
+        self.assertIn("regenerate", self.read_structure()["generated_from"])
+
+
+class TestSkipSource(BirnbaumDownloadTestCase):
+    def test_skipping_the_source_phase_downloads_only_the_scans(self):
+        self.run_download(include_source=False)
+
+        self.assertEqual(self.closure_calls, [])
+        self.assertFalse(
+            wikisource.birnbaum_siddur_source_text_directory(self.root).exists()
+        )
 
 
 class TestCli(unittest.TestCase):

--- a/opensiddur/tests/importer/util/test_pages.py
+++ b/opensiddur/tests/importer/util/test_pages.py
@@ -3,11 +3,15 @@ from unittest.mock import patch, mock_open, MagicMock
 from pathlib import Path
 
 from opensiddur.importer.util.pages import (
+    birnbaum_siddur_external_text_directory,
+    birnbaum_siddur_source_text_directory,
     feinstein_haggadah_data_directory,
     get_page,
     get_credits,
     heidenheim_haggadah_data_directory,
     jps1917_text_directory,
+    relative_path_to_title,
+    title_to_relative_path,
 )
 from opensiddur.importer.util.constants import Page
 
@@ -238,6 +242,52 @@ class TestHaggadahDataDirectories(unittest.TestCase):
         self.assertEqual(
             heidenheim_haggadah_data_directory(root),
             root / "heidenheim_haggadah_1822",
+        )
+
+
+class TestTitleToRelativePath(unittest.TestCase):
+    """Mapping wiki titles onto paths, so subpages become real directories"""
+
+    def test_subpage_slashes_become_directories(self):
+        self.assertEqual(
+            title_to_relative_path("אשכנז/דפי יסוד/קדיש"),
+            Path("אשכנז") / "דפי יסוד" / "קדיש.txt",
+        )
+
+    def test_a_title_without_slashes_is_a_single_file(self):
+        self.assertEqual(title_to_relative_path("index"), Path("index.txt"))
+
+    def test_round_trips(self):
+        for title in (
+            "אשכנז/דפי יסוד/קדיש",
+            "index",
+            'אשכנז/תפילה לפני יציאה לקרב לחיילי צה"ל',   # gershayim quote
+            "עשרת הדברות/ניקוד",
+            "a%b/c",                                      # the one escaped character
+        ):
+            self.assertEqual(relative_path_to_title(title_to_relative_path(title)), title)
+
+    def test_percent_is_escaped_so_the_mapping_is_reversible(self):
+        self.assertEqual(title_to_relative_path("a%25b"), Path("a%2525b.txt"))
+
+    def test_rejects_a_title_that_cannot_be_a_path(self):
+        for bad in ("", "a//b", "/leading", "trailing/"):
+            with self.assertRaises(ValueError):
+                title_to_relative_path(bad)
+
+
+class TestBirnbaumSourceDirectories(unittest.TestCase):
+    """The source and external trees hang off the Birnbaum data directory"""
+
+    def test_source_and_external_trees_are_separate(self):
+        root = Path("/tmp/sources")
+        self.assertEqual(
+            birnbaum_siddur_source_text_directory(root),
+            root / "birnbaum_siddur" / "source" / "text",
+        )
+        self.assertEqual(
+            birnbaum_siddur_external_text_directory(root),
+            root / "birnbaum_siddur" / "external" / "text",
         )
 
 

--- a/opensiddur/tests/importer/util/test_wikisource.py
+++ b/opensiddur/tests/importer/util/test_wikisource.py
@@ -6,15 +6,22 @@ import requests
 from opensiddur.importer.util import wikisource
 from opensiddur.importer.util.wikisource import (
     RateLimiter,
+    RevisionInfo,
     Wiki,
     WikisourceError,
     api_get,
     batched,
     build_session,
+    download_closure,
     fetch_contributors,
     fetch_revisions,
+    find_sections,
+    find_transclusions,
     is_bot_name,
+    is_redirect,
     list_book_pages,
+    list_pages_with_prefix,
+    normalize_title,
     page_title,
     query_pages,
     resolve_contact_email,
@@ -40,7 +47,7 @@ def make_response(status_code=200, payload=None, headers=None):
 def make_wiki(*responses):
     """A Wiki whose session returns the given responses in order."""
     session = MagicMock()
-    session.get.side_effect = list(responses)
+    session.post.side_effect = list(responses)
     return Wiki(server="he.wikisource.org", session=session)
 
 
@@ -122,16 +129,16 @@ class TestApiGet(unittest.TestCase):
         wiki = make_wiki(make_response(payload={"query": {}}))
         api_get(wiki, {"action": "query"})
 
-        _, kwargs = wiki.session.get.call_args
-        self.assertEqual(kwargs["params"]["format"], "json")
-        self.assertEqual(kwargs["params"]["formatversion"], 2)
-        self.assertEqual(kwargs["params"]["maxlag"], 5)
+        _, kwargs = wiki.session.post.call_args
+        self.assertEqual(kwargs["data"]["format"], "json")
+        self.assertEqual(kwargs["data"]["formatversion"], 2)
+        self.assertEqual(kwargs["data"]["maxlag"], 5)
 
     def test_targets_the_action_api(self):
         wiki = make_wiki(make_response(payload={"query": {}}))
         api_get(wiki, {"action": "query"})
 
-        args, _ = wiki.session.get.call_args
+        args, _ = wiki.session.post.call_args
         self.assertEqual(args[0], "https://he.wikisource.org/w/api.php")
 
     def test_waits_and_retries_when_the_database_is_lagging(self):
@@ -146,7 +153,7 @@ class TestApiGet(unittest.TestCase):
             api_get(wiki, {"action": "query"})
 
         sleep.assert_called_once_with(6.0)
-        self.assertEqual(wiki.session.get.call_count, 2)
+        self.assertEqual(wiki.session.post.call_count, 2)
 
     def test_gives_up_on_sustained_lag(self):
         lagging = [
@@ -188,7 +195,7 @@ class TestApiGet(unittest.TestCase):
         with self.assertRaises(requests.HTTPError):
             api_get(wiki, {"action": "query"})
 
-        self.assertEqual(wiki.session.get.call_count, 1)
+        self.assertEqual(wiki.session.post.call_count, 1)
 
     def test_reports_other_api_errors(self):
         wiki = make_wiki(
@@ -264,8 +271,8 @@ class TestQueryPages(unittest.TestCase):
 
         query_pages(wiki, {"action": "query"})
 
-        _, kwargs = wiki.session.get.call_args
-        self.assertEqual(kwargs["params"]["pccontinue"], "next")
+        _, kwargs = wiki.session.post.call_args
+        self.assertEqual(kwargs["data"]["pccontinue"], "next")
 
     def test_drops_pages_the_wiki_does_not_have(self):
         wiki = make_wiki(
@@ -319,9 +326,9 @@ class TestListBookPages(unittest.TestCase):
 
         list_book_pages(wiki, BOOK)
 
-        _, kwargs = wiki.session.get.call_args
-        self.assertEqual(kwargs["params"]["gapnamespace"], 104)
-        self.assertEqual(kwargs["params"]["gapprefix"], f"{BOOK}/")
+        _, kwargs = wiki.session.post.call_args
+        self.assertEqual(kwargs["data"]["gapnamespace"], 104)
+        self.assertEqual(kwargs["data"]["gapprefix"], f"{BOOK}/")
 
 
 class TestFetchRevisions(unittest.TestCase):
@@ -348,9 +355,9 @@ class TestFetchRevisions(unittest.TestCase):
         self.assertEqual(found[f"{NAMESPACE}:{BOOK}/1"].revid, 111)
         self.assertIsNone(found[f"{NAMESPACE}:{BOOK}/2"].content)
 
-        _, kwargs = wiki.session.get.call_args
-        self.assertNotIn("content", kwargs["params"]["rvprop"])
-        self.assertNotIn("rvslots", kwargs["params"])
+        _, kwargs = wiki.session.post.call_args
+        self.assertNotIn("content", kwargs["data"]["rvprop"])
+        self.assertNotIn("rvslots", kwargs["data"])
 
     def test_reads_wikitext_when_asked(self):
         wiki = make_wiki(
@@ -376,9 +383,9 @@ class TestFetchRevisions(unittest.TestCase):
         self.assertEqual(found[f"{NAMESPACE}:{BOOK}/1"].content, "שלום")
         self.assertEqual(found[f"{NAMESPACE}:{BOOK}/1"].user, "Dovi")
 
-        _, kwargs = wiki.session.get.call_args
-        self.assertIn("content", kwargs["params"]["rvprop"])
-        self.assertEqual(kwargs["params"]["rvslots"], "main")
+        _, kwargs = wiki.session.post.call_args
+        self.assertIn("content", kwargs["data"]["rvprop"])
+        self.assertEqual(kwargs["data"]["rvslots"], "main")
 
     def test_batches_titles_to_stay_within_the_api_limit(self):
         titles = [f"{NAMESPACE}:{BOOK}/{n}" for n in range(1, 121)]
@@ -386,7 +393,7 @@ class TestFetchRevisions(unittest.TestCase):
 
         fetch_revisions(wiki, titles, include_content=False)
 
-        self.assertEqual(wiki.session.get.call_count, 3)
+        self.assertEqual(wiki.session.post.call_count, 3)
 
     def test_skips_pages_with_no_revisions(self):
         wiki = make_wiki(
@@ -451,6 +458,164 @@ class TestFetchContributors(unittest.TestCase):
         )
 
         self.assertEqual(found[f"{NAMESPACE}:{BOOK}/50"], ["Dovi"])
+
+
+class TestNormalizeTitle(unittest.TestCase):
+    def test_folds_underscores_to_spaces(self):
+        # The Birnbaum siddur is linked both ways; without folding, the link graph
+        # double-counts it and the downloader fetches it twice.
+        self.assertEqual(
+            normalize_title("עמוד:Philip_Birnbaum_-_x.pdf/1"),
+            normalize_title("עמוד:Philip Birnbaum - x.pdf/1"),
+        )
+
+    def test_collapses_and_trims_whitespace(self):
+        self.assertEqual(normalize_title("  A   B  "), "A B")
+
+    def test_leaves_capitalisation_alone(self):
+        # Whether the first letter is case-insensitive is a per-wiki setting, so
+        # folding it here could merge two genuinely distinct titles.
+        self.assertEqual(normalize_title("aPage"), "aPage")
+
+
+class TestFindTransclusions(unittest.TestCase):
+    def test_reads_the_hebrew_parser_function(self):
+        self.assertEqual(
+            find_transclusions("{{#קטע:הסידור/קדיש|חצי קדיש}}"),
+            [("הסידור/קדיש", "חצי קדיש")],
+        )
+
+    def test_reads_the_english_aliases(self):
+        self.assertEqual(find_transclusions("{{#lst:Page|Sec}}"), [("Page", "Sec")])
+        self.assertEqual(find_transclusions("{{#section:Page|Sec}}"), [("Page", "Sec")])
+
+    def test_normalises_the_target_but_not_the_label(self):
+        found = find_transclusions("{{#קטע:A_B|keep  this}}")
+        self.assertEqual(found, [("A B", "keep  this")])
+
+    def test_reads_a_call_that_spans_a_line_break(self):
+        # Real data does this; a line-based reader silently misses it.
+        self.assertEqual(
+            find_transclusions("{{#קטע:Page|מגן אבות הוראה\n}}"),
+            [("Page", "מגן אבות הוראה")],
+        )
+
+    def test_finds_several_on_one_line(self):
+        self.assertEqual(
+            find_transclusions("{{ק|{{#קטע:A|1}}}} {{#קטע:B|2}}"),
+            [("A", "1"), ("B", "2")],
+        )
+
+    def test_ignores_markup_the_parser_would_not_act_on(self):
+        self.assertEqual(find_transclusions("<nowiki>{{#קטע:A|B}}</nowiki>"), [])
+        self.assertEqual(find_transclusions("<!-- {{#קטע:A|B}} -->"), [])
+
+
+class TestFindSections(unittest.TestCase):
+    def test_reads_the_hebrew_tag(self):
+        self.assertEqual(
+            find_sections("<קטע התחלה=כותרת חצי קדיש/>x<קטע סוף=כותרת חצי קדיש/>"),
+            ["כותרת חצי קדיש"],
+        )
+
+    def test_reads_quoted_and_bare_values(self):
+        self.assertEqual(find_sections('<section begin="Foo Bar"/>'), ["Foo Bar"])
+        self.assertEqual(find_sections("<section begin=Foo/>"), ["Foo"])
+        self.assertEqual(find_sections("<section begin='Foo'/>"), ["Foo"])
+
+    def test_deduplicates_while_keeping_order(self):
+        self.assertEqual(
+            find_sections("<קטע התחלה=b/><קטע התחלה=a/><קטע התחלה=b/>"), ["b", "a"]
+        )
+
+    def test_ignores_end_tags(self):
+        self.assertEqual(find_sections("<קטע סוף=a/>"), [])
+
+
+class TestIsRedirect(unittest.TestCase):
+    def test_recognises_the_hebrew_form(self):
+        self.assertEqual(is_redirect("#הפניה [[הסידור/הלל]]"), (True, "הסידור/הלל"))
+
+    def test_recognises_the_english_form(self):
+        self.assertEqual(is_redirect("#REDIRECT [[Target]]"), (True, "Target"))
+
+    def test_normalises_the_target(self):
+        self.assertEqual(is_redirect("#REDIRECT [[A_B]]")[1], "A B")
+
+    def test_ordinary_pages_are_not_redirects(self):
+        self.assertEqual(is_redirect("just text"), (False, None))
+
+
+class TestDownloadClosure(unittest.TestCase):
+    def _wiki_returning(self, graph):
+        """A Wiki whose fetch_revisions serves `graph` (title -> wikitext)."""
+        def fake(wiki, titles, *, include_content, **kwargs):
+            return {
+                t: RevisionInfo(revid=1, timestamp="2022-01-01T00:00:00Z", content=graph[t])
+                for t in titles
+                if t in graph
+            }
+        return MagicMock(), fake
+
+    def test_follows_references_breadth_first(self):
+        graph = {
+            "A": "{{#קטע:B|s}}",
+            "B": "{{#קטע:C|s}}",
+            "C": "leaf",
+        }
+        wiki, fake = self._wiki_returning(graph)
+        with patch.object(wikisource, "fetch_revisions", side_effect=fake):
+            found = download_closure(wiki, ["A"], include=lambda t: True)
+        self.assertEqual(sorted(found), ["A", "B", "C"])
+
+    def test_terminates_on_a_reference_cycle(self):
+        # The real graph is cyclic: assemblies transclude scan pages that
+        # transclude assemblies. Without cycle detection this never returns.
+        graph = {"A": "{{#קטע:B|s}}", "B": "{{#קטע:A|s}}"}
+        wiki, fake = self._wiki_returning(graph)
+        with patch.object(wikisource, "fetch_revisions", side_effect=fake):
+            found = download_closure(wiki, ["A"], include=lambda t: True)
+        self.assertEqual(sorted(found), ["A", "B"])
+
+    def test_include_stops_traversal(self):
+        graph = {"A": "{{#קטע:B|s}}", "B": "leaf"}
+        wiki, fake = self._wiki_returning(graph)
+        with patch.object(wikisource, "fetch_revisions", side_effect=fake):
+            found = download_closure(wiki, ["A"], include=lambda t: t != "B")
+        self.assertEqual(sorted(found), ["A"])
+
+    def test_max_depth_bounds_traversal(self):
+        graph = {"A": "{{#קטע:B|s}}", "B": "{{#קטע:C|s}}", "C": "leaf"}
+        wiki, fake = self._wiki_returning(graph)
+        with patch.object(wikisource, "fetch_revisions", side_effect=fake):
+            found = download_closure(wiki, ["A"], include=lambda t: True, max_depth=1)
+        self.assertEqual(sorted(found), ["A", "B"])
+
+    def test_deduplicates_roots_by_normalised_title(self):
+        graph = {"A B": "leaf"}
+        wiki, fake = self._wiki_returning(graph)
+        with patch.object(wikisource, "fetch_revisions", side_effect=fake) as fetch:
+            download_closure(wiki, ["A B", "A_B"], include=lambda t: True)
+        self.assertEqual(fetch.call_args.args[1], ["A B"])
+
+
+class TestListPagesWithPrefix(unittest.TestCase):
+    def test_collects_titles_across_continuation(self):
+        wiki = make_wiki(
+            make_response(payload=pages_payload({"title": "P/b"}, continuation={"gapcontinue": "x"})),
+            make_response(payload=pages_payload({"title": "P/a"})),
+        )
+
+        self.assertEqual(list_pages_with_prefix(wiki, "P/"), ["P/a", "P/b"])
+
+    def test_defaults_to_the_main_namespace(self):
+        wiki = make_wiki(make_response(payload=pages_payload()))
+
+        list_pages_with_prefix(wiki, "P/")
+
+        _, kwargs = wiki.session.post.call_args
+        self.assertEqual(kwargs["data"]["gapnamespace"], 0)
+        self.assertEqual(kwargs["data"]["gapprefix"], "P/")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #89. The scan pages it downloaded turned out to hold almost no text — this fetches the text they transclude, and the organisation Wikisource has built over it.

Companion data PR: opensiddur/sourcetexts#5 (updated in place, so one data PR covers the whole import)

## The problem

The 815 scan pages have a **median size of 109 bytes**. 405 of them consist mostly of `{{#קטע:PAGE|SECTION}}` calls — the Hebrew localisation of `{{#lst:}}`, [labeled section transclusion](https://www.mediawiki.org/wiki/Extension:Labeled_Section_Transclusion) — with the text living in mainspace pages and pulled in at render time.

Matching only the English spellings of that markup finds *nothing* rather than failing, which is exactly how this was missed the first time round.

## What it turned out to be

Good news rather than bad: the text arrives pre-cut into named liturgical units, with two independent organisations over them.

| Layer | What it is | Count |
|---|---|---|
| `עמוד:…pdf/N` | printed-page view (already downloaded) | 815 |
| `…/אשכנז/דפי יסוד/*` | foundation pages — the text, in labeled sections | 20 |
| `…/אשכנז/עמודים/*`, `…/אשכנז/<service>` | liturgical assemblies over the same sections | ~300 |

All three point at the same atoms, which is the shape `corresp`-based alignment wants later: the scan layer supplies `tei:pb` placement, the assembly layer supplies liturgical structure.

## Client changes, all generic

- **`find_transclusions` / `find_sections` / `is_redirect`** — match the *localised* parser-function and tag aliases (`#קטע` as well as `#lst`/`#section`), quoted and bare attribute values, and skip `<nowiki>` and comments.
- **`download_closure`** — breadth-first walker tracking titles in normalised form so a reference cycle terminates. Load-bearing, not defensive: the graph really is cyclic, since assemblies transclude scan pages that transclude assemblies.
- **`normalize_title`** — folds underscores to spaces, because MediaWiki treats them as the same character and this siddur is linked both ways. Deliberately leaves capitalisation alone: whether the first letter is case-insensitive is a per-wiki setting, and guessing wrong would merge genuinely distinct titles.

## Fixed: batching was silently capped by URL length

Fifty Hebrew subpage titles percent-encode to well over 8KB, and the server answers **`414 URI Too Long`**. Queries are now sent as POST, which the Action API accepts for reads precisely so batching need not be limited this way. This was latent for any wiki whose titles are not short and Latin.

## Output

324 subtree pages under `source/`, transitively referenced outside pages under `external/`, both mirroring the wiki's title hierarchy as real directories so the organisation is visible on disk and in diffs.

`structure.json` records the sections each page defines and transcludes — **including for the scan pages**, since that is precisely what ties printed pagination to liturgical text. Derived from the wikitext on disk and regenerable, so it is never a second source of truth.

**Redirects are kept.** 151 of the 324 subtree pages are redirects carrying alternative names for a service; that naming is organisation, not noise.

## Verification

- **1,810 tests pass**, 12 skipped, no failures — 79 of them covering this work
- Live run wrote 325 source pages and indexed 1,140
- **An unchanged re-run writes nothing at all**, including the manifest, so it never shows up as a diff

Every headline number was reconciled against independent measurement rather than accepted:

| Measure | Result |
|---|---|
| Redirects | 151 — exact match |
| Transclusions from scan pages | 3,123 — exact match |
| Sections defined | 3,045 = 3,044 (323 subtree pages) + 1 external; root defines 0 |
| Transclusions from source | 5,001 = 5,061 raw − 60 inside `<nowiki>` |

Two apparent discrepancies were chased down rather than rounded away. A count of 3,122 from an earlier shell command was **wrong**: `grep` is line-based, and one transclusion's label runs to the next line before `}}`, which MediaWiki parses fine. And a 60-call gap turned out to be transclusions inside `<nowiki>` — wiki documentation examples the parser correctly ignores.

`structure.json` reports **52 dangling references** — section labels no page defines. Each was checked rather than waved through: they are wiki-side typos (a dropped letter in `הוראה לתפילה פני…` where the page defines `הוראה לתפילה לפני…`; a missing suffix elsewhere). The target pages define 96–236 labels apiece, so the parser reads them correctly. Reported as a warning rather than failing the run — a dangling reference is a fact about the wiki, not a downloader error, and failing would make downloads hostage to someone else's typo.

## Also

`--skip-source` exists for scans-only runs, though it is rarely what you want. The jps1917 migration remains tracked separately in #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
