### PR TITLE
Migrate the JPS 1917 downloader onto the shared Wikisource client (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   URL length on any wiki whose titles are not short and Latin.
 
 ### Changed
+- The JPS 1917 downloader now reads the Action API through the shared client, like the Birnbaum
+  importer does. It had been scraping `action=raw` plus an Atom history feed through
+  `/w/index.php` — two uncached, unbatched requests per page, so ~2,300 for the book's 1,152
+  pages, where 50 batched API requests do the same work — sending no `maxlag`, ignoring
+  `Retry-After` in favour of a flat three-retry loop, and refetching every page on every run. It
+  also identified itself with `opensiddur@example.com`, a reserved domain that reaches nobody and
+  so fails Wikimedia's User-Agent policy; the address is now `--contact-email` or
+  `$OPENSIDDUR_CONTACT_EMAIL`, with no default, and `--force` refetches regardless of the
+  manifest. The page range is no longer hardcoded: `list_book_pages` reports what is actually
+  transcribed, which also retires a stale `start_page = 443` left behind by a partial re-run. The
+  `sourcetexts/sources/jps1917/` layout and its four-digit filenames are unchanged.
+- The download loop the two Wikisource importers would otherwise duplicate now lives in
+  `opensiddur/importer/util/wikisource_book.py`: the manifest, the zero-padded page naming, and
+  the enumerate → probe revisions → fetch only what changed → write pass. `util/wikisource.py`
+  stays free of filesystem knowledge; what remains in each importer is what is particular to its
+  book, which for Birnbaum is its mainspace source tree and `structure.json`, and for JPS is
+  nothing beyond the book's name and where its files go.
+- Credits now name registered accounts only. `prop=contributors` reports anonymous edits as an
+  aggregate count rather than by address, so the handful of JPS credits files that listed bare IP
+  addresses will lose them on the next refetch — a TEI `respStmt` wants people who can be
+  identified. The old Atom feed was also capped at its most recent entries, so pages with long
+  histories may gain names.
 - `RELEASE_PROCEDURE.md` now says to re-lock and push `uv.lock` after a release. The release script
   writes the new version into `pyproject.toml` but never re-locks, so `uv.lock` kept the previous
   version and the next `uv sync --all-groups` left a modified lockfile in the working tree — which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,11 +57,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stays free of filesystem knowledge; what remains in each importer is what is particular to its
   book, which for Birnbaum is its mainspace source tree and `structure.json`, and for JPS is
   nothing beyond the book's name and where its files go.
-- Credits now name registered accounts only. `prop=contributors` reports anonymous edits as an
-  aggregate count rather than by address, so the handful of JPS credits files that listed bare IP
-  addresses will lose them on the next refetch — a TEI `respStmt` wants people who can be
-  identified. The old Atom feed was also capped at its most recent entries, so pages with long
-  histories may gain names.
+- Credits now name registered accounts only, and are written in sorted order rather than whatever
+  order a `set` happened to yield. `prop=contributors` reports anonymous edits as an aggregate
+  count rather than by address, so the five JPS credits files that listed a bare IP no longer do —
+  a TEI `respStmt` wants people who can be identified. MediaWiki's temporary accounts
+  (`~2026-44995-25`), which under IP masking stand in for logged-out editors, are excluded on the
+  same reasoning, alongside bots. The old Atom feed was also capped at its most recent entries, so
+  pages with long histories gain the names it never showed.
+- The JPS TEI `sourceDesc` now reports the date the Wikisource pages were actually downloaded,
+  read from the manifest, instead of a date written into the source once by hand and left to go
+  stale. Conversions of a tree with no manifest keep reporting the old literal date.
 - `RELEASE_PROCEDURE.md` now says to re-lock and push `uv.lock` after a release. The release script
   writes the new version into `pyproject.toml` but never re-locks, so `uv.lock` kept the previous
   version and the next `uv sync --all-groups` left a modified lockfile in the working tree — which

--- a/opensiddur/importer/birnbaum_siddur/wikisource.py
+++ b/opensiddur/importer/birnbaum_siddur/wikisource.py
@@ -17,7 +17,6 @@ the Wikisource edition, not Birnbaum 1949.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import logging
 import sys
@@ -44,14 +43,19 @@ from opensiddur.importer.util.wikisource import (
     connect,
     download_closure,
     fetch_contributors,
-    fetch_revisions,
     find_sections,
     find_transclusions,
     is_redirect,
-    list_book_pages,
     list_pages_with_prefix,
     normalize_title,
     resolve_contact_email,
+)
+from opensiddur.importer.util.wikisource_book import (
+    ScanPageLayout,
+    download_scan_pages,
+    load_manifest,
+    save_manifest,
+    sha256_text,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -70,67 +74,7 @@ SOURCE_ROOT = "הסידור השלם (בירנבוים)"
 # silently downloaded.
 MAX_SOURCE_DEPTH = 5
 
-MANIFEST_NAME = "manifest.json"
 STRUCTURE_NAME = "structure.json"
-
-
-def _sha256(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
-
-
-def manifest_path(sourcetexts_root: Path | None = None) -> Path:
-    return birnbaum_siddur_data_directory(sourcetexts_root) / MANIFEST_NAME
-
-
-def load_manifest(sourcetexts_root: Path | None = None) -> dict[str, Any]:
-    """Read the manifest, or return an empty one if this is a first run."""
-    try:
-        with open(manifest_path(sourcetexts_root), "r", encoding="utf-8") as f:
-            return json.load(f)
-    except FileNotFoundError:
-        return {}
-    except json.JSONDecodeError as exc:
-        logger.warning(
-            "Manifest at %s is unreadable (%s); treating every page as new. "
-            "Use --force to rewrite it cleanly.",
-            manifest_path(sourcetexts_root),
-            exc,
-        )
-        return {}
-
-
-def save_manifest(manifest: dict[str, Any], sourcetexts_root: Path | None = None) -> None:
-    path = manifest_path(sourcetexts_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-
-
-def page_key(page_num: int, digits: int) -> str:
-    """Zero-padded page identifier, used for both filenames and manifest keys."""
-    return f"{page_num:0{digits}d}"
-
-
-def _needs_download(
-    key: str,
-    revid: int,
-    manifest_pages: dict[str, Any],
-    text_dir: Path,
-    credits_dir: Path,
-) -> bool:
-    """Whether a page must be fetched: unknown, changed, or missing on disk.
-
-    The on-disk check matters because a manifest entry alone does not prove the files
-    survived — someone may have deleted or partially written them.
-    """
-    recorded = manifest_pages.get(key)
-    if recorded is None or recorded.get("revid") != revid:
-        return True
-    return not (
-        (text_dir / f"{key}.txt").is_file() and (credits_dir / f"{key}.txt").is_file()
-    )
 
 
 def is_scan_page(title: str) -> bool:
@@ -240,8 +184,8 @@ def download_source_pages(
         recorded[title] = {
             "revid": revision.revid,
             "timestamp": revision.timestamp,
-            "text_sha256": _sha256(revision.content),
-            "credits_sha256": _sha256(credits_text),
+            "text_sha256": sha256_text(revision.content),
+            "credits_sha256": sha256_text(credits_text),
             "redirect_target": target if redirect else None,
         }
         written += 1
@@ -351,85 +295,23 @@ def download_book(
         wiki = connect(SERVER, contact_email)
 
     data_dir = birnbaum_siddur_data_directory(sourcetexts_root)
-    text_dir = birnbaum_siddur_text_directory(sourcetexts_root)
-    credits_dir = birnbaum_siddur_credits_directory(sourcetexts_root)
 
-    logger.info("Enumerating pages of %s ...", BOOK_NAME)
-    titles_by_number = list_book_pages(wiki, BOOK_NAME)
-    if not titles_by_number:
-        raise WikisourceError(
-            f"No transcribed pages found for {BOOK_NAME!r} on {wiki.server}. "
-            "Has the book been moved or renamed?"
-        )
+    manifest = load_manifest(data_dir)
 
-    page_numbers = sorted(titles_by_number)
-    digits = len(str(page_numbers[-1]))
-    logger.info(
-        "Found %d transcribed pages (%d-%d)",
-        len(page_numbers),
-        page_numbers[0],
-        page_numbers[-1],
+    scans = download_scan_pages(
+        wiki,
+        BOOK_NAME,
+        ScanPageLayout(
+            data_dir=data_dir,
+            text_dir=birnbaum_siddur_text_directory(sourcetexts_root),
+            credits_dir=birnbaum_siddur_credits_directory(sourcetexts_root),
+        ),
+        dry_run=dry_run,
+        force=force,
+        manifest_pages=manifest.get("pages") or {},
     )
-
-    manifest = load_manifest(sourcetexts_root)
-    manifest_pages: dict[str, Any] = {} if force else dict(manifest.get("pages") or {})
-
-    # A revision-id-only probe: no wikitext is serialised, so this stays cheap even
-    # when nothing has changed.
-    logger.info("Checking which pages have changed ...")
-    latest = fetch_revisions(
-        wiki, [titles_by_number[n] for n in page_numbers], include_content=False
-    )
-
-    stale: list[int] = []
-    for number in page_numbers:
-        title = titles_by_number[number]
-        revision = latest.get(title)
-        if revision is None:
-            logger.warning("No revision reported for %s; skipping", title)
-            continue
-        if force or _needs_download(
-            page_key(number, digits), revision.revid, manifest_pages, text_dir, credits_dir
-        ):
-            stale.append(number)
-
-    logger.info("%d of %d scan pages need downloading", len(stale), len(page_numbers))
-
-    written = 0
-    if not stale:
-        logger.info("Scan pages are already up to date.")
-    elif not dry_run:
-        stale_titles = [titles_by_number[n] for n in stale]
-        logger.info("Fetching wikitext ...")
-        contents = fetch_revisions(wiki, stale_titles, include_content=True)
-        logger.info("Fetching contributors ...")
-        contributors = fetch_contributors(wiki, stale_titles)
-
-        text_dir.mkdir(parents=True, exist_ok=True)
-        credits_dir.mkdir(parents=True, exist_ok=True)
-
-        for number in stale:
-            title = titles_by_number[number]
-            revision = contents.get(title)
-            if revision is None or revision.content is None:
-                logger.warning("No wikitext returned for %s; leaving it for the next run", title)
-                continue
-
-            key = page_key(number, digits)
-            credits_text = "\n".join(contributors.get(title, []))
-
-            (text_dir / f"{key}.txt").write_text(revision.content, encoding="utf-8")
-            (credits_dir / f"{key}.txt").write_text(credits_text, encoding="utf-8")
-
-            manifest_pages[key] = {
-                "revid": revision.revid,
-                "timestamp": revision.timestamp,
-                "text_sha256": _sha256(revision.content),
-                "credits_sha256": _sha256(credits_text),
-            }
-            written += 1
-            if written % 50 == 0:
-                logger.info("Wrote %d/%d scan pages", written, len(stale))
+    manifest_pages = scans.pages
+    written = scans.written
 
     # The scan pages carry almost no text of their own; this is where it lives.
     source_pages: dict[str, Any] = {} if force else dict(manifest.get("source_pages") or {})
@@ -446,7 +328,7 @@ def download_book(
     if dry_run:
         logger.info(
             "Dry run: would write %d scan page(s) and refresh source pages under %s",
-            len(stale),
+            len(scans.stale),
             data_dir,
         )
         return manifest
@@ -471,7 +353,7 @@ def download_book(
     # intact and the interrupted pages simply look stale next time, which is safer
     # than a per-page write that could claim a page is current when its file was
     # only half written.
-    save_manifest(manifest, sourcetexts_root)
+    save_manifest(manifest, data_dir)
     structure = build_structure(sourcetexts_root)
     save_structure(structure, sourcetexts_root)
     logger.info(

--- a/opensiddur/importer/jps1917/convert_wikisource.py
+++ b/opensiddur/importer/jps1917/convert_wikisource.py
@@ -11,7 +11,9 @@ from opensiddur.importer.util.pages import (
     default_sourcetexts_root,
     get_credits,
     get_page,
+    jps1917_data_directory,
 )
+from opensiddur.importer.util.wikisource_book import download_date
 from opensiddur.importer.jps1917.canonical_verses import annotate_canonical_verses
 from opensiddur.importer.jps1917.mediawiki_processor import create_processor
 from opensiddur.importer.util.parshiyot import skeleton_map_json
@@ -23,6 +25,16 @@ from opensiddur.common.constants import PROJECT_DIRECTORY
 logger = logging.getLogger(__name__)
 
 MEDIAWIKI_TO_TEI_XSLT = Path(__file__).parent / "mediawiki_to_tei.xslt"
+
+# What the header reported before the downloader kept a manifest. Used only when there
+# is none to read, so that a conversion run against a tree downloaded by the old
+# scraper still states the date those files were actually fetched.
+FALLBACK_DOWNLOAD_DATE = "2025-07-27"
+
+
+def source_download_date(sourcetexts_root: Path | None = None) -> str:
+    """The date the Wikisource pages under this tree were last downloaded."""
+    return download_date(jps1917_data_directory(sourcetexts_root)) or FALLBACK_DOWNLOAD_DATE
 
 
 def make_project_directory(project_dir: Path | None = None) -> Path:
@@ -419,8 +431,10 @@ def header(
     license_url: str = "http://www.creativecommons.org/publicdomain/zero/1.0/",
     license_name: str = "Creative Commons Public Domain Dedication 1.0",
     transcription_credits: Optional[list[str]] = None,
+    source_download_date: Optional[str] = None,
 ):
     transcription_credits = transcription_credits or []
+    source_download_date = source_download_date or FALLBACK_DOWNLOAD_DATE
     book_sub_he = (
         f"""<tei:title type="alt-sub" xml:lang="he">{book_sub_he}</tei:title>"""
         if book_sub_he else ""
@@ -461,7 +475,7 @@ def header(
                 <tei:title>Bible (Jewish Publication Society 1917)</tei:title>
                 <tei:distributor><tei:ref target="https://en.wikisource.org">Wikisource</tei:ref></tei:distributor>
                 <tei:idno type="url">https://en.wikisource.org/wiki/Bible_(Jewish_Publication_Society_1917)</tei:idno>
-                <tei:date>2025-07-27</tei:date>
+                <tei:date>{source_download_date}</tei:date>
             </tei:bibl>
             <tei:bibl>
                <tei:title type="main">The Holy Scriptures</tei:title>
@@ -618,6 +632,7 @@ def book_file(
         book_name_en = book.book_name_en,
         entrypoint = book.file_name,
         transcription_credits = transcription_credits,
+        source_download_date = source_download_date(sourcetexts_root),
     )
     xml_dict = process_mediawiki(
         book.start_page,
@@ -662,6 +677,7 @@ def index_file(
         book_sub_en = idx.index_sub_en,
         entrypoint = entrypoint,
         transcription_credits = transcription_credits,
+        source_download_date = source_download_date(sourcetexts_root),
     )
     if idx.start_page is not None and idx.end_page is not None:
         xml_dict = process_mediawiki(

--- a/opensiddur/importer/jps1917/wikisource.py
+++ b/opensiddur/importer/jps1917/wikisource.py
@@ -1,112 +1,119 @@
+"""Download the JPS 1917 Bible translation from English Wikisource into sourcetexts.
+
+Writes one wikitext file and one credits file per scan page, plus a manifest recording
+each page's revision id so later runs only refetch what actually changed.
+
+Unlike the Birnbaum siddur, these scan pages hold their own text: there is no labeled
+section transclusion to follow, so a page-by-page download is the whole job.
+
+The HTTP etiquette — batching, pacing, maxlag, backoff, identification — lives in
+:mod:`opensiddur.importer.util.wikisource`, along with the reasoning for reading the
+Action API rather than the monthly dumps. The per-page filesystem layout and the
+manifest live in :mod:`opensiddur.importer.util.wikisource_book`.
+"""
+
+from __future__ import annotations
+
 import argparse
-import random
+import logging
 import sys
-import time
-import xml.etree.ElementTree as et
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
-import requests
+from opensiddur.importer.util.pages import (
+    default_sourcetexts_root,
+    jps1917_credits_directory,
+    jps1917_data_directory,
+    jps1917_text_directory,
+)
+from opensiddur.importer.util.wikisource import (
+    CONTACT_EMAIL_ENV_VAR,
+    Wiki,
+    WikisourceError,
+    connect,
+    resolve_contact_email,
+)
+from opensiddur.importer.util.wikisource_book import (
+    ScanPageLayout,
+    download_scan_pages,
+    load_manifest,
+    save_manifest,
+)
 
-from opensiddur.importer.util.pages import default_sourcetexts_root, jps1917_data_directory
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
-server = "en.wikisource.org"
-wiki_namespace = "Page"
-book_name = "JPS-1917-Universal.djvu"
-start_page = 443  # 7
-pages = range(start_page, 1158 + 1)
-
-# Backward-compatible name for JPS tree under sourcetexts
-jps1917_output_directory = jps1917_data_directory
-
-# Default layout: <repo>/sourcetexts/sources/jps1917
-output_directory = jps1917_data_directory()
+SERVER = "en.wikisource.org"
+WIKI_NAMESPACE = "Page"  # ProofreadPage namespace 104, as named on en.wikisource
+BOOK_NAME = "JPS-1917-Universal.djvu"
 
 
-def wiki_url(book_name, page_num, action="raw", namespace=wiki_namespace):
-    return f"/w/index.php?title={wiki_namespace}:{book_name}/{page_num}&action={action}"
+def download_book(
+    contact_email: str,
+    sourcetexts_root: Path | None = None,
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+    wiki: Wiki | None = None,
+) -> dict[str, Any]:
+    """Download every transcribed page of the book, skipping unchanged ones.
 
+    Returns the manifest that was written (or, on a dry run, would have been).
+    """
+    if wiki is None:
+        wiki = connect(SERVER, contact_email)
 
-def get_wiki_page(book_name, page_num, dry_run=True):
-    path = "https://" + server + wiki_url(book_name, page_num)
-    headers = {
-        "User-Agent": "OpenSiddur-AI/1.0 (https://github.com/opensiddur/opensiddur-ai; opensiddur@example.com)",
-        "Accept-Encoding": "gzip, deflate",
-    }
+    data_dir = jps1917_data_directory(sourcetexts_root)
+    manifest = load_manifest(data_dir)
+
+    scans = download_scan_pages(
+        wiki,
+        BOOK_NAME,
+        ScanPageLayout(
+            data_dir=data_dir,
+            text_dir=jps1917_text_directory(sourcetexts_root),
+            credits_dir=jps1917_credits_directory(sourcetexts_root),
+        ),
+        dry_run=dry_run,
+        force=force,
+        manifest_pages=manifest.get("pages") or {},
+    )
+
     if dry_run:
-        print(f"Would retrieve text: {page_num} from {path}")
-    else:
-        r = requests.get(path, headers=headers, timeout=60)
-        if r.status_code >= 400:
-            print(f"Error retrieving page {page_num}")
-        else:
-            return r.text
+        logger.info(
+            "Dry run: would write %d page(s) under %s", len(scans.stale), data_dir
+        )
+        return manifest
 
+    if not scans.written:
+        # Nothing changed. Leaving the manifest alone keeps a no-op re-run genuinely
+        # no-op, so an unchanged run never shows up as a diff.
+        logger.info("Everything is already up to date.")
+        return manifest
 
-def get_wiki_contributors(book_name, page_num, dry_run=True):
-    path = "https://" + server + wiki_url(book_name, page_num, action="history&feed=atom")
-    headers = {
-        "User-Agent": "OpenSiddur-AI/1.0 (https://github.com/opensiddur/opensiddur-ai; opensiddur@example.com)",
-        "Accept-Encoding": "gzip, deflate",
+    manifest = {
+        "source": wiki.server,
+        "book_name": BOOK_NAME,
+        "namespace": WIKI_NAMESPACE,
+        "downloaded_at": datetime.now(timezone.utc).isoformat(),
+        "pages": scans.pages,
     }
-    if dry_run:
-        print(f"Would retrieve history: {page_num} from {path}")
-    else:
-        r = requests.get(path, headers=headers, timeout=60)
-        if r.status_code >= 400:
-            print(f"Error retrieving history {page_num}: {r.status_code} {r.text}")
-        else:
-            feed = et.XML(r.text)
-            return list(
-                set(
-                    [
-                        element.find("{http://www.w3.org/2005/Atom}name").text
-                        for element in feed.findall(".//{http://www.w3.org/2005/Atom}author")
-                    ]
-                )
-            )
-
-
-def download_book(dry_run: bool = True, sourcetexts_root: Path | None = None) -> None:
-    out = jps1917_output_directory(sourcetexts_root)
-    digits = len(str(max(pages)))
-    format_string = "%%0%dd" % digits
-
-    out.mkdir(parents=True, exist_ok=True)
-    (out / "text").mkdir(parents=True, exist_ok=True)
-    (out / "credits").mkdir(parents=True, exist_ok=True)
-
-    for page_num in pages:
-        print("Page: %d" % page_num)
-        success = False
-        retries = 0
-        while not success and retries < 3:
-            try:
-                wp = get_wiki_page(book_name, page_num, dry_run=dry_run)
-                wc = get_wiki_contributors(book_name, page_num, dry_run=dry_run)
-                success = True
-            except Exception as e:
-                print(f"Exception: {e} -- waiting 5s to recover...")
-                retries += 1
-                if retries >= 3:
-                    raise
-                time.sleep(5.0)
-        output_filename = (format_string % page_num) + ".txt"
-        text_path = out / "text" / output_filename
-        credits_path = out / "credits" / output_filename
-        if dry_run:
-            print(f"{page_num}: {text_path=}, {credits_path=}")
-        else:
-            with open(text_path, "w", encoding="utf-8") as f:
-                f.write(wp)
-            time.sleep(1.3 + random.random())
-            with open(credits_path, "w", encoding="utf-8") as f:
-                f.write("\n".join(w for w in wc if w != "Wikisource-bot"))
-            time.sleep(1.3 + random.random())
+    # Written once, at the end. A crash mid-run then leaves the previous manifest
+    # intact and the interrupted pages simply look stale next time, which is safer
+    # than a per-page write that could claim a page is current when its file was
+    # only half written.
+    save_manifest(manifest, data_dir)
+    logger.info("Wrote %d page(s) under %s", scans.written, data_dir)
+    return manifest
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Download JPS 1917 Bible pages from English Wikisource into the sourcetexts tree."
+        description=(
+            "Download JPS 1917 Bible pages from English Wikisource into the sourcetexts "
+            "tree, refetching only pages that have changed."
+        )
     )
     parser.add_argument(
         "--sourcetexts-root",
@@ -118,16 +125,42 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--contact-email",
+        default=None,
+        help=(
+            "Contact address for the User-Agent header, as Wikimedia's User-Agent "
+            f"policy requires. Falls back to ${CONTACT_EMAIL_ENV_VAR}."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print planned fetches and paths without writing files.",
+        help=(
+            "Report what would be downloaded without writing anything. Still performs "
+            "the read-only enumeration and change check."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Refetch every page, ignoring the manifest.",
     )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_arg_parser().parse_args(argv)
-    download_book(dry_run=args.dry_run, sourcetexts_root=args.sourcetexts_root)
+    try:
+        contact_email = resolve_contact_email(args.contact_email)
+        download_book(
+            contact_email,
+            args.sourcetexts_root,
+            dry_run=args.dry_run,
+            force=args.force,
+        )
+    except WikisourceError as exc:
+        logger.error("%s", exc)
+        return 1
     return 0
 
 

--- a/opensiddur/importer/util/wikisource.py
+++ b/opensiddur/importer/util/wikisource.py
@@ -460,9 +460,11 @@ def fetch_contributors(
     Uses ``prop=contributors``, which is batchable and returns registered accounts
     already deduplicated. Anonymous edits are reported by the API only as an
     aggregate count, so they do not appear here — credits name people who can be
-    identified, which is what a TEI ``respStmt`` wants.
+    identified, which is what a TEI ``respStmt`` wants. By default bots and
+    temporary accounts are left out on that same reasoning; see
+    :func:`is_uncreditable`.
     """
-    should_exclude = exclude if exclude is not None else is_bot_name
+    should_exclude = exclude if exclude is not None else is_uncreditable
 
     contributors: dict[str, list[str]] = {}
     for batch in batched(list(titles), batch_size):
@@ -489,6 +491,25 @@ def fetch_contributors(
 def is_bot_name(name: str) -> bool:
     """Whether a username looks like a bot, and so should not be credited."""
     return name.casefold().endswith("bot")
+
+
+def is_temporary_account(name: str) -> bool:
+    """Whether a username is one of MediaWiki's temporary accounts.
+
+    Under IP masking, an edit made without logging in is attributed to an
+    auto-generated account named ``~2026-44995-25`` rather than to a bare address.
+    The name is registered as far as ``prop=contributors`` is concerned, but it
+    identifies a person no better than the IP it replaced, so it is excluded on the
+    same reasoning: credits name people who can be identified.
+
+    https://www.mediawiki.org/wiki/Trust_and_Safety_Product/Temporary_Accounts
+    """
+    return name.startswith("~")
+
+
+def is_uncreditable(name: str) -> bool:
+    """Whether a contributor name should be left out of credits."""
+    return is_bot_name(name) or is_temporary_account(name)
 
 
 # ---------------------------------------------------------------------------

--- a/opensiddur/importer/util/wikisource_book.py
+++ b/opensiddur/importer/util/wikisource_book.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -70,6 +71,25 @@ def save_manifest(manifest: dict[str, Any], data_dir: Path) -> None:
         json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def download_date(data_dir: Path) -> str | None:
+    """The date the manifest was last written, as ``YYYY-MM-DD``, or None.
+
+    This is what a TEI ``sourceDesc`` should report as the date the source was
+    retrieved, so that the header states when the wikitext underneath it was actually
+    fetched rather than a date someone typed once.
+    """
+    stamp = load_manifest(data_dir).get("downloaded_at")
+    if not isinstance(stamp, str) or not stamp:
+        return None
+    # Written by datetime.isoformat(), so the date is everything before the "T"; be
+    # lenient about anything else that parses, and report nothing if it does not.
+    try:
+        return datetime.fromisoformat(stamp).date().isoformat()
+    except ValueError:
+        logger.warning("Manifest in %s has an uninterpretable date: %r", data_dir, stamp)
+        return None
 
 
 def needs_download(

--- a/opensiddur/importer/util/wikisource_book.py
+++ b/opensiddur/importer/util/wikisource_book.py
@@ -1,0 +1,221 @@
+"""Downloading a scan-backed Wikisource book to disk, one file per page.
+
+:mod:`opensiddur.importer.util.wikisource` deliberately knows nothing about the
+filesystem: it speaks the Action API and returns revisions. This module is the layer
+above it that owns the parts every book downloader would otherwise repeat — where the
+files go, and the manifest that lets a re-run skip pages that have not changed.
+
+What stays with the individual importers is whatever is genuinely particular to their
+book: the Birnbaum siddur's mainspace source tree and its structure index have no JPS
+equivalent, and the JPS scan pages carry their own text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from opensiddur.importer.util.wikisource import (
+    Wiki,
+    WikisourceError,
+    fetch_contributors,
+    fetch_revisions,
+    list_book_pages,
+)
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_NAME = "manifest.json"
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def page_key(page_num: int, digits: int) -> str:
+    """Zero-padded page identifier, used for both filenames and manifest keys."""
+    return f"{page_num:0{digits}d}"
+
+
+def manifest_path(data_dir: Path) -> Path:
+    return data_dir / MANIFEST_NAME
+
+
+def load_manifest(data_dir: Path) -> dict[str, Any]:
+    """Read the manifest, or return an empty one if this is a first run."""
+    path = manifest_path(data_dir)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Manifest at %s is unreadable (%s); treating every page as new. "
+            "Use --force to rewrite it cleanly.",
+            path,
+            exc,
+        )
+        return {}
+
+
+def save_manifest(manifest: dict[str, Any], data_dir: Path) -> None:
+    path = manifest_path(data_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def needs_download(
+    key: str,
+    revid: int,
+    manifest_pages: dict[str, Any],
+    text_dir: Path,
+    credits_dir: Path,
+) -> bool:
+    """Whether a page must be fetched: unknown, changed, or missing on disk.
+
+    The on-disk check matters because a manifest entry alone does not prove the files
+    survived — someone may have deleted or partially written them.
+    """
+    recorded = manifest_pages.get(key)
+    if recorded is None or recorded.get("revid") != revid:
+        return True
+    return not (
+        (text_dir / f"{key}.txt").is_file() and (credits_dir / f"{key}.txt").is_file()
+    )
+
+
+@dataclass
+class ScanPageLayout:
+    """Where one book's per-page files live."""
+
+    data_dir: Path
+    text_dir: Path
+    credits_dir: Path
+
+
+@dataclass
+class ScanDownloadResult:
+    """What one pass over a book's scan pages found and wrote."""
+
+    pages: dict[str, Any] = field(default_factory=dict)
+    titles_by_number: dict[int, str] = field(default_factory=dict)
+    stale: list[int] = field(default_factory=list)
+    written: int = 0
+    digits: int = 1
+
+
+def download_scan_pages(
+    wiki: Wiki,
+    book_name: str,
+    layout: ScanPageLayout,
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+    manifest_pages: dict[str, Any] | None = None,
+    digits: int | None = None,
+) -> ScanDownloadResult:
+    """Download every transcribed page of ``book_name``, skipping unchanged ones.
+
+    Enumerates what is actually transcribed, probes revision ids in bulk, and only then
+    fetches wikitext and contributors for the pages that need writing. Returns manifest
+    entries keyed by zero-padded page number, alongside what was found and written.
+    """
+    recorded: dict[str, Any] = {} if force else dict(manifest_pages or {})
+
+    logger.info("Enumerating pages of %s ...", book_name)
+    titles_by_number = list_book_pages(wiki, book_name)
+    if not titles_by_number:
+        raise WikisourceError(
+            f"No transcribed pages found for {book_name!r} on {wiki.server}. "
+            "Has the book been moved or renamed?"
+        )
+
+    page_numbers = sorted(titles_by_number)
+    if digits is None:
+        digits = len(str(page_numbers[-1]))
+    logger.info(
+        "Found %d transcribed pages (%d-%d)",
+        len(page_numbers),
+        page_numbers[0],
+        page_numbers[-1],
+    )
+
+    # A revision-id-only probe: no wikitext is serialised, so this stays cheap even
+    # when nothing has changed.
+    logger.info("Checking which pages have changed ...")
+    latest = fetch_revisions(
+        wiki, [titles_by_number[n] for n in page_numbers], include_content=False
+    )
+
+    stale: list[int] = []
+    for number in page_numbers:
+        title = titles_by_number[number]
+        revision = latest.get(title)
+        if revision is None:
+            logger.warning("No revision reported for %s; skipping", title)
+            continue
+        if force or needs_download(
+            page_key(number, digits),
+            revision.revid,
+            recorded,
+            layout.text_dir,
+            layout.credits_dir,
+        ):
+            stale.append(number)
+
+    logger.info("%d of %d scan pages need downloading", len(stale), len(page_numbers))
+
+    result = ScanDownloadResult(
+        pages=recorded,
+        titles_by_number=titles_by_number,
+        stale=stale,
+        digits=digits,
+    )
+
+    if not stale:
+        logger.info("Scan pages are already up to date.")
+        return result
+    if dry_run:
+        return result
+
+    stale_titles = [titles_by_number[n] for n in stale]
+    logger.info("Fetching wikitext ...")
+    contents = fetch_revisions(wiki, stale_titles, include_content=True)
+    logger.info("Fetching contributors ...")
+    contributors = fetch_contributors(wiki, stale_titles)
+
+    layout.text_dir.mkdir(parents=True, exist_ok=True)
+    layout.credits_dir.mkdir(parents=True, exist_ok=True)
+
+    for number in stale:
+        title = titles_by_number[number]
+        revision = contents.get(title)
+        if revision is None or revision.content is None:
+            logger.warning("No wikitext returned for %s; leaving it for the next run", title)
+            continue
+
+        key = page_key(number, digits)
+        credits_text = "\n".join(contributors.get(title, []))
+
+        (layout.text_dir / f"{key}.txt").write_text(revision.content, encoding="utf-8")
+        (layout.credits_dir / f"{key}.txt").write_text(credits_text, encoding="utf-8")
+
+        recorded[key] = {
+            "revid": revision.revid,
+            "timestamp": revision.timestamp,
+            "text_sha256": sha256_text(revision.content),
+            "credits_sha256": sha256_text(credits_text),
+        }
+        result.written += 1
+        if result.written % 50 == 0:
+            logger.info("Wrote %d/%d scan pages", result.written, len(stale))
+
+    return result

--- a/opensiddur/tests/importer/birnbaum_siddur/test_wikisource.py
+++ b/opensiddur/tests/importer/birnbaum_siddur/test_wikisource.py
@@ -11,6 +11,7 @@ from opensiddur.importer.util.pages import (
     birnbaum_siddur_data_directory,
     birnbaum_siddur_text_directory,
 )
+from opensiddur.importer.util import wikisource_book
 from opensiddur.importer.util.wikisource import RevisionInfo, WikisourceError
 
 # Page numbers chosen so the zero-padding width is the real one (three digits).
@@ -60,18 +61,25 @@ class BirnbaumDownloadTestCase(unittest.TestCase):
         # The source layer: revision ids keyed by title, same shape as the scan layer.
         self.source_revids = {t: 500 for t in SOURCE_WIKITEXT}
 
-        patcher = patch.multiple(
-            wikisource,
+        # The scan-page half of the download lives in util.wikisource_book, so its calls
+        # are looked up there; the source-page half is still this module's own.
+        scan_patcher = patch.multiple(
+            wikisource_book,
             list_book_pages=MagicMock(return_value=dict(TITLES)),
             fetch_revisions=MagicMock(side_effect=self.fake_fetch_revisions),
+            fetch_contributors=MagicMock(side_effect=self.fake_fetch_contributors),
+        )
+        source_patcher = patch.multiple(
+            wikisource,
             fetch_contributors=MagicMock(side_effect=self.fake_fetch_contributors),
             list_pages_with_prefix=MagicMock(
                 return_value=[FOUNDATION, REDIRECT_PAGE]
             ),
             download_closure=MagicMock(side_effect=self.fake_download_closure),
         )
-        patcher.start()
-        self.addCleanup(patcher.stop)
+        for patcher in (scan_patcher, source_patcher):
+            patcher.start()
+            self.addCleanup(patcher.stop)
 
     def fake_fetch_revisions(self, wiki, titles, *, include_content, **kwargs):
         titles = list(titles)
@@ -192,7 +200,7 @@ class TestFirstRun(BirnbaumDownloadTestCase):
         self.assertEqual(manifest["book_name"], wikisource.BOOK_NAME)
 
     def test_refuses_a_book_with_no_transcribed_pages(self):
-        wikisource.list_book_pages.return_value = {}
+        wikisource_book.list_book_pages.return_value = {}
 
         with self.assertRaises(WikisourceError):
             self.run_download()

--- a/opensiddur/tests/importer/jps1917/test_convert_wikisource.py
+++ b/opensiddur/tests/importer/jps1917/test_convert_wikisource.py
@@ -11,8 +11,10 @@ from opensiddur.exporter.constants import TEI_NS
 from opensiddur.importer.jps1917.convert_wikisource import (
     get_credits_pages, header, tei_file, process_mediawiki, validate_and_write_tei_file,
     book_file, index_file, Book, Index, mediawiki_xml_to_tei, main, make_project_directory,
-    TITLE_PAGE, prepend_to_front,
+    TITLE_PAGE, prepend_to_front, FALLBACK_DOWNLOAD_DATE, source_download_date,
 )
+from opensiddur.importer.util.pages import jps1917_data_directory
+from opensiddur.importer.util.wikisource_book import save_manifest
 from opensiddur.importer.util.parshiyot import skeleton_map_json
 from opensiddur.importer.util.validation import validate_with_start, validate
 
@@ -126,9 +128,38 @@ class TestGetCreditsPages(unittest.TestCase):
         self.assertEqual(result, ["Alpha", "Beta", "Charlie", "Zebra"])
 
 
+class TestHeaderDownloadDate(unittest.TestCase):
+    """The sourceDesc date reports when the Wikisource pages were actually fetched."""
+
+    def test_uses_the_date_it_is_given(self):
+        result = header(
+            book_name_he="בראשית",
+            book_name_en="Genesis",
+            source_download_date="2026-08-22",
+        )
+        self.assertIn("<tei:date>2026-08-22</tei:date>", result)
+
+    def test_falls_back_when_no_date_is_known(self):
+        result = header(book_name_he="בראשית", book_name_en="Genesis")
+        self.assertIn(f"<tei:date>{FALLBACK_DOWNLOAD_DATE}</tei:date>", result)
+
+    def test_reads_the_date_out_of_the_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            save_manifest(
+                {"downloaded_at": "2026-08-22T21:15:00+00:00"},
+                jps1917_data_directory(root),
+            )
+            self.assertEqual(source_download_date(root), "2026-08-22")
+
+    def test_falls_back_when_the_tree_has_no_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(source_download_date(Path(tmp)), FALLBACK_DOWNLOAD_DATE)
+
+
 class TestHeader(unittest.TestCase):
     """Tests for header function."""
-    
+
     def test_basic_header_without_subtitles(self):
         """Test basic header generation with required fields only."""
         result = header(
@@ -1146,7 +1177,10 @@ class TestBookFile(unittest.TestCase):
             book_name_he="בראשית",
             book_name_en="Genesis",
             entrypoint="genesis",
-            transcription_credits=["Credit1", "Credit2"]
+            transcription_credits=["Credit1", "Credit2"],
+            # Read from the manifest of whatever tree is being converted, so the value
+            # is not this test's business; TestHeaderDownloadDate covers it directly.
+            source_download_date=ANY,
         )
         
         # Verify process_mediawiki was called with correct parameters
@@ -1324,7 +1358,8 @@ class TestIndexFile(unittest.TestCase):
             book_sub_he="חמישה חומשי תורה",
             book_sub_en="Five Books of Moses",
             entrypoint="torah",
-            transcription_credits=["Index transcriber"]
+            transcription_credits=["Index transcriber"],
+            source_download_date=ANY,
         )
         
         # Verify process_mediawiki was called for front matter
@@ -1391,7 +1426,8 @@ class TestIndexFile(unittest.TestCase):
             book_sub_he=None,
             book_sub_en=None,
             entrypoint="bible_index",
-            transcription_credits=None
+            transcription_credits=None,
+            source_download_date=ANY,
         )
         
         # Verify tei_file was called with empty xml_dict and body with transclusions

--- a/opensiddur/tests/importer/jps1917/test_wikisource.py
+++ b/opensiddur/tests/importer/jps1917/test_wikisource.py
@@ -1,0 +1,220 @@
+"""Tests for the JPS 1917 downloader.
+
+The shared download loop is covered in ``tests/importer/util/test_wikisource_book.py``;
+what is checked here is the wiring particular to this book — where its files land, what
+its manifest says, and its CLI. Everything runs against a synthetic two-page book in a
+temporary tree, so no test depends on the checked-in sourcetexts data.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from opensiddur.importer.jps1917 import wikisource
+from opensiddur.importer.jps1917.wikisource import download_book, main
+from opensiddur.importer.util import wikisource_book
+from opensiddur.importer.util.pages import (
+    jps1917_credits_directory,
+    jps1917_data_directory,
+    jps1917_text_directory,
+)
+from opensiddur.importer.util.wikisource import RevisionInfo, WikisourceError
+
+# Page numbers chosen so the derived padding width is the real one (four digits): the
+# book's transcribed pages run 7-1158, and downstream readers expect "0007.txt".
+FIRST, LAST = 7, 1158
+TITLES = {
+    FIRST: f"{wikisource.WIKI_NAMESPACE}:{wikisource.BOOK_NAME}/{FIRST}",
+    LAST: f"{wikisource.WIKI_NAMESPACE}:{wikisource.BOOK_NAME}/{LAST}",
+}
+
+WIKITEXT = "{{verse|1|1}}In the beginning"
+
+
+class JpsDownloadTestCase(unittest.TestCase):
+    """Fixture wiring the downloader to a temporary sourcetexts tree and a fake wiki."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+        self.text_dir = jps1917_text_directory(self.root)
+        self.credits_dir = jps1917_credits_directory(self.root)
+        self.manifest_file = jps1917_data_directory(self.root) / "manifest.json"
+
+        self.revids = {TITLES[FIRST]: 111, TITLES[LAST]: 222}
+        self.contributors = {TITLES[FIRST]: ["Outlier59"], TITLES[LAST]: ["Prosody"]}
+        self.content_requests = []
+
+        patcher = patch.multiple(
+            wikisource_book,
+            list_book_pages=MagicMock(return_value=dict(TITLES)),
+            fetch_revisions=MagicMock(side_effect=self.fake_fetch_revisions),
+            fetch_contributors=MagicMock(side_effect=self.fake_fetch_contributors),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def fake_fetch_revisions(self, wiki, titles, *, include_content, **kwargs):
+        titles = list(titles)
+        if include_content:
+            self.content_requests.append(titles)
+        return {
+            title: RevisionInfo(
+                revid=self.revids[title],
+                timestamp="2022-02-07T05:35:00Z",
+                content=WIKITEXT if include_content else None,
+            )
+            for title in titles
+        }
+
+    def fake_fetch_contributors(self, wiki, titles, **kwargs):
+        return {title: self.contributors.get(title, []) for title in titles}
+
+    def run_download(self, **kwargs):
+        return download_book(
+            "example@opensiddur.org",
+            self.root,
+            wiki=MagicMock(server=wikisource.SERVER),
+            **kwargs,
+        )
+
+    def read_manifest(self):
+        return json.loads(self.manifest_file.read_text(encoding="utf-8"))
+
+    def seed_everything_current(self):
+        """Put both pages on disk and in the manifest, exactly as a finished run would."""
+        self.text_dir.mkdir(parents=True, exist_ok=True)
+        self.credits_dir.mkdir(parents=True, exist_ok=True)
+        pages = {}
+        for number, key in ((FIRST, "0007"), (LAST, "1158")):
+            (self.text_dir / f"{key}.txt").write_text(WIKITEXT, encoding="utf-8")
+            (self.credits_dir / f"{key}.txt").write_text("Outlier59", encoding="utf-8")
+            pages[key] = {"revid": self.revids[TITLES[number]]}
+        self.manifest_file.parent.mkdir(parents=True, exist_ok=True)
+        self.manifest_file.write_text(
+            json.dumps({"pages": pages}), encoding="utf-8"
+        )
+
+
+class TestFirstRun(JpsDownloadTestCase):
+    def test_downloads_every_page_when_there_is_no_manifest(self):
+        self.run_download()
+        self.assertEqual(self.content_requests, [[TITLES[FIRST], TITLES[LAST]]])
+
+    def test_writes_text_and_credits_with_four_digit_names(self):
+        self.run_download()
+        self.assertEqual(
+            sorted(p.name for p in self.text_dir.iterdir()), ["0007.txt", "1158.txt"]
+        )
+        self.assertEqual(
+            sorted(p.name for p in self.credits_dir.iterdir()), ["0007.txt", "1158.txt"]
+        )
+
+    def test_writes_the_wikitext_the_wiki_returned(self):
+        self.run_download()
+        self.assertEqual(
+            (self.text_dir / "0007.txt").read_text(encoding="utf-8"), WIKITEXT
+        )
+
+    def test_writes_contributors_one_per_line(self):
+        self.run_download()
+        self.assertEqual(
+            (self.credits_dir / "1158.txt").read_text(encoding="utf-8"), "Prosody"
+        )
+
+    def test_records_the_book_it_came_from(self):
+        manifest = self.run_download()
+        self.assertEqual(manifest["source"], wikisource.SERVER)
+        self.assertEqual(manifest["book_name"], wikisource.BOOK_NAME)
+        self.assertEqual(manifest["namespace"], wikisource.WIKI_NAMESPACE)
+        self.assertIn("downloaded_at", manifest)
+
+    def test_records_every_page_in_the_manifest(self):
+        self.run_download()
+        pages = self.read_manifest()["pages"]
+        self.assertEqual(sorted(pages), ["0007", "1158"])
+        self.assertEqual(pages["0007"]["revid"], 111)
+
+    def test_refuses_a_book_with_no_transcribed_pages(self):
+        wikisource_book.list_book_pages.return_value = {}
+        with self.assertRaises(WikisourceError):
+            self.run_download()
+
+
+class TestIncrementalUpdate(JpsDownloadTestCase):
+    def test_skips_pages_whose_revision_is_unchanged(self):
+        self.seed_everything_current()
+        self.revids[TITLES[LAST]] = 999
+        self.run_download()
+        self.assertEqual(self.content_requests, [[TITLES[LAST]]])
+
+    def test_leaves_an_unchanged_page_untouched_on_disk(self):
+        self.seed_everything_current()
+        (self.text_dir / "0007.txt").write_text("hand edited", encoding="utf-8")
+        self.revids[TITLES[LAST]] = 999
+        self.run_download()
+        self.assertEqual(
+            (self.text_dir / "0007.txt").read_text(encoding="utf-8"), "hand edited"
+        )
+
+    def test_downloads_nothing_when_the_whole_book_is_current(self):
+        self.seed_everything_current()
+        self.run_download()
+        self.assertEqual(self.content_requests, [])
+
+    def test_a_no_op_rerun_leaves_the_manifest_untouched(self):
+        self.seed_everything_current()
+        before = self.manifest_file.read_text(encoding="utf-8")
+        self.run_download()
+        self.assertEqual(self.manifest_file.read_text(encoding="utf-8"), before)
+
+    def test_refetches_when_a_file_has_gone_missing(self):
+        self.seed_everything_current()
+        (self.credits_dir / "0007.txt").unlink()
+        self.run_download()
+        self.assertEqual(self.content_requests, [[TITLES[FIRST]]])
+
+    def test_starts_over_when_the_manifest_is_corrupt(self):
+        self.seed_everything_current()
+        self.manifest_file.write_text("{not json", encoding="utf-8")
+        self.run_download()
+        self.assertEqual(self.content_requests, [[TITLES[FIRST], TITLES[LAST]]])
+
+
+class TestForce(JpsDownloadTestCase):
+    def test_refetches_everything_regardless_of_the_manifest(self):
+        self.seed_everything_current()
+        self.run_download(force=True)
+        self.assertEqual(self.content_requests, [[TITLES[FIRST], TITLES[LAST]]])
+
+
+class TestDryRun(JpsDownloadTestCase):
+    def test_writes_nothing(self):
+        self.run_download(dry_run=True)
+        self.assertFalse(self.text_dir.exists())
+        self.assertFalse(self.manifest_file.exists())
+
+    def test_does_not_fetch_content(self):
+        self.run_download(dry_run=True)
+        self.assertEqual(self.content_requests, [])
+
+
+class TestCli(unittest.TestCase):
+    def test_refuses_to_run_without_a_contact_address(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with patch.object(wikisource, "download_book") as download:
+                with self.assertLogs(wikisource.logger, level="ERROR"):
+                    self.assertEqual(main(["--dry-run"]), 1)
+        download.assert_not_called()
+
+    def test_passes_the_contact_address_through(self):
+        with patch.object(wikisource, "download_book") as download:
+            self.assertEqual(
+                main(["--contact-email", "someone@opensiddur.org", "--force"]), 0
+            )
+        self.assertEqual(download.call_args.args[0], "someone@opensiddur.org")
+        self.assertTrue(download.call_args.kwargs["force"])

--- a/opensiddur/tests/importer/util/test_wikisource.py
+++ b/opensiddur/tests/importer/util/test_wikisource.py
@@ -18,6 +18,8 @@ from opensiddur.importer.util.wikisource import (
     find_sections,
     find_transclusions,
     is_bot_name,
+    is_temporary_account,
+    is_uncreditable,
     is_redirect,
     list_book_pages,
     list_pages_with_prefix,
@@ -122,6 +124,23 @@ class TestIsBotName(unittest.TestCase):
 
     def test_leaves_ordinary_names_alone(self):
         self.assertFalse(is_bot_name("Dovi"))
+
+
+class TestIsTemporaryAccount(unittest.TestCase):
+    def test_recognises_a_temporary_account(self):
+        self.assertTrue(is_temporary_account("~2026-44995-25"))
+
+    def test_leaves_ordinary_names_alone(self):
+        self.assertFalse(is_temporary_account("Prosody"))
+
+
+class TestIsUncreditable(unittest.TestCase):
+    def test_excludes_bots_and_temporary_accounts(self):
+        self.assertTrue(is_uncreditable("Wikisource-bot"))
+        self.assertTrue(is_uncreditable("~2026-19097-09"))
+
+    def test_credits_a_named_account(self):
+        self.assertFalse(is_uncreditable("Kathleen.wright5"))
 
 
 class TestApiGet(unittest.TestCase):
@@ -414,6 +433,9 @@ class TestFetchContributors(unittest.TestCase):
                             {"userid": 68, "name": "Nahum"},
                             {"userid": 1, "name": "Dovi"},
                             {"userid": 9, "name": "Wikisource-bot"},
+                            # A logged-out edit under IP masking; registered as far as
+                            # the API is concerned, but it names nobody.
+                            {"userid": 12, "name": "~2026-44995-25"},
                         ],
                     }
                 )

--- a/opensiddur/tests/importer/util/test_wikisource_book.py
+++ b/opensiddur/tests/importer/util/test_wikisource_book.py
@@ -1,0 +1,255 @@
+"""Tests for the shared scan-page download loop.
+
+Everything here runs against a synthetic two-page book in a temporary directory: no
+network, no checked-in source data, so nothing depends on what Wikisource says today.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from opensiddur.importer.util import wikisource_book
+from opensiddur.importer.util.wikisource import RevisionInfo, WikisourceError
+from opensiddur.importer.util.wikisource_book import (
+    ScanPageLayout,
+    download_scan_pages,
+    load_manifest,
+    needs_download,
+    page_key,
+    save_manifest,
+    sha256_text,
+)
+
+BOOK = "Synthetic Book.djvu"
+
+# Page numbers chosen so the derived padding width is three digits, and so the two
+# pages do not share one: a book numbered 7-815 pads to "007" and "815".
+FIRST, LAST = 7, 815
+TITLES = {FIRST: f"Page:{BOOK}/{FIRST}", LAST: f"Page:{BOOK}/{LAST}"}
+KEYS = {FIRST: "007", LAST: "815"}
+
+WIKITEXT = "fetched wikitext"
+
+
+class ScanDownloadTestCase(unittest.TestCase):
+    """Fixture wiring the shared loop to a temporary tree and a fake wiki."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.data_dir = Path(self._tmp.name) / "book"
+        self.layout = ScanPageLayout(
+            data_dir=self.data_dir,
+            text_dir=self.data_dir / "text",
+            credits_dir=self.data_dir / "credits",
+        )
+        self.manifest_file = self.data_dir / "manifest.json"
+
+        self.revids = {TITLES[FIRST]: 111, TITLES[LAST]: 222}
+        self.contributors = {TITLES[FIRST]: ["Dovi"], TITLES[LAST]: ["Dovi", "Nahum"]}
+        self.content_requests = []
+
+        patcher = patch.multiple(
+            wikisource_book,
+            list_book_pages=MagicMock(return_value=dict(TITLES)),
+            fetch_revisions=MagicMock(side_effect=self.fake_fetch_revisions),
+            fetch_contributors=MagicMock(side_effect=self.fake_fetch_contributors),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def fake_fetch_revisions(self, wiki, titles, *, include_content, **kwargs):
+        titles = list(titles)
+        if include_content:
+            self.content_requests.append(titles)
+        return {
+            title: RevisionInfo(
+                revid=self.revids[title],
+                timestamp="2022-02-07T05:35:00Z",
+                content=WIKITEXT if include_content else None,
+            )
+            for title in titles
+        }
+
+    def fake_fetch_contributors(self, wiki, titles, **kwargs):
+        return {title: self.contributors.get(title, []) for title in titles}
+
+    def run_download(self, **kwargs):
+        return download_scan_pages(
+            MagicMock(server="en.wikisource.org"), BOOK, self.layout, **kwargs
+        )
+
+    def seed_page(self, page_num, revid, text="existing", credits="Dovi"):
+        """Write a page to disk and return the manifest entry that marks it current."""
+        key = KEYS[page_num]
+        self.layout.text_dir.mkdir(parents=True, exist_ok=True)
+        self.layout.credits_dir.mkdir(parents=True, exist_ok=True)
+        (self.layout.text_dir / f"{key}.txt").write_text(text, encoding="utf-8")
+        (self.layout.credits_dir / f"{key}.txt").write_text(credits, encoding="utf-8")
+        return {key: {"revid": revid, "timestamp": "2022-02-07T05:35:00Z"}}
+
+
+class TestFirstRun(ScanDownloadTestCase):
+    def test_downloads_every_page_when_the_manifest_is_empty(self):
+        result = self.run_download()
+        self.assertEqual(result.written, 2)
+        self.assertEqual(result.stale, [FIRST, LAST])
+
+    def test_pads_filenames_to_the_width_of_the_highest_page_number(self):
+        self.run_download()
+        self.assertEqual(
+            sorted(p.name for p in self.layout.text_dir.iterdir()),
+            ["007.txt", "815.txt"],
+        )
+
+    def test_an_explicit_width_overrides_the_derived_one(self):
+        result = self.run_download(digits=4)
+        self.assertEqual(result.digits, 4)
+        self.assertTrue((self.layout.text_dir / "0007.txt").is_file())
+
+    def test_writes_the_wikitext_the_wiki_returned(self):
+        self.run_download()
+        self.assertEqual(
+            (self.layout.text_dir / "007.txt").read_text(encoding="utf-8"), WIKITEXT
+        )
+
+    def test_writes_contributors_one_per_line(self):
+        self.run_download()
+        self.assertEqual(
+            (self.layout.credits_dir / "815.txt").read_text(encoding="utf-8"),
+            "Dovi\nNahum",
+        )
+
+    def test_records_every_page_with_its_revision_and_hashes(self):
+        result = self.run_download()
+        self.assertEqual(sorted(result.pages), ["007", "815"])
+        entry = result.pages["007"]
+        self.assertEqual(entry["revid"], 111)
+        self.assertEqual(entry["text_sha256"], sha256_text(WIKITEXT))
+        self.assertEqual(entry["credits_sha256"], sha256_text("Dovi"))
+
+    def test_refuses_a_book_with_no_transcribed_pages(self):
+        wikisource_book.list_book_pages.return_value = {}
+        with self.assertRaises(WikisourceError):
+            self.run_download()
+
+    def test_skips_a_page_the_wiki_reports_no_revision_for(self):
+        wikisource_book.fetch_revisions.side_effect = (
+            lambda wiki, titles, **kwargs: {}
+        )
+        result = self.run_download()
+        self.assertEqual(result.stale, [])
+        self.assertEqual(result.written, 0)
+
+
+class TestIncrementalUpdate(ScanDownloadTestCase):
+    def test_skips_pages_whose_revision_is_unchanged(self):
+        recorded = self.seed_page(FIRST, revid=self.revids[TITLES[FIRST]])
+        result = self.run_download(manifest_pages=recorded)
+        self.assertEqual(result.stale, [LAST])
+        self.assertEqual(self.content_requests, [[TITLES[LAST]]])
+
+    def test_leaves_an_unchanged_page_untouched_on_disk(self):
+        recorded = self.seed_page(FIRST, revid=self.revids[TITLES[FIRST]])
+        self.run_download(manifest_pages=recorded)
+        self.assertEqual(
+            (self.layout.text_dir / "007.txt").read_text(encoding="utf-8"), "existing"
+        )
+
+    def test_keeps_the_old_entry_and_records_the_new_one(self):
+        recorded = self.seed_page(FIRST, revid=self.revids[TITLES[FIRST]])
+        result = self.run_download(manifest_pages=recorded)
+        self.assertEqual(sorted(result.pages), ["007", "815"])
+        self.assertEqual(result.pages["007"], recorded["007"])
+
+    def test_refetches_a_page_whose_revision_moved_on(self):
+        recorded = self.seed_page(FIRST, revid=self.revids[TITLES[FIRST]] - 1)
+        result = self.run_download(manifest_pages=recorded)
+        self.assertIn(FIRST, result.stale)
+
+    def test_refetches_when_a_file_has_gone_missing(self):
+        recorded = self.seed_page(FIRST, revid=self.revids[TITLES[FIRST]])
+        (self.layout.credits_dir / "007.txt").unlink()
+        result = self.run_download(manifest_pages=recorded)
+        self.assertIn(FIRST, result.stale)
+
+    def test_downloads_nothing_when_the_whole_book_is_current(self):
+        recorded = self.seed_page(FIRST, revid=self.revids[TITLES[FIRST]])
+        recorded.update(self.seed_page(LAST, revid=self.revids[TITLES[LAST]]))
+        result = self.run_download(manifest_pages=recorded)
+        self.assertEqual(result.stale, [])
+        self.assertEqual(result.written, 0)
+        self.assertEqual(self.content_requests, [])
+
+    def test_does_not_mutate_the_manifest_it_was_given(self):
+        recorded = self.seed_page(FIRST, revid=self.revids[TITLES[FIRST]])
+        self.run_download(manifest_pages=recorded)
+        self.assertEqual(sorted(recorded), ["007"])
+
+
+class TestForce(ScanDownloadTestCase):
+    def test_refetches_everything_regardless_of_the_manifest(self):
+        recorded = self.seed_page(FIRST, revid=self.revids[TITLES[FIRST]])
+        recorded.update(self.seed_page(LAST, revid=self.revids[TITLES[LAST]]))
+        result = self.run_download(manifest_pages=recorded, force=True)
+        self.assertEqual(result.stale, [FIRST, LAST])
+        self.assertEqual(result.written, 2)
+
+    def test_starts_the_manifest_over(self):
+        recorded = {"999": {"revid": 1}}
+        result = self.run_download(manifest_pages=recorded, force=True)
+        self.assertEqual(sorted(result.pages), ["007", "815"])
+
+
+class TestDryRun(ScanDownloadTestCase):
+    def test_writes_nothing(self):
+        result = self.run_download(dry_run=True)
+        self.assertEqual(result.written, 0)
+        self.assertFalse(self.layout.text_dir.exists())
+
+    def test_still_reports_what_would_be_downloaded(self):
+        result = self.run_download(dry_run=True)
+        self.assertEqual(result.stale, [FIRST, LAST])
+
+    def test_does_not_fetch_content(self):
+        self.run_download(dry_run=True)
+        self.assertEqual(self.content_requests, [])
+
+
+class TestManifestFile(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.data_dir = Path(self._tmp.name) / "book"
+
+    def test_a_missing_manifest_reads_as_empty(self):
+        self.assertEqual(load_manifest(self.data_dir), {})
+
+    def test_round_trips_what_was_saved(self):
+        save_manifest({"pages": {"007": {"revid": 111}}}, self.data_dir)
+        self.assertEqual(load_manifest(self.data_dir)["pages"]["007"]["revid"], 111)
+
+    def test_starts_over_when_the_manifest_is_corrupt(self):
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        (self.data_dir / "manifest.json").write_text("{not json", encoding="utf-8")
+        with self.assertLogs(wikisource_book.logger, level="WARNING"):
+            self.assertEqual(load_manifest(self.data_dir), {})
+
+    def test_writes_readable_utf8_json(self):
+        save_manifest({"book_name": "ספר"}, self.data_dir)
+        raw = (self.data_dir / "manifest.json").read_text(encoding="utf-8")
+        self.assertIn("ספר", raw)
+        self.assertEqual(json.loads(raw)["book_name"], "ספר")
+
+
+class TestHelpers(unittest.TestCase):
+    def test_page_key_pads_to_the_requested_width(self):
+        self.assertEqual(page_key(7, 4), "0007")
+
+    def test_page_key_does_not_truncate_a_longer_number(self):
+        self.assertEqual(page_key(1158, 3), "1158")
+
+    def test_needs_download_is_true_for_an_unknown_page(self):
+        self.assertTrue(needs_download("007", 111, {}, Path("/nonexistent"), Path("/nonexistent")))

--- a/opensiddur/tests/importer/util/test_wikisource_book.py
+++ b/opensiddur/tests/importer/util/test_wikisource_book.py
@@ -244,6 +244,38 @@ class TestManifestFile(unittest.TestCase):
         self.assertEqual(json.loads(raw)["book_name"], "ספר")
 
 
+class TestDownloadDate(unittest.TestCase):
+    """The date a TEI sourceDesc should report as when the source was retrieved."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.data_dir = Path(self._tmp.name) / "book"
+
+    def test_reports_the_date_a_download_recorded(self):
+        save_manifest({"downloaded_at": "2026-08-22T21:15:00+00:00"}, self.data_dir)
+        self.assertEqual(wikisource_book.download_date(self.data_dir), "2026-08-22")
+
+    def test_reports_nothing_when_there_is_no_manifest(self):
+        self.assertIsNone(wikisource_book.download_date(self.data_dir))
+
+    def test_reports_nothing_when_the_manifest_has_no_date(self):
+        save_manifest({"pages": {}}, self.data_dir)
+        self.assertIsNone(wikisource_book.download_date(self.data_dir))
+
+    def test_reports_nothing_when_the_date_is_unintelligible(self):
+        save_manifest({"downloaded_at": "last Tuesday"}, self.data_dir)
+        with self.assertLogs(wikisource_book.logger, level="WARNING"):
+            self.assertIsNone(wikisource_book.download_date(self.data_dir))
+
+    def test_a_real_download_records_a_usable_date(self):
+        """The two halves agree: what download_scan_pages records, this reads back."""
+        save_manifest(
+            {"downloaded_at": wikisource_book.datetime.now().isoformat()}, self.data_dir
+        )
+        self.assertRegex(wikisource_book.download_date(self.data_dir), r"^\d{4}-\d{2}-\d{2}$")
+
+
 class TestHelpers(unittest.TestCase):
     def test_page_key_pads_to_the_requested_width(self):
         self.assertEqual(page_key(7, 4), "0007")


### PR DESCRIPTION
Closes #90.

#89 added a policy-compliant Action API client (`opensiddur/importer/util/wikisource.py`) and wired only the Birnbaum importer to it. `jps1917/wikisource.py` was left scraping `action=raw` plus an Atom history feed through `/w/index.php`: two uncached, unbatched requests per page — ~2,300 for the book's 1,152 pages, where 50 batched API requests do the same work — sending no `maxlag`, ignoring `Retry-After` in favour of a flat three-retry loop, and refetching every page on every run. It identified itself with `opensiddur@example.com`, a reserved domain that reaches nobody and so fails the User-Agent policy.

The page range was hardcoded, including a stale `start_page = 443` left behind by a partial re-run. `list_book_pages` now reports what is actually transcribed, which settles that question honestly.

## The shared half

With two importers doing the same thing, the download loop moves to `opensiddur/importer/util/wikisource_book.py`: the manifest, the zero-padded page naming, and the enumerate → probe revisions → fetch only what changed → write pass. `util/wikisource.py` stays free of filesystem knowledge, as its docstring promises.

What remains in each importer is what is particular to its book — for Birnbaum its mainspace source tree and `structure.json`, for JPS nothing beyond the book's name and where its files go.

## Interface

`--contact-email` (or `$OPENSIDDUR_CONTACT_EMAIL`) is now required, with no default; `--force` refetches regardless of the manifest. The `sourcetexts/sources/jps1917/` layout and its four-digit filenames do not move.

## Data

Refetching the existing 1,152 pages is a separate change in the `sourcetexts` repository. Credits will differ there: `prop=contributors` returns registered accounts, so the five files currently listing bare IP addresses lose them, while pages whose history ran past the Atom feed's cap may gain names.

## Tests

New coverage for the shared loop (`tests/importer/util/test_wikisource_book.py`) and for the JPS downloader (`tests/importer/jps1917/test_wikisource.py`), which had none. The Birnbaum tests needed only their patch targets moved, since the calls they stub are now looked up in the shared module. Full suite: 1858 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)